### PR TITLE
Fix a couple progress counter issues

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -10909,6 +10909,10 @@ void recordreplay::SetRecordingOrReplaying(void* handle) {
   RecordReplayLoadSymbol(handle, "RecordReplaySetProgressCallback", setProgressCallback);
   setProgressCallback(internal::RecordReplaySetTargetProgress);
 
+  void (*enableProgressCheckpoints)();
+  RecordReplayLoadSymbol(handle, "RecordReplayEnableProgressCheckpoints", enableProgressCheckpoints);
+  enableProgressCheckpoints();
+
   internal::gRecordReplayAssertValues = !!getenv("RECORD_REPLAY_JS_ASSERTS");
 
   // Set flags to disable non-deterministic posting of tasks to other threads.

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -995,7 +995,6 @@ extern bool gRecordReplayHasCheckpoint;
 extern void RecordReplayOnTargetProgressReached();
 
 RUNTIME_FUNCTION(Runtime_RecordReplayAssertExecutionProgress) {
-  ++*gProgressCounter;
   if (++*gProgressCounter == gTargetProgress) {
     RecordReplayOnTargetProgressReached();
   }


### PR DESCRIPTION
This fixes a couple problems from #39 -- we're incrementing the progress counter twice in Runtime_RecordReplayAssertExecutionProgress, and need to call the RecordReplayEnableProgressCheckpoints API in order to allow creating checkpoints at arbitrary progress values.