### PR TITLE
Copy instrumentation sites from full vector as needed

### DIFF
--- a/src/codegen/compiler.cc
+++ b/src/codegen/compiler.cc
@@ -2075,14 +2075,10 @@ MaybeHandle<SharedFunctionInfo> Compiler::CompileToplevel(
                                        isolate, is_compiled_scope);
 }
 
-extern void RecordReplayCopyMainThreadInstrumentationSitesAfterBackgroundCompileTask();
-
 // static
 bool Compiler::FinalizeBackgroundCompileTask(
     BackgroundCompileTask* task, Handle<SharedFunctionInfo> shared_info,
     Isolate* isolate, ClearExceptionFlag flag) {
-  RecordReplayCopyMainThreadInstrumentationSitesAfterBackgroundCompileTask();
-
   DCHECK(!FLAG_finalize_streaming_on_background);
 
   TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("v8.compile"),


### PR DESCRIPTION
We're seeing some crashes while replaying from https://github.com/replayio/chromium-v8/pull/47 where instrumentation sites are accessed on the main thread that are out of range, presumably indicating that they weren't copied over to the main thread vector from the full vector before the script starts executing.  It's not clear why this is happening but this PR should fix the problem, by simplifying how we deal with these two vectors and copying instrumentation sites to the main thread vector as needed.