### PR TITLE
re-enable events

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11071,7 +11071,8 @@ static std::set<std::string>* gRecordReplayKnownFeatures = new std::set<std::str
 // Ideally, this should always be a short list.
 // NOTE: These should generally be "double-negative" flags which we need to convert to positive in the near future.
 static const char* gExperimentalFlags[] = {
-  "disable-collect-events"
+  // NOTE: Events are currently in the pipeline, but causing too many crashes. Re-enable once ready.
+  // "disable-collect-events"
 };
 
 static inline void RecordReplayCheckKnownFeature(const char* feature) {

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11071,8 +11071,7 @@ static std::set<std::string>* gRecordReplayKnownFeatures = new std::set<std::str
 // Ideally, this should always be a short list.
 // NOTE: These should generally be "double-negative" flags which we need to convert to positive in the near future.
 static const char* gExperimentalFlags[] = {
-  // NOTE: Events are currently in the pipeline, but causing too many crashes. Re-enable once ready.
-  // "disable-collect-events"
+  "disable-collect-events"
 };
 
 static inline void RecordReplayCheckKnownFeature(const char* feature) {


### PR DESCRIPTION
* enable events in test suites again, as a follow up of https://github.com/replayio/chromium/pull/439