### PR TITLE
RUN-1341: re-enable events experimental flag (part of RUN-1392)

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11111,7 +11111,7 @@ static const char* GetDisabledFeatureSpecifier() {
 
 static bool GetTestEnvironmentFlag() {
   auto* sTestEnvironment = getenv("RECORD_REPLAY_TEST_ENVIRONMENT");
-  // check is based on Util.cpp
+  // check is based on TestEnv in Utils.cpp
   return sTestEnvironment && sTestEnvironment[0] && sTestEnvironment[0] != '0';
 }
 

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11088,7 +11088,7 @@ bool recordreplay::FeatureEnabled(const char* feature) {
   }
 
   std::string sFeature(feature);
-  if (gRecordReplayDisabledFeatures->find(sFeature) == gRecordReplayDisabledFeatures->end()) {
+  if (gRecordReplayDisabledFeatures->find(sFeature) != gRecordReplayDisabledFeatures->end()) {
     return false;
   }
 

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11070,9 +11070,9 @@ static std::set<std::string>* gRecordReplayKnownFeatures = new std::set<std::str
 // The set of all experimental flags pertaining to features we are currently developing.
 // Ideally, this should always be a short list.
 // NOTE: These should generally be "double-negative" flags which we need to convert to positive in the near future.
-static std::vector<std::string>* gExperimentalFlags = new std::vector<std::string>({
+static const char* gExperimentalFlags[] = {
   "disable-collect-events"
-});
+};
 
 static inline void RecordReplayCheckKnownFeature(const char* feature) {
   std::string sFeature(feature);
@@ -11110,8 +11110,7 @@ static const char* GetDisabledFeatureSpecifier() {
 }
 
 static bool GetTestEnvironmentFlag() {
-  auto* sTestEnvironment = getenv("RECORD_REPLAY_TEST_ENVIRONMENT");
-  return sTestEnvironment && !strcmp(sTestEnvironment, "1");
+  return !!getenv("RECORD_REPLAY_TEST_ENVIRONMENT");
 }
 
 static void RecordReplayInitializeDisabledFeatures() {
@@ -11121,7 +11120,7 @@ static void RecordReplayInitializeDisabledFeatures() {
   gRecordReplayDisabledFeatures = new std::set<std::string>();
 
   if (isTestEnvironment) {
-    for (auto& experimentalFeature : *gExperimentalFlags) {
+    for (auto* experimentalFeature : gExperimentalFlags) {
       gRecordReplayDisabledFeatures->insert(experimentalFeature);
     }
   }
@@ -11875,6 +11874,7 @@ void recordreplay::SetRecordingOrReplaying(void* handle) {
   // Log disabled features.
   if (gRecordReplayDisabledFeatures) {
     for (const std::string& feature : *gRecordReplayDisabledFeatures) {
+      fprintf(stderr, "RecordReplayDisabledFeature %s\n", feature.c_str());
       RecordReplayCheckKnownFeature(feature.c_str());
     }
   }

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11875,7 +11875,6 @@ void recordreplay::SetRecordingOrReplaying(void* handle) {
   // Log disabled features.
   if (gRecordReplayDisabledFeatures) {
     for (const std::string& feature : *gRecordReplayDisabledFeatures) {
-      fprintf(stderr, "RecordReplayDisabledFeature %s\n", feature.c_str());
       RecordReplayCheckKnownFeature(feature.c_str());
     }
   }

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -10956,7 +10956,7 @@ static std::set<std::string>* gRecordReplayDisabledFeatures;
 // Known features which can be disabled via RECORD_REPLAY_DISABLE_FEATURES.
 // Used to catch misspellings when testing if a feature is enabled or specifying
 // disabled features.
-static std::set<std::string> gRecordReplayKnownFeatures = {
+static std::set<std::string>* gRecordReplayKnownFeatures = new std::set<std::string>({
   // Disable all tests for whether we are recording/replaying.
   "record-replay",
 
@@ -11065,16 +11065,18 @@ static std::set<std::string> gRecordReplayKnownFeatures = {
 
   // Record/replay events are turned off by default (for now) (RUN-1251)
   "disable-collect-events"
-};
+});
 
-static std::set<std::string> gExperimentalFlags = {
+// The set of all experimental flags pertaining to features we are currently developing.
+// Ideally, this should always be a short list.
+// NOTE: These should generally be "double-negative" flags which we need to convert to positive in the near future.
+static std::vector<std::string>* gExperimentalFlags = new std::vector<std::string>({
   "disable-collect-events"
-};
+});
 
 static inline void RecordReplayCheckKnownFeature(const char* feature) {
   std::string sFeature(feature);
-  // TODO: fixme
-  if (gRecordReplayKnownFeatures.find(sFeature) == gRecordReplayKnownFeatures.end()) {
+  if (gRecordReplayKnownFeatures->find(sFeature) == gRecordReplayKnownFeatures->end()) {
     fprintf(stderr, "UnknownFeature %s\n", feature);
     recordreplay::Print("UnknownFeature %s", feature);
   }
@@ -11119,7 +11121,9 @@ static void RecordReplayInitializeDisabledFeatures() {
   gRecordReplayDisabledFeatures = new std::set<std::string>();
 
   if (isTestEnvironment) {
-    // TODO: add gExperimentalFlags
+    for (auto& experimentalFeature : *gExperimentalFlags) {
+      gRecordReplayDisabledFeatures->insert(experimentalFeature);
+    }
   }
   
   if (!env) {
@@ -11571,7 +11575,6 @@ extern "C" void V8RecordReplayOnMouseEvent(const char* kind, size_t clientX,
   if (!internal::gRecordReplayHasCheckpoint) {
     return;
   }
-  // TODO: make sure event name (kind) is correct
   gRecordReplayOnMouseEvent(kind, clientX, clientY);
 }
 
@@ -11580,7 +11583,6 @@ extern "C" void V8RecordReplayOnKeyEvent(const char* kind, const char* key) {
   if (!internal::gRecordReplayHasCheckpoint) {
     return;
   }
-  // TODO: make sure event name (kind) is correct
   gRecordReplayOnKeyEvent(kind, key);
 }
 
@@ -11589,9 +11591,6 @@ extern "C" void V8RecordReplayOnNavigationEvent(const char* kind, const char* ur
   if (!internal::gRecordReplayHasCheckpoint) {
     return;
   }
-  // TODO: double check empty urls, about: urls, chrome: urls etc.
-  //  → compare w/
-  //  https://github.com/replayio/gecko-dev/blob/67254b1846b996c69063082ada18c54ceebfbe6d/toolkit/recordreplay/ProcessRecordReplay.cpp#L966
   gRecordReplayOnNavigationEvent(kind, url);
 }
 

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11110,7 +11110,9 @@ static const char* GetDisabledFeatureSpecifier() {
 }
 
 static bool GetTestEnvironmentFlag() {
-  return !!getenv("RECORD_REPLAY_TEST_ENVIRONMENT");
+  auto* sTestEnvironment = getenv("RECORD_REPLAY_TEST_ENVIRONMENT");
+  // check is based on Util.cpp
+  return sTestEnvironment && sTestEnvironment[0] && sTestEnvironment[0] != '0';
 }
 
 static void RecordReplayInitializeDisabledFeatures() {


### PR DESCRIPTION
Re-enable experimental flag, after merging replayio/chromium#421.

* https://linear.app/replay/issue/RUN-1392/fix-events-recorder-crashes