### PR TITLE
Allow recorded events during deterministic compilations

### DIFF
--- a/src/codegen/compiler.cc
+++ b/src/codegen/compiler.cc
@@ -1901,8 +1901,6 @@ bool Compiler::Compile(Isolate* isolate, Handle<SharedFunctionInfo> shared_info,
   DCHECK(!isolate->has_pending_exception());
   DCHECK(!shared_info->HasBytecodeArray());
 
-  recordreplay::AutoDisallowEvents disallow;
-
   VMState<BYTECODE_COMPILER> state(isolate);
   PostponeInterruptsScope postpone(isolate);
   TimerEventScope<TimerEventCompileCode> compile_timer(isolate);

--- a/src/runtime/runtime-compiler.cc
+++ b/src/runtime/runtime-compiler.cc
@@ -39,6 +39,10 @@ bool MaybeSpawnNativeContextIndependentCompilationJob(
 
 Object CompileOptimized(Isolate* isolate, Handle<JSFunction> function,
                         ConcurrencyMode mode) {
+  // The point at which optimized compilations occur can vary between recording
+  // and replaying.
+  recordreplay::AutoDisallowEvents disallow;
+
   StackLimitCheck check(isolate);
   if (check.JsHasOverflowed(kStackSpaceRequiredForCompilation * KB)) {
     return isolate->StackOverflow();


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-513