### PR TITLE
(1) add `disable-collect-events`, (2) add `browser-event` (fix up fro…

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11059,6 +11059,12 @@ static const char* gRecordReplayKnownFeatures[] = {
 
   // Use optimizing JIT compiler.
   "use-optimizing-jit",
+
+  // Send certain event information to render thread.
+  "browser-event",
+
+  // Record/replay events are turned off by default (for now) (RUN-1251)
+  "disable-collect-events"
 };
 
 static inline void RecordReplayCheckKnownFeature(const char* feature) {


### PR DESCRIPTION
…m a month ago that causes warnings)
* https://linear.app/replay/issue/RUN-1251/add-an-eventsenabled-feature-flag-to-chromium