### PR TITLE
Don't call OnExceptionUnwind when events are disallowed

### DIFF
--- a/src/runtime/runtime-internal.cc
+++ b/src/runtime/runtime-internal.cc
@@ -189,6 +189,7 @@ RUNTIME_FUNCTION(Runtime_UnwindAndFindExceptionHandler) {
   // when unwinding is the same as the last time when unwinding, this is a
   // frame unwind instead of an initial throw and we can ignore it.
   if (recordreplay::IsRecordingOrReplaying() &&
+      !recordreplay::AreEventsDisallowed() &&
       IsMainThread() &&
       *gProgressCounter != gLastExceptionUnwindProgress) {
     RecordReplayOnExceptionUnwind(isolate);


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-552