### PR TITLE
Keep track of persistent object IDs for objects created with 'new'

### DIFF
--- a/include/js_protocol.pdl
+++ b/include/js_protocol.pdl
@@ -1054,6 +1054,8 @@ domain Runtime
       optional string description
       # Unique object identifier (for non-primitive values).
       optional RemoteObjectId objectId
+      # Any available persistent object identifier when recording/replaying.
+      optional string persistentId
       # Preview containing abbreviated property values. Specified for `object` type values only.
       experimental optional ObjectPreview preview
       experimental optional CustomPreview customPreview

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -10103,6 +10103,8 @@ void RecordReplayInstrument(const char* kind, const char* function, int offset) 
   gRecordReplayOnInstrument(kind, function, offset);
 }
 
+extern void TrackObjectsCallback(bool track_objects);
+
 extern char* CommandCallback(const char* command, const char* params);
 extern void ClearPauseDataCallback();
 
@@ -10966,6 +10968,10 @@ void recordreplay::SetRecordingOrReplaying(void* handle) {
   void (*enableProgressCheckpoints)();
   RecordReplayLoadSymbol(handle, "RecordReplayEnableProgressCheckpoints", enableProgressCheckpoints);
   enableProgressCheckpoints();
+
+  void (*setTrackObjectsCallback)(void (*aCallback)(bool aTrackObjects));
+  RecordReplayLoadSymbol(handle, "RecordReplaySetTrackObjectsCallback", setTrackObjectsCallback);
+  setTrackObjectsCallback(internal::TrackObjectsCallback);
 
   internal::gRecordReplayAssertValues = !!getenv("RECORD_REPLAY_JS_ASSERTS");
   internal::gRecordReplayAssertProgress =

--- a/src/builtins/x64/builtins-x64.cc
+++ b/src/builtins/x64/builtins-x64.cc
@@ -207,9 +207,12 @@ void Builtins::Generate_JSConstructStubGeneric(MacroAssembler* masm) {
   __ bind(&post_instantiation_deopt_entry);
 
   if (RecordReplayTrackConstructorObjectIds()) {
+    __ pushq(rax);
     __ Push(rax);
-    __ CallRuntime(Runtime::kRecordReplayTrackObjectId, 1);
-    __ Pop(rax);
+    __ movq(rax, Operand(rbp, ConstructFrameConstants::kContextOffset));
+    __ Push(rax);
+    __ CallRuntime(Runtime::kRecordReplayTrackObjectId, 2);
+    __ popq(rax);
   }
 
   // Restore new target.

--- a/src/builtins/x64/builtins-x64.cc
+++ b/src/builtins/x64/builtins-x64.cc
@@ -38,6 +38,8 @@
 namespace v8 {
 namespace internal {
 
+extern bool RecordReplayTrackConstructorObjectIds();
+
 #define __ ACCESS_MASM(masm)
 
 void Builtins::Generate_Adaptor(MacroAssembler* masm, Address address) {
@@ -203,6 +205,12 @@ void Builtins::Generate_JSConstructStubGeneric(MacroAssembler* masm) {
   masm->isolate()->heap()->SetConstructStubCreateDeoptPCOffset(
       masm->pc_offset());
   __ bind(&post_instantiation_deopt_entry);
+
+  if (RecordReplayTrackConstructorObjectIds()) {
+    __ Push(rax);
+    __ CallRuntime(Runtime::kRecordReplayTrackObjectId, 1);
+    __ Pop(rax);
+  }
 
   // Restore new target.
   __ Pop(rdx);

--- a/src/compiler/js-inlining.cc
+++ b/src/compiler/js-inlining.cc
@@ -30,6 +30,9 @@
 
 namespace v8 {
 namespace internal {
+
+extern bool RecordReplayTrackConstructorObjectIds();
+
 namespace compiler {
 
 namespace {
@@ -482,6 +485,14 @@ Reduction JSInliner::ReduceJSCall(Node* node) {
       !IsConstructable(shared_info->kind())) {
     TRACE("Not inlining " << *shared_info << " into " << outer_shared_info
                           << " because constructor is not constructable.");
+    return NoChange();
+  }
+
+  // Constructors are not inlined when keeping track of constructor object IDs,
+  // for simplicity.
+  if (node->opcode() == IrOpcode::kJSConstruct && RecordReplayTrackConstructorObjectIds()) {
+    TRACE("Not inlining " << *shared_info << " into " << outer_shared_info
+                          << " because constructor object IDs are being tracked.");
     return NoChange();
   }
 

--- a/src/inspector/injected-script.cc
+++ b/src/inspector/injected-script.cc
@@ -48,6 +48,13 @@
 #include "src/inspector/v8-value-utils.h"
 #include "src/inspector/value-mirror.h"
 
+namespace v8 {
+  namespace internal {
+    extern int RecordReplayObjectId(v8::Isolate* isolate, Local<v8::Context> cx,
+                                    v8::Local<v8::Value> object, bool allow_create);
+  }
+}
+
 namespace v8_inspector {
 
 namespace {
@@ -1040,6 +1047,12 @@ Response InjectedScript::bindRemoteObjectIfNeeded(
       return Response::ServerError("Cannot find context with specified id");
     }
     remoteObject->setObjectId(injectedScript->bindObject(value, groupName));
+    int persistentId = v8::internal::RecordReplayObjectId(isolate, context, value,
+                                                          /* allow_create */ false);
+    if (persistentId) {
+      auto persistentIdString = String16::fromInteger64(static_cast<int64_t>(persistentId));
+      remoteObject->setPersistentId(persistentIdString);
+    }
   }
   return Response::Success();
 }

--- a/src/interpreter/bytecode-array-builder.cc
+++ b/src/interpreter/bytecode-array-builder.cc
@@ -1404,10 +1404,9 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayInstrumentation(const ch
 
 BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayInstrumentationGenerator(
     const char* kind, Register generator_object) {
-  // Even though instrumentation opcodes aren't needed when recording, we still
-  // need to emit InstrumentationGenerator opcodes so that generator objects
-  // will be associated with IDs at consistent points.
-  if (emit_record_replay_opcodes_) {
+  // Instrumentation opcodes aren't needed when recording, except when we are asserting
+  // encountered values and need consistent IDs for these objects when recording.
+  if (emit_record_replay_opcodes_ && (recordreplay::IsReplaying() || gRecordReplayAssertValues)) {
     int bytecode_offset = bytecode_array_writer_.size();
     int index = RegisterInstrumentationSite(kind, kNoSourcePosition, bytecode_offset);
     OutputRecordReplayInstrumentationGenerator(index, generator_object);

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -4,6 +4,7 @@
 
 #include <vector>
 
+#include "src/api/api-inl.h"
 #include "src/codegen/compiler.h"
 #include "src/common/globals.h"
 #include "src/debug/debug-coverage.h"
@@ -1320,7 +1321,8 @@ RUNTIME_FUNCTION(Runtime_RecordReplayInstrumentation) {
   return ReadOnlyRoots(isolate).undefined_value();
 }
 
-extern int RecordReplayObjectId(Isolate* isolate, Handle<Object> internal_object);
+extern int RecordReplayObjectId(v8::Isolate* isolate, Local<v8::Context> cx,
+                                v8::Local<v8::Value> object, bool allow_create);
 
 static int gCurrentGeneratorId;
 
@@ -1333,13 +1335,16 @@ RUNTIME_FUNCTION(Runtime_RecordReplayInstrumentationGenerator) {
   DCHECK_EQ(3, args.length());
   CONVERT_ARG_HANDLE_CHECKED(JSFunction, function, 0);
   CONVERT_NUMBER_CHECKED(int32_t, index, Int32, args[1]);
-  CONVERT_ARG_HANDLE_CHECKED(JSGeneratorObject, generator_object, 2);
+  CONVERT_ARG_HANDLE_CHECKED(Object, generator_object, 2);
 
   // Note: RecordReplayObjectId calls have to occur in the same places when
   // replaying (regardless of whether instrumentation is enabled) so that objects
   // will be assigned consistent IDs.
   CHECK(!gCurrentGeneratorId);
-  gCurrentGeneratorId = RecordReplayObjectId(isolate, generator_object);
+  v8::Isolate* v8_isolate = (v8::Isolate*) isolate;
+  gCurrentGeneratorId = RecordReplayObjectId(v8_isolate, v8_isolate->GetCurrentContext(),
+                                             v8::Utils::ToLocal(generator_object),
+                                             /* allow_create */ true);
 
   if (gRecordReplayInstrumentationEnabled) {
     OnInstrumentation(isolate, function, index);
@@ -1351,10 +1356,14 @@ RUNTIME_FUNCTION(Runtime_RecordReplayInstrumentationGenerator) {
 }
 
 RUNTIME_FUNCTION(Runtime_RecordReplayTrackObjectId) {
-  DCHECK_EQ(1, args.length());
+  DCHECK_EQ(2, args.length());
   CONVERT_ARG_HANDLE_CHECKED(Object, value, 0);
+  CONVERT_ARG_HANDLE_CHECKED(Context, context, 1);
 
-  RecordReplayObjectId(isolate, value);
+  v8::Isolate* v8_isolate = (v8::Isolate*) isolate;
+  RecordReplayObjectId(v8_isolate, v8::Utils::ToLocal(context),
+                       v8::Utils::ToLocal(value),
+                       /* allow_create */ true);
 
   return ReadOnlyRoots(isolate).undefined_value();
 }

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1320,7 +1320,7 @@ RUNTIME_FUNCTION(Runtime_RecordReplayInstrumentation) {
   return ReadOnlyRoots(isolate).undefined_value();
 }
 
-extern int RecordReplayObjectId(Handle<Object> internal_object);
+extern int RecordReplayObjectId(Isolate* isolate, Handle<Object> internal_object);
 
 static int gCurrentGeneratorId;
 
@@ -1336,16 +1336,25 @@ RUNTIME_FUNCTION(Runtime_RecordReplayInstrumentationGenerator) {
   CONVERT_ARG_HANDLE_CHECKED(JSGeneratorObject, generator_object, 2);
 
   // Note: RecordReplayObjectId calls have to occur in the same places when
-  // replaying as when recording (regardless of whether instrumentation is
-  // enabled) so that objects will be assigned consistent IDs.
+  // replaying (regardless of whether instrumentation is enabled) so that objects
+  // will be assigned consistent IDs.
   CHECK(!gCurrentGeneratorId);
-  gCurrentGeneratorId = RecordReplayObjectId(generator_object);
+  gCurrentGeneratorId = RecordReplayObjectId(isolate, generator_object);
 
   if (gRecordReplayInstrumentationEnabled) {
     OnInstrumentation(isolate, function, index);
   }
 
   gCurrentGeneratorId = 0;
+
+  return ReadOnlyRoots(isolate).undefined_value();
+}
+
+RUNTIME_FUNCTION(Runtime_RecordReplayTrackObjectId) {
+  DCHECK_EQ(1, args.length());
+  CONVERT_ARG_HANDLE_CHECKED(Object, value, 0);
+
+  RecordReplayObjectId(isolate, value);
 
   return ReadOnlyRoots(isolate).undefined_value();
 }

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -153,7 +153,7 @@ namespace internal {
   F(RecordReplayAssertValue, 3, 1)              \
   F(RecordReplayInstrumentation, 2, 1)          \
   F(RecordReplayInstrumentationGenerator, 3, 1) \
-  F(RecordReplayTrackObjectId, 1, 1)
+  F(RecordReplayTrackObjectId, 2, 1)
 
 #define FOR_EACH_INTRINSIC_FORIN(F, I) \
   F(ForInEnumerate, 1, 1)              \

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -152,7 +152,8 @@ namespace internal {
   F(RecordReplayNotifyActivity, 0, 1)           \
   F(RecordReplayAssertValue, 3, 1)              \
   F(RecordReplayInstrumentation, 2, 1)          \
-  F(RecordReplayInstrumentationGenerator, 3, 1)
+  F(RecordReplayInstrumentationGenerator, 3, 1) \
+  F(RecordReplayTrackObjectId, 1, 1)
 
 #define FOR_EACH_INTRINSIC_FORIN(F, I) \
   F(ForInEnumerate, 1, 1)              \


### PR DESCRIPTION
For https://linear.app/replay/issue/RUN-787