### PR TITLE
Revert "RUN-1429: adding `KeyIterationParams` to v8 prop (key + element) iteration"

### DIFF
--- a/include/js_protocol.pdl
+++ b/include/js_protocol.pdl
@@ -1527,8 +1527,6 @@ domain Runtime
       # Allocated heap size in bytes.
       number totalSize
 
-  type KeyIterationIndex extends integer
-
   # Returns properties of a given object. Object group of the result is inherited from the target
   # object.
   command getProperties
@@ -1545,10 +1543,6 @@ domain Runtime
       experimental optional boolean generatePreview
       # If true, returns non-indexed properties only.
       experimental optional boolean nonIndexedPropertiesOnly
-      # If > 0, returns up to `pageSize` properties only.
-      optional KeyIterationIndex pageSize
-      # If pageIndex > 0 and pageSize > 0, returns properties starting at pageIndex * pageSize.
-      optional KeyIterationIndex pageIndex
     returns
       # Object properties.
       array of PropertyDescriptor result

--- a/include/v8-container.h
+++ b/include/v8-container.h
@@ -69,8 +69,7 @@ class V8_EXPORT Map : public Object {
    * Returns an array of length Size() * 2, where index N is the Nth key and
    * index N + 1 is the Nth value.
    */
-  Local<Array> AsArray(const v8::KeyIterationParams* params =
-                           v8::KeyIterationParams::Default()) const;
+  Local<Array> AsArray() const;
 
   /**
    * Creates a new empty Map.
@@ -106,7 +105,7 @@ class V8_EXPORT Set : public Object {
   /**
    * Returns an array of the keys in this Set.
    */
-  Local<Array> AsArray(const v8::KeyIterationParams* params = v8::KeyIterationParams::Default()) const;
+  Local<Array> AsArray() const;
 
   /**
    * Creates a new empty Set.

--- a/src/debug/debug-interface.cc
+++ b/src/debug/debug-interface.cc
@@ -185,7 +185,8 @@ void ClearBreakOnNextFunctionCall(Isolate* isolate) {
   i_isolate->debug()->ClearBreakOnNextFunctionCall();
 }
 
-MaybeLocal<Array> GetInternalProperties(Isolate* v8_isolate, Local<Value> value) {
+MaybeLocal<Array> GetInternalProperties(Isolate* v8_isolate,
+                                        Local<Value> value) {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(v8_isolate);
   ENTER_V8_NO_SCRIPT_NO_EXCEPTION(isolate);
   i::Handle<i::Object> val = Utils::OpenHandle(*value);
@@ -1400,8 +1401,7 @@ void RecordAsyncStackTaggingCreateTaskCall(v8::Isolate* v8_isolate) {
 }
 
 std::unique_ptr<PropertyIterator> PropertyIterator::Create(
-    Local<Context> context, Local<Object> object, bool skip_indices,
-    const v8::KeyIterationParams* params) {
+    Local<Context> context, Local<Object> object, bool skip_indices) {
   internal::Isolate* isolate =
       reinterpret_cast<i::Isolate*>(object->GetIsolate());
   if (isolate->is_execution_terminating()) {
@@ -1410,7 +1410,7 @@ std::unique_ptr<PropertyIterator> PropertyIterator::Create(
   CallDepthScope<false> call_depth_scope(isolate, context);
 
   auto result = i::DebugPropertyIterator::Create(
-      isolate, Utils::OpenHandle(*object), skip_indices, params);
+      isolate, Utils::OpenHandle(*object), skip_indices);
   if (!result) {
     DCHECK(isolate->has_pending_exception());
     call_depth_scope.Escape();

--- a/src/debug/debug-interface.h
+++ b/src/debug/debug-interface.h
@@ -626,8 +626,7 @@ class V8_EXPORT_PRIVATE PropertyIterator {
   // The returned std::unique_ptr is empty iff that happens.
   V8_WARN_UNUSED_RESULT static std::unique_ptr<PropertyIterator> Create(
       v8::Local<v8::Context> context, v8::Local<v8::Object> object,
-      bool skip_indices = false,
-      const v8::KeyIterationParams* params = v8::KeyIterationParams::Default());
+      bool skip_indices = false);
 
   virtual ~PropertyIterator() = default;
 

--- a/src/debug/debug-property-iterator.cc
+++ b/src/debug/debug-property-iterator.cc
@@ -15,11 +15,10 @@ namespace v8 {
 namespace internal {
 
 std::unique_ptr<DebugPropertyIterator> DebugPropertyIterator::Create(
-    Isolate* isolate, Handle<JSReceiver> receiver, bool skip_indices,
-    const v8::KeyIterationParams* params) {
+    Isolate* isolate, Handle<JSReceiver> receiver, bool skip_indices) {
   // Can't use std::make_unique as Ctor is private.
   auto iterator = std::unique_ptr<DebugPropertyIterator>(
-      new DebugPropertyIterator(isolate, receiver, skip_indices, params));
+      new DebugPropertyIterator(isolate, receiver, skip_indices));
 
   if (receiver->IsJSProxy()) {
     iterator->AdvanceToPrototype();
@@ -35,13 +34,11 @@ std::unique_ptr<DebugPropertyIterator> DebugPropertyIterator::Create(
 
 DebugPropertyIterator::DebugPropertyIterator(Isolate* isolate,
                                              Handle<JSReceiver> receiver,
-                                             bool skip_indices,
-                                             const v8::KeyIterationParams* params)
+                                             bool skip_indices)
     : isolate_(isolate),
       prototype_iterator_(isolate, receiver, kStartAtReceiver,
                           PrototypeIterator::END_AT_NULL),
       skip_indices_(skip_indices),
-      key_iteration_params_(params),
       current_key_index_(0),
       current_keys_(isolate_->factory()->empty_fixed_array()),
       current_keys_length_(0) {}
@@ -200,8 +197,7 @@ bool DebugPropertyIterator::FillKeysForCurrentPrototypeAndStage() {
   if (KeyAccumulator::GetKeys(isolate_, receiver, KeyCollectionMode::kOwnOnly,
                               filter, GetKeysConversion::kConvertToString,
                               false,
-                              skip_indices_ || receiver->IsJSTypedArray(),
-                              key_iteration_params_)
+                              skip_indices_ || receiver->IsJSTypedArray())
           .ToHandle(&current_keys_)) {
     current_keys_length_ = current_keys_->length();
     return true;

--- a/src/debug/debug-property-iterator.h
+++ b/src/debug/debug-property-iterator.h
@@ -24,8 +24,7 @@ class JSReceiver;
 class DebugPropertyIterator final : public debug::PropertyIterator {
  public:
   V8_WARN_UNUSED_RESULT static std::unique_ptr<DebugPropertyIterator> Create(
-      Isolate* isolate, Handle<JSReceiver> receiver, bool skip_indices,
-      const v8::KeyIterationParams* params = v8::KeyIterationParams::Default());
+      Isolate* isolate, Handle<JSReceiver> receiver, bool skip_indices);
   ~DebugPropertyIterator() override = default;
   DebugPropertyIterator(const DebugPropertyIterator&) = delete;
   DebugPropertyIterator& operator=(const DebugPropertyIterator&) = delete;
@@ -45,8 +44,7 @@ class DebugPropertyIterator final : public debug::PropertyIterator {
 
  private:
   DebugPropertyIterator(Isolate* isolate, Handle<JSReceiver> receiver,
-                        bool skip_indices,
-                        const v8::KeyIterationParams* params = v8::KeyIterationParams::Default());
+                        bool skip_indices);
 
   V8_WARN_UNUSED_RESULT bool FillKeysForCurrentPrototypeAndStage();
   bool should_move_to_next_stage() const;
@@ -63,7 +61,6 @@ class DebugPropertyIterator final : public debug::PropertyIterator {
     kAllProperties = 2
   } stage_ = kExoticIndices;
   bool skip_indices_;
-  const v8::KeyIterationParams* key_iteration_params_;
 
   size_t current_key_index_;
   Handle<FixedArray> current_keys_;

--- a/src/inspector/injected-script.cc
+++ b/src/inspector/injected-script.cc
@@ -417,9 +417,7 @@ class PropertyAccumulator : public ValueMirror::PropertyAccumulator {
 Response InjectedScript::getProperties(
     v8::Local<v8::Object> object, const String16& groupName, bool ownProperties,
     bool accessorPropertiesOnly, bool nonIndexedPropertiesOnly,
-    WrapMode wrapMode,
-    const v8::KeyIterationParams* params,
-    std::unique_ptr<Array<PropertyDescriptor>>* properties,
+    WrapMode wrapMode, std::unique_ptr<Array<PropertyDescriptor>>* properties,
     Maybe<protocol::Runtime::ExceptionDetails>* exceptionDetails) {
   v8::HandleScope handles(m_context->isolate());
   v8::Local<v8::Context> context = m_context->context();
@@ -432,9 +430,7 @@ Response InjectedScript::getProperties(
   PropertyAccumulator accumulator(&mirrors);
   if (!ValueMirror::getProperties(context, object, ownProperties,
                                   accessorPropertiesOnly,
-                                  nonIndexedPropertiesOnly,
-                                  &accumulator,
-                                  params)) {
+                                  nonIndexedPropertiesOnly, &accumulator)) {
     return createExceptionDetails(tryCatch, groupName, exceptionDetails);
   }
   for (const PropertyMirror& mirror : mirrors) {
@@ -503,7 +499,6 @@ Response InjectedScript::getProperties(
 Response InjectedScript::getInternalAndPrivateProperties(
     v8::Local<v8::Value> value, const String16& groupName,
     bool accessorPropertiesOnly,
-    const v8::KeyIterationParams* params,
     std::unique_ptr<protocol::Array<InternalPropertyDescriptor>>*
         internalProperties,
     std::unique_ptr<protocol::Array<PrivatePropertyDescriptor>>*
@@ -521,7 +516,7 @@ Response InjectedScript::getInternalAndPrivateProperties(
   if (!accessorPropertiesOnly) {
     std::vector<InternalPropertyMirror> internalPropertiesWrappers;
     ValueMirror::getInternalProperties(m_context->context(), value_obj,
-                                       &internalPropertiesWrappers, params);
+                                       &internalPropertiesWrappers);
     for (const auto& internalProperty : internalPropertiesWrappers) {
       std::unique_ptr<RemoteObject> remoteObject;
       Response response = internalProperty.value->buildRemoteObject(

--- a/src/inspector/injected-script.h
+++ b/src/inspector/injected-script.h
@@ -88,15 +88,14 @@ class InjectedScript final {
   Response getProperties(
       v8::Local<v8::Object>, const String16& groupName, bool ownProperties,
       bool accessorPropertiesOnly, bool nonIndexedPropertiesOnly,
-      WrapMode wrapMode, 
-      const v8::KeyIterationParams* params,
+      WrapMode wrapMode,
       std::unique_ptr<protocol::Array<protocol::Runtime::PropertyDescriptor>>*
           result,
       Maybe<protocol::Runtime::ExceptionDetails>*);
 
   Response getInternalAndPrivateProperties(
       v8::Local<v8::Value>, const String16& groupName,
-      bool accessorPropertiesOnly, const v8::KeyIterationParams* params,
+      bool accessorPropertiesOnly,
       std::unique_ptr<
           protocol::Array<protocol::Runtime::InternalPropertyDescriptor>>*
           internalProperties,

--- a/src/inspector/v8-debugger.cc
+++ b/src/inspector/v8-debugger.cc
@@ -737,13 +737,12 @@ v8::MaybeLocal<v8::Value> V8Debugger::generatorScopes(
 }
 
 v8::MaybeLocal<v8::Array> V8Debugger::collectionsEntries(
-    v8::Local<v8::Context> context, v8::Local<v8::Value> collection,
-    const v8::KeyIterationParams* params) {
+    v8::Local<v8::Context> context, v8::Local<v8::Value> collection) {
   v8::Isolate* isolate = context->GetIsolate();
   v8::Local<v8::Array> entries;
   bool isKeyValue = false;
   if (!collection->IsObject() || !collection.As<v8::Object>()
-                                      ->PreviewEntries(&isKeyValue, params)
+                                      ->PreviewEntries(&isKeyValue)
                                       .ToLocal(&entries)) {
     return v8::MaybeLocal<v8::Array>();
   }
@@ -777,13 +776,12 @@ v8::MaybeLocal<v8::Array> V8Debugger::collectionsEntries(
 }
 
 v8::MaybeLocal<v8::Array> V8Debugger::internalProperties(
-    v8::Local<v8::Context> context, v8::Local<v8::Value> value,
-    const v8::KeyIterationParams* params) {
+    v8::Local<v8::Context> context, v8::Local<v8::Value> value) {
   v8::Local<v8::Array> properties;
   if (!v8::debug::GetInternalProperties(m_isolate, value).ToLocal(&properties))
     return v8::MaybeLocal<v8::Array>();
   v8::Local<v8::Array> entries;
-  if (collectionsEntries(context, value, params).ToLocal(&entries)) {
+  if (collectionsEntries(context, value).ToLocal(&entries)) {
     createDataProperty(context, properties, properties->Length(),
                        toV8StringInternalized(m_isolate, "[[Entries]]"));
     createDataProperty(context, properties, properties->Length(), entries);

--- a/src/inspector/v8-debugger.h
+++ b/src/inspector/v8-debugger.h
@@ -103,9 +103,8 @@ class V8Debugger : public v8::debug::DebugDelegate,
   std::unique_ptr<V8StackTraceImpl> createStackTrace(v8::Local<v8::StackTrace>);
   std::unique_ptr<V8StackTraceImpl> captureStackTrace(bool fullStack);
 
-  v8::MaybeLocal<v8::Array> internalProperties(
-      v8::Local<v8::Context>, v8::Local<v8::Value>,
-      const v8::KeyIterationParams* params);
+  v8::MaybeLocal<v8::Array> internalProperties(v8::Local<v8::Context>,
+                                               v8::Local<v8::Value>);
 
   v8::Local<v8::Array> queryObjects(v8::Local<v8::Context> context,
                                     v8::Local<v8::Object> prototype);
@@ -170,8 +169,7 @@ class V8Debugger : public v8::debug::DebugDelegate,
   v8::MaybeLocal<v8::Value> generatorScopes(v8::Local<v8::Context>,
                                             v8::Local<v8::Value>);
   v8::MaybeLocal<v8::Array> collectionsEntries(v8::Local<v8::Context> context,
-                                               v8::Local<v8::Value> value,
-                                               const v8::KeyIterationParams* params);
+                                               v8::Local<v8::Value> value);
 
   void asyncTaskScheduledForStack(const StringView& taskName, void* task,
                                   bool recurring, bool skipTopFrame = false);

--- a/src/inspector/v8-runtime-agent-impl.cc
+++ b/src/inspector/v8-runtime-agent-impl.cc
@@ -54,8 +54,6 @@
 
 #include "v8.h"
 
-#include "src/base/platform/elapsed-timer.h"
-
 namespace v8_inspector {
 
 namespace V8RuntimeAgentImplState {
@@ -436,8 +434,6 @@ Response V8RuntimeAgentImpl::getProperties(
     const String16& objectId, Maybe<bool> ownProperties,
     Maybe<bool> accessorPropertiesOnly, Maybe<bool> generatePreview,
     Maybe<bool> nonIndexedPropertiesOnly,
-    Maybe<protocol::Runtime::KeyIterationIndex> pageSize,
-    Maybe<protocol::Runtime::KeyIterationIndex> pageIndex,
     std::unique_ptr<protocol::Array<protocol::Runtime::PropertyDescriptor>>*
         result,
     Maybe<protocol::Array<protocol::Runtime::InternalPropertyDescriptor>>*
@@ -459,16 +455,12 @@ Response V8RuntimeAgentImpl::getProperties(
     return Response::ServerError("Value with given id is not an object");
 
   v8::Local<v8::Object> object = scope.object().As<v8::Object>();
-
-  v8::KeyIterationParams params(pageSize.fromMaybe(0), pageIndex.fromMaybe(0));
-
   response = scope.injectedScript()->getProperties(
       object, scope.objectGroupName(), ownProperties.fromMaybe(false),
       accessorPropertiesOnly.fromMaybe(false),
       nonIndexedPropertiesOnly.fromMaybe(false),
       generatePreview.fromMaybe(false) ? WrapMode::kWithPreview
                                        : WrapMode::kNoPreview,
-      &params,
       result, exceptionDetails);
   if (!response.IsSuccess()) return response;
   if (exceptionDetails->isJust()) return Response::Success();
@@ -477,7 +469,7 @@ Response V8RuntimeAgentImpl::getProperties(
   std::unique_ptr<protocol::Array<PrivatePropertyDescriptor>>
       privatePropertiesProtocolArray;
   response = scope.injectedScript()->getInternalAndPrivateProperties(
-      object, scope.objectGroupName(), accessorPropertiesOnly.fromMaybe(false), &params,
+      object, scope.objectGroupName(), accessorPropertiesOnly.fromMaybe(false),
       &internalPropertiesProtocolArray, &privatePropertiesProtocolArray);
   if (!response.IsSuccess()) return response;
   if (!internalPropertiesProtocolArray->empty())

--- a/src/inspector/v8-runtime-agent-impl.h
+++ b/src/inspector/v8-runtime-agent-impl.h
@@ -94,8 +94,6 @@ class V8RuntimeAgentImpl : public protocol::Runtime::Backend {
       const String16& objectId, Maybe<bool> ownProperties,
       Maybe<bool> accessorPropertiesOnly, Maybe<bool> generatePreview,
       Maybe<bool> nonIndexedPropertiesOnly,
-      Maybe<protocol::Runtime::KeyIterationIndex> pageSize,
-      Maybe<protocol::Runtime::KeyIterationIndex> pageIndex,
       std::unique_ptr<protocol::Array<protocol::Runtime::PropertyDescriptor>>*
           result,
       Maybe<protocol::Array<protocol::Runtime::InternalPropertyDescriptor>>*

--- a/src/inspector/value-mirror.cc
+++ b/src/inspector/value-mirror.cc
@@ -25,8 +25,6 @@
 
 #include "v8.h"
 
-#include "src/inspector/string-util.h"
-
 namespace v8_inspector {
 
 using protocol::Response;
@@ -1315,25 +1313,9 @@ std::unique_ptr<ValueMirror> createNativeSetter(v8::Local<v8::Context> context,
   return ValueMirror::create(context, function);
 }
 
-static const char* allowed_getters[] = {
-  "type", "fromElement", "target", "isTrusted"
-};
-
 bool doesAttributeHaveObservableSideEffectOnGet(v8::Local<v8::Context> context,
                                                 v8::Local<v8::Object> object,
                                                 v8::Local<v8::Name> name) {
-  if (v8::recordreplay::HasDivergedFromRecording()) {
-    // Disallow most getters during Pause, since they cause unwanted crashes.
-    // -> https://linear.app/replay/issue/RUN-1478
-    for (auto allowed : allowed_getters) {
-      v8::String::Utf8Value nameRaw(context->GetIsolate(), name.As<v8::String>());
-      if (!strcmp(allowed, *nameRaw)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   // TODO(dgozman): we should remove this, annotate more embedder properties as
   // side-effect free, and call all getters which do not produce side effects.
   if (!name->IsString()) return false;
@@ -1377,8 +1359,7 @@ bool ValueMirror::getProperties(v8::Local<v8::Context> context,
                                 v8::Local<v8::Object> object,
                                 bool ownProperties, bool accessorPropertiesOnly,
                                 bool nonIndexedPropertiesOnly,
-                                PropertyAccumulator* accumulator,
-                                const v8::KeyIterationParams* params) {
+                                PropertyAccumulator* accumulator) {
   v8::Isolate* isolate = context->GetIsolate();
   v8::TryCatch tryCatch(isolate);
   v8::Local<v8::Set> set = v8::Set::New(isolate);
@@ -1402,13 +1383,19 @@ bool ValueMirror::getProperties(v8::Local<v8::Context> context,
   }
 
   auto iterator = v8::debug::PropertyIterator::Create(context, object,
-                                                      nonIndexedPropertiesOnly, params);
+                                                      nonIndexedPropertiesOnly);
   if (!iterator) {
     CHECK(tryCatch.HasCaught());
     return false;
   }
 
+  int i = 0;
   while (!iterator->Done()) {
+    if (v8::recordreplay::HasDivergedFromRecording() && ++i > 1000) {
+      // Quick-and-dirty fix for slow Pause object queries + getAllFrames (RUN-1315)
+      v8::recordreplay::Print("[RuntimeWarning] ValueMirror::getProperties overflow break");
+      break;
+    }
     bool isOwn = iterator->is_own();
     if (!isOwn && ownProperties) break;
     v8::Local<v8::Name> v8Name = iterator->name();
@@ -1484,7 +1471,6 @@ bool ValueMirror::getProperties(v8::Local<v8::Context> context,
             setterMirror = ValueMirror::create(context, descriptor.set);
           }
           isAccessorProperty = getterMirror || setterMirror;
-
           if (name != "__proto__" && !getterFunction.IsEmpty() &&
               getterFunction->ScriptId() == v8::UnboundScript::kNoScriptId &&
               !doesAttributeHaveObservableSideEffectOnGet(context, object,
@@ -1531,8 +1517,7 @@ bool ValueMirror::getProperties(v8::Local<v8::Context> context,
 // static
 void ValueMirror::getInternalProperties(
     v8::Local<v8::Context> context, v8::Local<v8::Object> object,
-    std::vector<InternalPropertyMirror>* mirrors,
-    const v8::KeyIterationParams* params) {
+    std::vector<InternalPropertyMirror>* mirrors) {
   v8::Isolate* isolate = context->GetIsolate();
   v8::MicrotasksScope microtasksScope(isolate,
                                       v8::MicrotasksScope::kDoNotRunMicrotasks);
@@ -1561,7 +1546,7 @@ void ValueMirror::getInternalProperties(
       static_cast<V8InspectorImpl*>(v8::debug::GetInspector(isolate))
           ->debugger();
   v8::Local<v8::Array> properties;
-  if (debugger->internalProperties(context, object, params).ToLocal(&properties)) {
+  if (debugger->internalProperties(context, object).ToLocal(&properties)) {
     for (uint32_t i = 0; i < properties->Length(); i += 2) {
       v8::Local<v8::Value> name;
       if (!properties->Get(context, i).ToLocal(&name) || !name->IsString()) {

--- a/src/inspector/value-mirror.h
+++ b/src/inspector/value-mirror.h
@@ -78,12 +78,10 @@ class ValueMirror {
                             v8::Local<v8::Object> object, bool ownProperties,
                             bool accessorPropertiesOnly,
                             bool nonIndexedPropertiesOnly,
-                            PropertyAccumulator* accumulator,
-                            const v8::KeyIterationParams* params = v8::KeyIterationParams::Default());
+                            PropertyAccumulator* accumulator);
   static void getInternalProperties(
       v8::Local<v8::Context> context, v8::Local<v8::Object> object,
-      std::vector<InternalPropertyMirror>* mirrors,
-      const v8::KeyIterationParams* params = v8::KeyIterationParams::Default());
+      std::vector<InternalPropertyMirror>* mirrors);
   static std::vector<PrivatePropertyMirror> getPrivateProperties(
       v8::Local<v8::Context> context, v8::Local<v8::Object> object,
       bool accessorPropertiesOnly);

--- a/src/objects/elements-inl.h
+++ b/src/objects/elements-inl.h
@@ -23,11 +23,10 @@ ElementsAccessor::CollectElementIndices(Handle<JSObject> object,
 
 inline MaybeHandle<FixedArray> ElementsAccessor::PrependElementIndices(
     Isolate* isolate, Handle<JSObject> object, Handle<FixedArray> keys,
-    GetKeysConversion convert, PropertyFilter filter,
-    const KeyIterationParams* params) {
+    GetKeysConversion convert, PropertyFilter filter) {
   return PrependElementIndices(isolate, object,
                                handle(object->elements(), isolate), keys,
-                               convert, filter, params);
+                               convert, filter);
 }
 
 inline bool ElementsAccessor::HasElement(JSObject holder, uint32_t index,

--- a/src/objects/elements.cc
+++ b/src/objects/elements.cc
@@ -86,8 +86,6 @@ namespace internal {
 
 namespace {
 
-static KeyIterationParams kDefaultKeyIterationParams(0, 0);
-
 #define RETURN_NOTHING_IF_NOT_SUCCESSFUL(call) \
   do {                                         \
     if (!(call)) return Nothing<bool>();       \
@@ -1183,8 +1181,7 @@ class ElementsAccessorBase : public InternalElementsAccessor {
     PropertyFilter filter = keys->filter();
     Isolate* isolate = keys->isolate();
     Factory* factory = isolate->factory();
-    auto* params = keys->key_indexing_params();
-    for (size_t i = (size_t)params->KeyFirstIndex(); i < (size_t)params->KeyEndIndex((KeyIterationIndex)length); i++) {
+    for (size_t i = 0; i < length; i++) {
       if (Subclass::HasElementImpl(isolate, *object, i, *backing_store,
                                    filter)) {
         RETURN_FAILURE_IF_NOT_SUCCESSFUL(
@@ -1198,13 +1195,11 @@ class ElementsAccessorBase : public InternalElementsAccessor {
       Isolate* isolate, Handle<JSObject> object,
       Handle<FixedArrayBase> backing_store, GetKeysConversion convert,
       PropertyFilter filter, Handle<FixedArray> list, uint32_t* nof_indices,
-      uint32_t insertion_index = 0,
-      const KeyIterationParams* params = KeyIterationParams::Default()) {
+      uint32_t insertion_index = 0) {
     size_t length = Subclass::GetMaxIndex(*object, *backing_store);
     uint32_t const kMaxStringTableEntries =
         isolate->heap()->MaxNumberToStringCacheSize();
-    
-    for (size_t i = (size_t)params->KeyFirstIndex(); i < (size_t)params->KeyEndIndex((KeyIterationIndex)length); i++) {
+    for (size_t i = 0; i < length; i++) {
       if (Subclass::HasElementImpl(isolate, *object, i, *backing_store,
                                    filter)) {
         if (convert == GetKeysConversion::kConvertToString) {
@@ -1226,17 +1221,15 @@ class ElementsAccessorBase : public InternalElementsAccessor {
   MaybeHandle<FixedArray> PrependElementIndices(
       Isolate* isolate, Handle<JSObject> object,
       Handle<FixedArrayBase> backing_store, Handle<FixedArray> keys,
-      GetKeysConversion convert, PropertyFilter filter,
-      const KeyIterationParams* params) final {
+      GetKeysConversion convert, PropertyFilter filter) final {
     return Subclass::PrependElementIndicesImpl(isolate, object, backing_store,
-                                               keys, convert, filter, params);
+                                               keys, convert, filter);
   }
 
   static MaybeHandle<FixedArray> PrependElementIndicesImpl(
       Isolate* isolate, Handle<JSObject> object,
       Handle<FixedArrayBase> backing_store, Handle<FixedArray> keys,
-      GetKeysConversion convert, PropertyFilter filter,
-      const KeyIterationParams* params = KeyIterationParams::Default()) {
+      GetKeysConversion convert, PropertyFilter filter) {
     uint32_t nof_property_keys = keys->length();
     size_t initial_list_length =
         Subclass::GetMaxNumberOfEntries(*object, *backing_store);
@@ -1246,12 +1239,6 @@ class ElementsAccessorBase : public InternalElementsAccessor {
           MessageTemplate::kInvalidArrayLength));
     }
     initial_list_length += nof_property_keys;
-
-    initial_list_length = params->PageSize((KeyIterationIndex)initial_list_length);
-    if (initial_list_length <= nof_property_keys) {
-      // No space for indices.
-      return keys;
-    }
 
     // Collect the element indices into a new list.
     DCHECK_LE(initial_list_length, std::numeric_limits<int>::max());
@@ -1271,13 +1258,6 @@ class ElementsAccessorBase : public InternalElementsAccessor {
         initial_list_length =
             Subclass::NumberOfElementsImpl(*object, *backing_store);
         initial_list_length += nof_property_keys;
-
-        initial_list_length =
-            params->PageSize((KeyIterationIndex)initial_list_length);
-        if (initial_list_length <= nof_property_keys) {
-          // No space for indices.
-          return keys;
-        }
       }
       DCHECK_LE(initial_list_length, std::numeric_limits<int>::max());
       combined_keys = isolate->factory()->NewFixedArray(
@@ -1290,7 +1270,7 @@ class ElementsAccessorBase : public InternalElementsAccessor {
     combined_keys = Subclass::DirectCollectElementIndicesImpl(
         isolate, object, backing_store,
         needs_sorting ? GetKeysConversion::kKeepNumbers : convert, filter,
-        combined_keys, &nof_indices, 0, params);
+        combined_keys, &nof_indices);
 
     if (needs_sorting) {
       SortIndices(isolate, combined_keys, nof_indices);
@@ -1673,13 +1653,12 @@ class DictionaryElementsAccessor
     Isolate* isolate = keys->isolate();
     Handle<NumberDictionary> dictionary =
         Handle<NumberDictionary>::cast(backing_store);
-    const auto* params = keys->key_indexing_params();
     Handle<FixedArray> elements = isolate->factory()->NewFixedArray(
-        (int)params->PageSize(GetMaxNumberOfEntries(*object, *backing_store)));
+        GetMaxNumberOfEntries(*object, *backing_store));
     int insertion_index = 0;
     PropertyFilter filter = keys->filter();
     ReadOnlyRoots roots(isolate);
-    for (InternalIndex i : dictionary->IterateEntries(params)) {
+    for (InternalIndex i : dictionary->IterateEntries()) {
       AllowGarbageCollection allow_gc;
       Object raw_key = dictionary->KeyAt(isolate, i);
       if (!dictionary->IsKey(roots, raw_key)) continue;
@@ -1703,14 +1682,13 @@ class DictionaryElementsAccessor
       Isolate* isolate, Handle<JSObject> object,
       Handle<FixedArrayBase> backing_store, GetKeysConversion convert,
       PropertyFilter filter, Handle<FixedArray> list, uint32_t* nof_indices,
-      uint32_t insertion_index = 0,
-      const KeyIterationParams* params = KeyIterationParams::Default()) {
+      uint32_t insertion_index = 0) {
     if (filter & SKIP_STRINGS) return list;
     if (filter & ONLY_ALL_CAN_READ) return list;
 
     Handle<NumberDictionary> dictionary =
         Handle<NumberDictionary>::cast(backing_store);
-    for (InternalIndex i : dictionary->IterateEntries(params)) {
+    for (InternalIndex i : dictionary->IterateEntries()) {
       uint32_t key = GetKeyForEntryImpl(isolate, dictionary, i, filter);
       if (key == kMaxUInt32) continue;
       Handle<Object> index = isolate->factory()->NewNumberFromUint(key);
@@ -4677,13 +4655,11 @@ class SloppyArgumentsElementsAccessor
       KeyAccumulator* keys) {
     Isolate* isolate = keys->isolate();
     uint32_t nof_indices = 0;
-    const auto* params = keys->key_indexing_params();
     Handle<FixedArray> indices = isolate->factory()->NewFixedArray(
-        params->PageSize(GetCapacityImpl(*object, *backing_store)));
+        GetCapacityImpl(*object, *backing_store));
     DirectCollectElementIndicesImpl(isolate, object, backing_store,
                                     GetKeysConversion::kKeepNumbers,
-                                    ENUMERABLE_STRINGS, indices, &nof_indices, 
-                                    0, params);
+                                    ENUMERABLE_STRINGS, indices, &nof_indices);
     SortIndices(isolate, indices, nof_indices);
     for (uint32_t i = 0; i < nof_indices; i++) {
       RETURN_FAILURE_IF_NOT_SUCCESSFUL(keys->AddKey(indices->get(i)));
@@ -4694,14 +4670,13 @@ class SloppyArgumentsElementsAccessor
   static Handle<FixedArray> DirectCollectElementIndicesImpl(
       Isolate* isolate, Handle<JSObject> object,
       Handle<FixedArrayBase> backing_store, GetKeysConversion convert,
-      PropertyFilter filter, Handle<FixedArray> list, uint32_t* nof_indices, 
-      uint32_t insertion_index = 0,
-      const KeyIterationParams* params = KeyIterationParams::Default()) {
+      PropertyFilter filter, Handle<FixedArray> list, uint32_t* nof_indices,
+      uint32_t insertion_index = 0) {
     Handle<SloppyArgumentsElements> elements =
         Handle<SloppyArgumentsElements>::cast(backing_store);
-    uint32_t length = (uint32_t)params->PageSize(elements->length());
+    uint32_t length = elements->length();
 
-    for (uint32_t i = (uint32_t)params->KeyFirstIndex(); i < (uint32_t)params->KeyEndIndex((KeyIterationIndex)length); ++i) {
+    for (uint32_t i = 0; i < length; ++i) {
       if (elements->mapped_entries(i, kRelaxedLoad).IsTheHole(isolate))
         continue;
       if (convert == GetKeysConversion::kConvertToString) {
@@ -4716,7 +4691,7 @@ class SloppyArgumentsElementsAccessor
     Handle<FixedArray> store(elements->arguments(), isolate);
     return ArgumentsAccessor::DirectCollectElementIndicesImpl(
         isolate, object, store, convert, filter, list, nof_indices,
-        insertion_index, params);
+        insertion_index);
   }
 
   static Maybe<bool> IncludesValueImpl(Isolate* isolate,
@@ -5155,8 +5130,7 @@ class StringWrapperElementsAccessor
       KeyAccumulator* keys) {
     uint32_t length = GetString(*object).length();
     Factory* factory = keys->isolate()->factory();
-    auto* params = keys->key_indexing_params();
-    for (uint32_t i = (uint32_t)params->KeyFirstIndex(); i < (uint32_t)params->KeyEndIndex((KeyIterationIndex)length); i++) {
+    for (uint32_t i = 0; i < length; i++) {
       RETURN_FAILURE_IF_NOT_SUCCESSFUL(
           keys->AddKey(factory->NewNumberFromUint(i)));
     }

--- a/src/objects/elements.h
+++ b/src/objects/elements.h
@@ -94,13 +94,11 @@ class ElementsAccessor {
   virtual MaybeHandle<FixedArray> PrependElementIndices(
       Isolate* isolate, Handle<JSObject> object,
       Handle<FixedArrayBase> backing_store, Handle<FixedArray> keys,
-      GetKeysConversion convert, PropertyFilter filter = ALL_PROPERTIES,
-      const KeyIterationParams* params = KeyIterationParams::Default()) = 0;
+      GetKeysConversion convert, PropertyFilter filter = ALL_PROPERTIES) = 0;
 
   inline MaybeHandle<FixedArray> PrependElementIndices(
       Isolate* isolate, Handle<JSObject> object, Handle<FixedArray> keys,
-      GetKeysConversion convert, PropertyFilter filter = ALL_PROPERTIES,
-      const KeyIterationParams* params = KeyIterationParams::Default());
+      GetKeysConversion convert, PropertyFilter filter = ALL_PROPERTIES);
 
   V8_WARN_UNUSED_RESULT virtual ExceptionStatus AddElementsToKeyAccumulator(
       Handle<JSObject> receiver, KeyAccumulator* accumulator,

--- a/src/objects/hash-table-inl.h
+++ b/src/objects/hash-table-inl.h
@@ -94,10 +94,8 @@ int HashTableBase::Capacity() const {
   return Smi::cast(get(kCapacityIndex)).value();
 }
 
-InternalIndex::Range HashTableBase::IterateEntries(
-    const KeyIterationParams* params) const {
-  return InternalIndex::Range((size_t)params->KeyFirstIndex(),
-                              (size_t)params->KeyEndIndex(Capacity()));
+InternalIndex::Range HashTableBase::IterateEntries() const {
+  return InternalIndex::Range(Capacity());
 }
 
 void HashTableBase::ElementAdded() {

--- a/src/objects/hash-table.h
+++ b/src/objects/hash-table.h
@@ -78,8 +78,7 @@ class V8_EXPORT_PRIVATE HashTableBase : public NON_EXPORTED_BASE(FixedArray) {
   // Returns the capacity of the hash table.
   inline int Capacity() const;
 
-  inline InternalIndex::Range IterateEntries(
-      const KeyIterationParams* params = KeyIterationParams::Default()) const;
+  inline InternalIndex::Range IterateEntries() const;
 
   // ElementAdded should be called whenever an element is added to a
   // hash table.

--- a/src/objects/keys.cc
+++ b/src/objects/keys.cc
@@ -90,10 +90,9 @@ static Handle<FixedArray> CombineKeys(Isolate* isolate,
 MaybeHandle<FixedArray> KeyAccumulator::GetKeys(
     Isolate* isolate, Handle<JSReceiver> object, KeyCollectionMode mode,
     PropertyFilter filter, GetKeysConversion keys_conversion, bool is_for_in,
-    bool skip_indices,
-    const KeyIterationParams* params) {
+    bool skip_indices) {
   FastKeyAccumulator accumulator(isolate, object, mode, filter, is_for_in,
-                                 skip_indices, params);
+                                 skip_indices);
   return accumulator.GetKeys(keys_conversion);
 }
 
@@ -372,8 +371,7 @@ Handle<FixedArray> ReduceFixedArrayTo(Isolate* isolate,
 // Initializes and directly returns the enume cache. Users of this function
 // have to make sure to never directly leak the enum cache.
 Handle<FixedArray> GetFastEnumPropertyKeys(Isolate* isolate,
-                                           Handle<JSObject> object,
-                                           const KeyIterationParams* params = KeyIterationParams::Default()) {
+                                           Handle<JSObject> object) {
   Handle<Map> map(object->map(), isolate);
   Handle<FixedArray> keys(
       map->instance_descriptors(isolate).enum_cache().keys(), isolate);
@@ -381,9 +379,7 @@ Handle<FixedArray> GetFastEnumPropertyKeys(Isolate* isolate,
   // Check if the {map} has a valid enum length, which implies that it
   // must have a valid enum cache as well.
   int enum_length = map->EnumLength();
-
-  // Ignore cache in case of custom params.
-  if (enum_length != kInvalidEnumCacheSentinel && !*params) {
+  if (enum_length != kInvalidEnumCacheSentinel) {
     DCHECK(map->OnlyHasSimpleProperties());
     DCHECK_LE(enum_length, keys->length());
     DCHECK_EQ(enum_length, map->NumberOfEnumerableProperties());
@@ -396,8 +392,7 @@ Handle<FixedArray> GetFastEnumPropertyKeys(Isolate* isolate,
 
   // Check if there's already a shared enum cache on the {map}s
   // DescriptorArray with sufficient number of entries.
-  // Also: Ignore cache in case of custom params.
-  if (enum_length <= keys->length() && !*params) {
+  if (enum_length <= keys->length()) {
     if (map->OnlyHasSimpleProperties()) map->SetEnumLength(enum_length);
     isolate->counters()->enum_cache_hits()->Increment();
     return ReduceFixedArrayTo(isolate, keys, enum_length);
@@ -405,17 +400,13 @@ Handle<FixedArray> GetFastEnumPropertyKeys(Isolate* isolate,
 
   Handle<DescriptorArray> descriptors =
       Handle<DescriptorArray>(map->instance_descriptors(isolate), isolate);
-      
-  // Ignore cache in case of custom params.
-  if (!*params) {
-    isolate->counters()->enum_cache_misses()->Increment();
-  }
+  isolate->counters()->enum_cache_misses()->Increment();
 
   // Create the keys array.
   int index = 0;
   bool fields_only = true;
   keys = isolate->factory()->NewFixedArray(enum_length);
-  for (InternalIndex i : map->IterateOwnDescriptors(params)) {
+  for (InternalIndex i : map->IterateOwnDescriptors()) {
     DisallowGarbageCollection no_gc;
     PropertyDetails details = descriptors->GetDetails(i);
     if (details.IsDontEnum()) continue;
@@ -432,7 +423,7 @@ Handle<FixedArray> GetFastEnumPropertyKeys(Isolate* isolate,
   if (fields_only) {
     indices = isolate->factory()->NewFixedArray(enum_length);
     index = 0;
-    for (InternalIndex i : map->IterateOwnDescriptors(params)) {
+    for (InternalIndex i : map->IterateOwnDescriptors()) {
       DisallowGarbageCollection no_gc;
       PropertyDetails details = descriptors->GetDetails(i);
       if (details.IsDontEnum()) continue;
@@ -447,11 +438,8 @@ Handle<FixedArray> GetFastEnumPropertyKeys(Isolate* isolate,
     DCHECK_EQ(index, indices->length());
   }
 
-  // Ignore cache in case of custom params.
-  if (!*params) {
-    DescriptorArray::InitializeOrChangeEnumCache(descriptors, isolate, keys,
-                                                 indices);
-  }
+  DescriptorArray::InitializeOrChangeEnumCache(descriptors, isolate, keys,
+                                               indices);
   if (map->OnlyHasSimpleProperties()) map->SetEnumLength(enum_length);
 
   return keys;
@@ -461,15 +449,14 @@ template <bool fast_properties>
 MaybeHandle<FixedArray> GetOwnKeysWithElements(Isolate* isolate,
                                                Handle<JSObject> object,
                                                GetKeysConversion convert,
-                                               bool skip_indices,
-                                               const KeyIterationParams* params = KeyIterationParams::Default()) {
+                                               bool skip_indices) {
   Handle<FixedArray> keys;
   ElementsAccessor* accessor = object->GetElementsAccessor();
   if (fast_properties) {
-    keys = GetFastEnumPropertyKeys(isolate, object, params);
+    keys = GetFastEnumPropertyKeys(isolate, object);
   } else {
     // TODO(cbruni): preallocate big enough array to also hold elements.
-    keys = KeyAccumulator::GetOwnEnumPropertyKeys(isolate, object, params);
+    keys = KeyAccumulator::GetOwnEnumPropertyKeys(isolate, object);
   }
 
   MaybeHandle<FixedArray> result;
@@ -477,7 +464,7 @@ MaybeHandle<FixedArray> GetOwnKeysWithElements(Isolate* isolate,
     result = keys;
   } else {
     result = accessor->PrependElementIndices(isolate, object, keys, convert,
-                                             ONLY_ENUMERABLE, params);
+                                             ONLY_ENUMERABLE);
   }
 
   if (v8_flags.trace_for_in_enumerate) {
@@ -525,12 +512,10 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysFast(
   // Do not try to use the enum-cache for dict-mode objects.
   if (map.is_dictionary_map()) {
     return GetOwnKeysWithElements<false>(isolate_, object, keys_conversion,
-                                         skip_indices_, key_iteration_params_);
+                                         skip_indices_);
   }
   int enum_length = receiver_->map().EnumLength();
-
-  // Ignore cache in case of custom params.
-  if (enum_length == kInvalidEnumCacheSentinel && !*key_iteration_params_) {
+  if (enum_length == kInvalidEnumCacheSentinel) {
     Handle<FixedArray> keys;
     // Try initializing the enum cache and return own properties.
     if (GetOwnKeysWithUninitializedEnumCache().ToHandle(&keys)) {
@@ -546,7 +531,7 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysFast(
   // The properties-only case failed because there were probably elements on the
   // receiver.
   return GetOwnKeysWithElements<true>(isolate_, object, keys_conversion,
-                                      skip_indices_, key_iteration_params_);
+                                      skip_indices_);
 }
 
 MaybeHandle<FixedArray>
@@ -567,8 +552,7 @@ FastKeyAccumulator::GetOwnKeysWithUninitializedEnumCache() {
   }
   // We have no elements but possibly enumerable property keys, hence we can
   // directly initialize the enum cache.
-  Handle<FixedArray> keys =
-      GetFastEnumPropertyKeys(isolate_, object, key_iteration_params_);
+  Handle<FixedArray> keys = GetFastEnumPropertyKeys(isolate_, object);
   if (is_for_in_) return keys;
   // Do not leak the enum cache as it might end up as an elements backing store.
   return isolate_->factory()->CopyFixedArray(keys);
@@ -583,7 +567,6 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysSlow(
   accumulator.set_may_have_elements(may_have_elements_);
   accumulator.set_first_prototype_map(first_prototype_map_);
   accumulator.set_try_prototype_info_cache(try_prototype_info_cache_);
-  accumulator.set_key_indexing_params(key_iteration_params_);
 
   MAYBE_RETURN(accumulator.CollectKeys(receiver_, receiver_),
                MaybeHandle<FixedArray>());
@@ -598,19 +581,19 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysWithPrototypeInfoCache(
     if (receiver_->map().is_dictionary_map()) {
       maybe_own_keys = GetOwnKeysWithElements<false>(
           isolate_, Handle<JSObject>::cast(receiver_), keys_conversion,
-          skip_indices_, key_iteration_params_);
+          skip_indices_);
     } else {
       maybe_own_keys = GetOwnKeysWithElements<true>(
           isolate_, Handle<JSObject>::cast(receiver_), keys_conversion,
-          skip_indices_, key_iteration_params_);
+          skip_indices_);
     }
     ASSIGN_RETURN_ON_EXCEPTION(isolate_, own_keys, maybe_own_keys, FixedArray);
   } else {
     own_keys = KeyAccumulator::GetOwnEnumPropertyKeys(
-        isolate_, Handle<JSObject>::cast(receiver_), key_iteration_params_);
+        isolate_, Handle<JSObject>::cast(receiver_));
   }
   Handle<FixedArray> prototype_chain_keys;
-  if (has_prototype_info_cache_ && !*key_iteration_params_) {
+  if (has_prototype_info_cache_) {
     prototype_chain_keys =
         handle(FixedArray::cast(
                    PrototypeInfo::cast(first_prototype_map_->prototype_info())
@@ -625,7 +608,6 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysWithPrototypeInfoCache(
     accumulator.set_receiver(receiver_);
     accumulator.set_first_prototype_map(first_prototype_map_);
     accumulator.set_try_prototype_info_cache(try_prototype_info_cache_);
-    accumulator.set_key_indexing_params(key_iteration_params_);
     MAYBE_RETURN(accumulator.CollectKeys(first_prototype_, first_prototype_),
                  MaybeHandle<FixedArray>());
     prototype_chain_keys = accumulator.GetKeys(keys_conversion);
@@ -829,8 +811,7 @@ base::Optional<int> CollectOwnPropertyNamesInternal(
 template <typename Dictionary>
 void CommonCopyEnumKeysTo(Isolate* isolate, Handle<Dictionary> dictionary,
                           Handle<FixedArray> storage, KeyCollectionMode mode,
-                          KeyAccumulator* accumulator,
-                          const KeyIterationParams* params) {
+                          KeyAccumulator* accumulator) {
   DCHECK_IMPLIES(mode != KeyCollectionMode::kOwnOnly, accumulator != nullptr);
   int length = storage->length();
   int properties = 0;
@@ -867,7 +848,6 @@ void CommonCopyEnumKeysTo(Isolate* isolate, Handle<Dictionary> dictionary,
     }
     properties++;
     if (mode == KeyCollectionMode::kOwnOnly && properties == length) break;
-    if (*params && properties == length) break;
   }
 
   CHECK_EQ(length, properties);
@@ -879,12 +859,11 @@ void CommonCopyEnumKeysTo(Isolate* isolate, Handle<Dictionary> dictionary,
 template <typename Dictionary>
 void CopyEnumKeysTo(Isolate* isolate, Handle<Dictionary> dictionary,
                     Handle<FixedArray> storage, KeyCollectionMode mode,
-                    KeyAccumulator* accumulator,
-                    const KeyIterationParams* params) {
+                    KeyAccumulator* accumulator) {
   static_assert(!Dictionary::kIsOrderedDictionaryType);
 
   CommonCopyEnumKeysTo<Dictionary>(isolate, dictionary, storage, mode,
-                                   accumulator, params);
+                                   accumulator);
 
   int length = storage->length();
 
@@ -905,10 +884,9 @@ void CopyEnumKeysTo(Isolate* isolate, Handle<Dictionary> dictionary,
 template <>
 void CopyEnumKeysTo(Isolate* isolate, Handle<SwissNameDictionary> dictionary,
                     Handle<FixedArray> storage, KeyCollectionMode mode,
-                    KeyAccumulator* accumulator,
-                    const KeyIterationParams* params) {
+                    KeyAccumulator* accumulator) {
   CommonCopyEnumKeysTo<SwissNameDictionary>(isolate, dictionary, storage, mode,
-                                            accumulator, params);
+                                            accumulator);
 
   // No need to sort, as CommonCopyEnumKeysTo on OrderedNameDictionary
   // adds entries to |storage| in the dict's insertion order
@@ -921,39 +899,34 @@ Handle<FixedArray> GetOwnEnumPropertyDictionaryKeys(Isolate* isolate,
                                                     KeyCollectionMode mode,
                                                     KeyAccumulator* accumulator,
                                                     Handle<JSObject> object,
-                                                    T raw_dictionary,
-                                                    const KeyIterationParams* params = KeyIterationParams::Default()) {
+                                                    T raw_dictionary) {
   Handle<T> dictionary(raw_dictionary, isolate);
   if (dictionary->NumberOfElements() == 0) {
     return isolate->factory()->empty_fixed_array();
   }
-  int length = params->PageSize(dictionary->NumberOfEnumerableProperties());
+  int length = dictionary->NumberOfEnumerableProperties();
   Handle<FixedArray> storage = isolate->factory()->NewFixedArray(length);
-  CopyEnumKeysTo(isolate, dictionary, storage, mode, accumulator, params);
+  CopyEnumKeysTo(isolate, dictionary, storage, mode, accumulator);
   return storage;
 }
 
 // Collect the keys from |dictionary| into |keys|, in ascending chronological
 // order of property creation.
 template <typename Dictionary>
-ExceptionStatus CollectKeysFromDictionary(
-    Handle<Dictionary> dictionary, KeyAccumulator* keys,
-    const KeyIterationParams* params = KeyIterationParams::Default()) {
+ExceptionStatus CollectKeysFromDictionary(Handle<Dictionary> dictionary,
+                                          KeyAccumulator* keys) {
   Isolate* isolate = keys->isolate();
   ReadOnlyRoots roots(isolate);
-
-  auto numberOfElements = params->PageSize((KeyIterationIndex)dictionary->NumberOfElements());
-
   // TODO(jkummerow): Consider using a std::unique_ptr<InternalIndex[]> instead.
   Handle<FixedArray> array =
-      isolate->factory()->NewFixedArray(numberOfElements);
+      isolate->factory()->NewFixedArray(dictionary->NumberOfElements());
   int array_size = 0;
   PropertyFilter filter = keys->filter();
   // Handle enumerable strings in CopyEnumKeysTo.
   DCHECK_NE(keys->filter(), ENUMERABLE_STRINGS);
   {
     DisallowGarbageCollection no_gc;
-    for (InternalIndex i : dictionary->IterateEntries(params)) {
+    for (InternalIndex i : dictionary->IterateEntries()) {
       Object key;
       Dictionary raw_dictionary = *dictionary;
       if (!raw_dictionary.ToKey(roots, i, &key)) continue;
@@ -1017,8 +990,7 @@ Maybe<bool> KeyAccumulator::CollectOwnPropertyNames(Handle<JSReceiver> receiver,
   if (filter_ == ENUMERABLE_STRINGS) {
     Handle<FixedArray> enum_keys;
     if (object->HasFastProperties()) {
-      enum_keys = KeyAccumulator::GetOwnEnumPropertyKeys(isolate_, object,
-                                                         key_iteration_params_);
+      enum_keys = KeyAccumulator::GetOwnEnumPropertyKeys(isolate_, object);
       // If the number of properties equals the length of enumerable properties
       // we do not have to filter out non-enumerable ones
       Map map = object->map();
@@ -1038,16 +1010,13 @@ Maybe<bool> KeyAccumulator::CollectOwnPropertyNames(Handle<JSReceiver> receiver,
     } else if (object->IsJSGlobalObject()) {
       enum_keys = GetOwnEnumPropertyDictionaryKeys(
           isolate_, mode_, this, object,
-          JSGlobalObject::cast(*object).global_dictionary(kAcquireLoad),
-          key_iteration_params_);
+          JSGlobalObject::cast(*object).global_dictionary(kAcquireLoad));
     } else if (V8_ENABLE_SWISS_NAME_DICTIONARY_BOOL) {
       enum_keys = GetOwnEnumPropertyDictionaryKeys(
-          isolate_, mode_, this, object, object->property_dictionary_swiss(),
-          key_iteration_params_);
+          isolate_, mode_, this, object, object->property_dictionary_swiss());
     } else {
       enum_keys = GetOwnEnumPropertyDictionaryKeys(
-          isolate_, mode_, this, object, object->property_dictionary(),
-          key_iteration_params_);
+          isolate_, mode_, this, object, object->property_dictionary());
     }
     if (object->IsJSModuleNamespace()) {
       // Simulate [[GetOwnProperty]] for establishing enumerability, which
@@ -1080,16 +1049,13 @@ Maybe<bool> KeyAccumulator::CollectOwnPropertyNames(Handle<JSReceiver> receiver,
       RETURN_NOTHING_IF_NOT_SUCCESSFUL(CollectKeysFromDictionary(
           handle(JSGlobalObject::cast(*object).global_dictionary(kAcquireLoad),
                  isolate_),
-          this,
-          key_iteration_params_));
+          this));
     } else if (V8_ENABLE_SWISS_NAME_DICTIONARY_BOOL) {
       RETURN_NOTHING_IF_NOT_SUCCESSFUL(CollectKeysFromDictionary(
-          handle(object->property_dictionary_swiss(), isolate_), this,
-          key_iteration_params_));
+          handle(object->property_dictionary_swiss(), isolate_), this));
     } else {
       RETURN_NOTHING_IF_NOT_SUCCESSFUL(CollectKeysFromDictionary(
-          handle(object->property_dictionary(), isolate_), this,
-          key_iteration_params_));
+          handle(object->property_dictionary(), isolate_), this));
     }
   }
   // Add the property keys from the interceptor.
@@ -1187,22 +1153,21 @@ Maybe<bool> KeyAccumulator::CollectOwnKeys(Handle<JSReceiver> receiver,
 
 // static
 Handle<FixedArray> KeyAccumulator::GetOwnEnumPropertyKeys(
-    Isolate* isolate, Handle<JSObject> object,
-    const KeyIterationParams* params) {
+    Isolate* isolate, Handle<JSObject> object) {
   if (object->HasFastProperties()) {
     return GetFastEnumPropertyKeys(isolate, object);
   } else if (object->IsJSGlobalObject()) {
     return GetOwnEnumPropertyDictionaryKeys(
         isolate, KeyCollectionMode::kOwnOnly, nullptr, object,
-        JSGlobalObject::cast(*object).global_dictionary(kAcquireLoad), params);
+        JSGlobalObject::cast(*object).global_dictionary(kAcquireLoad));
   } else if (V8_ENABLE_SWISS_NAME_DICTIONARY_BOOL) {
     return GetOwnEnumPropertyDictionaryKeys(
         isolate, KeyCollectionMode::kOwnOnly, nullptr, object,
-        object->property_dictionary_swiss(), params);
+        object->property_dictionary_swiss());
   } else {
     return GetOwnEnumPropertyDictionaryKeys(
         isolate, KeyCollectionMode::kOwnOnly, nullptr, object,
-        object->property_dictionary(), params);
+        object->property_dictionary());
   }
 }
 

--- a/src/objects/keys.h
+++ b/src/objects/keys.h
@@ -59,8 +59,7 @@ class KeyAccumulator final {
       Isolate* isolate, Handle<JSReceiver> object, KeyCollectionMode mode,
       PropertyFilter filter,
       GetKeysConversion keys_conversion = GetKeysConversion::kKeepNumbers,
-      bool is_for_in = false, bool skip_indices = false,
-      const KeyIterationParams* params = KeyIterationParams::Default());
+      bool is_for_in = false, bool skip_indices = false);
 
   Handle<FixedArray> GetKeys(
       GetKeysConversion convert = GetKeysConversion::kKeepNumbers);
@@ -72,8 +71,7 @@ class KeyAccumulator final {
   // Does not throw for uninitialized exports in module namespace objects, so
   // this has to be checked separately.
   static Handle<FixedArray> GetOwnEnumPropertyKeys(Isolate* isolate,
-                                                   Handle<JSObject> object,
-                                                   const KeyIterationParams* key_iteration_params_ = KeyIterationParams::Default());
+                                                   Handle<JSObject> object);
 
   V8_WARN_UNUSED_RESULT ExceptionStatus
   AddKey(Object key, AddKeyConversion convert = DO_NOT_CONVERT);
@@ -88,11 +86,6 @@ class KeyAccumulator final {
   // The collection mode defines whether we collect the keys from the prototype
   // chain or only look at the receiver.
   KeyCollectionMode mode() { return mode_; }
-
-  const KeyIterationParams* key_indexing_params() const {
-    return key_iteration_params_;
-  }
-
   void set_skip_indices(bool value) { skip_indices_ = value; }
   // Shadowing keys are used to filter keys. This happens when non-enumerable
   // keys appear again on the prototype chain.
@@ -160,9 +153,6 @@ class KeyAccumulator final {
     last_non_empty_prototype_ = object;
   }
   void set_may_have_elements(bool value) { may_have_elements_ = value; }
-  void set_key_indexing_params(const KeyIterationParams* params) {
-    key_iteration_params_ = params;
-  }
 
   Isolate* isolate_;
   Handle<OrderedHashSet> keys_;
@@ -179,7 +169,6 @@ class KeyAccumulator final {
   bool skip_shadow_check_ = true;
   bool may_have_elements_ = true;
   bool try_prototype_info_cache_ = false;
-  const KeyIterationParams* key_iteration_params_ = KeyIterationParams::Default();
 
   friend FastKeyAccumulator;
 };
@@ -190,18 +179,17 @@ class KeyAccumulator final {
 // case where we do not have to walk the prototype chain.
 class FastKeyAccumulator {
  public:
-  FastKeyAccumulator(
-      Isolate* isolate, Handle<JSReceiver> receiver, KeyCollectionMode mode,
-      PropertyFilter filter, bool is_for_in = false, bool skip_indices = false,
-      const KeyIterationParams* params = KeyIterationParams::Default())
+  FastKeyAccumulator(Isolate* isolate, Handle<JSReceiver> receiver,
+                     KeyCollectionMode mode, PropertyFilter filter,
+                     bool is_for_in = false, bool skip_indices = false)
       : isolate_(isolate),
         receiver_(receiver),
         mode_(mode),
         filter_(filter),
         is_for_in_(is_for_in),
-        skip_indices_(skip_indices),
-        key_iteration_params_(params)
-  { Prepare(); }
+        skip_indices_(skip_indices) {
+    Prepare();
+  }
   FastKeyAccumulator(const FastKeyAccumulator&) = delete;
   FastKeyAccumulator& operator=(const FastKeyAccumulator&) = delete;
 
@@ -212,12 +200,10 @@ class FastKeyAccumulator {
   MaybeHandle<FixedArray> GetKeys(
       GetKeysConversion convert = GetKeysConversion::kKeepNumbers);
 
-  MaybeHandle<FixedArray> GetKeysSlow(
-      GetKeysConversion convert);
-
  private:
   void Prepare();
   MaybeHandle<FixedArray> GetKeysFast(GetKeysConversion convert);
+  MaybeHandle<FixedArray> GetKeysSlow(GetKeysConversion convert);
   MaybeHandle<FixedArray> GetKeysWithPrototypeInfoCache(
       GetKeysConversion convert);
 
@@ -241,8 +227,6 @@ class FastKeyAccumulator {
   bool has_prototype_info_cache_ = false;
   bool try_prototype_info_cache_ = false;
   bool only_own_has_simple_elements_ = false;
-  const KeyIterationParams* key_iteration_params_ =
-      KeyIterationParams::Default();
 };
 
 }  // namespace internal

--- a/src/objects/map-inl.h
+++ b/src/objects/map-inl.h
@@ -228,11 +228,8 @@ void Map::SetNumberOfOwnDescriptors(int number) {
       Bits3::NumberOfOwnDescriptorsBits::update(bit_field3(), number));
 }
 
-InternalIndex::Range Map::IterateOwnDescriptors(
-    const KeyIterationParams* params) const {
-  return InternalIndex::Range(
-      (size_t)params->KeyFirstIndex(),
-      (size_t)params->KeyEndIndex(NumberOfOwnDescriptors()));
+InternalIndex::Range Map::IterateOwnDescriptors() const {
+  return InternalIndex::Range(NumberOfOwnDescriptors());
 }
 
 int Map::EnumLength() const {

--- a/src/objects/map.h
+++ b/src/objects/map.h
@@ -637,8 +637,7 @@ class Map : public TorqueGeneratedMap<Map, HeapObject> {
 
   inline int NumberOfOwnDescriptors() const;
   inline void SetNumberOfOwnDescriptors(int number);
-  inline InternalIndex::Range IterateOwnDescriptors(
-      const KeyIterationParams* params = KeyIterationParams::Default()) const;
+  inline InternalIndex::Range IterateOwnDescriptors() const;
 
   inline Cell RetrieveDescriptorsPointer();
 

--- a/src/objects/ordered-hash-table.h
+++ b/src/objects/ordered-hash-table.h
@@ -113,10 +113,8 @@ class OrderedHashTable : public FixedArray {
     return Smi::ToInt(get(NumberOfBucketsIndex()));
   }
 
-  InternalIndex::Range IterateEntries(
-      const KeyIterationParams* params = KeyIterationParams::Default()) {
-    return InternalIndex::Range(params->KeyFirstIndex(),
-                                params->KeyEndIndex(UsedCapacity()));
+  InternalIndex::Range IterateEntries() {
+    return InternalIndex::Range(UsedCapacity());
   }
 
   // use IsKey to check if this is a deleted entry.
@@ -476,10 +474,8 @@ class SmallOrderedHashTable : public HeapObject {
 
   V8_INLINE Object KeyAt(InternalIndex entry) const;
 
-  InternalIndex::Range IterateEntries(
-      const KeyIterationParams* params = KeyIterationParams::Default()) {
-    return InternalIndex::Range(params->KeyFirstIndex(),
-                                params->KeyEndIndex(UsedCapacity()));
+  InternalIndex::Range IterateEntries() {
+    return InternalIndex::Range(UsedCapacity());
   }
 
   DECL_VERIFIER(SmallOrderedHashTable)

--- a/src/objects/swiss-name-dictionary-inl.h
+++ b/src/objects/swiss-name-dictionary-inl.h
@@ -618,13 +618,11 @@ InternalIndex SwissNameDictionary::IndexIterator::operator*() {
 }
 
 SwissNameDictionary::IndexIterable::IndexIterable(
-    Handle<SwissNameDictionary> dict, const KeyIterationParams* params)
-    : dict_{dict},
-      first_(params->KeyFirstIndex()),
-      last_(params->KeyEndIndex(dict_->UsedCapacity())) {}
+    Handle<SwissNameDictionary> dict)
+    : dict_{dict} {}
 
 SwissNameDictionary::IndexIterator SwissNameDictionary::IndexIterable::begin() {
-  return IndexIterator(dict_, first_);
+  return IndexIterator(dict_, 0);
 }
 
 SwissNameDictionary::IndexIterator SwissNameDictionary::IndexIterable::end() {
@@ -632,12 +630,12 @@ SwissNameDictionary::IndexIterator SwissNameDictionary::IndexIterable::end() {
     return IndexIterator(dict_, 0);
   } else {
     DCHECK(!dict_.is_null());
-    return IndexIterator(dict_, last_);
+    return IndexIterator(dict_, dict_->UsedCapacity());
   }
 }
 
-SwissNameDictionary::IndexIterable SwissNameDictionary::IterateEntriesOrdered(
-    const KeyIterationParams* params) {
+SwissNameDictionary::IndexIterable
+SwissNameDictionary::IterateEntriesOrdered() {
   // If we are supposed to iterate the empty dictionary (which is non-writable)
   // and pointer compression with a per-Isolate cage is disabled, we have no
   // simple way to get the isolate, which we would need to create a handle.
@@ -650,12 +648,11 @@ SwissNameDictionary::IndexIterable SwissNameDictionary::IterateEntriesOrdered(
   Isolate* isolate;
   GetIsolateFromHeapObject(*this, &isolate);
   DCHECK_NE(isolate, nullptr);
-  return IndexIterable(handle(*this, isolate), params);
+  return IndexIterable(handle(*this, isolate));
 }
 
-SwissNameDictionary::IndexIterable SwissNameDictionary::IterateEntries(
-    const KeyIterationParams* params) {
-  return IterateEntriesOrdered(params);
+SwissNameDictionary::IndexIterable SwissNameDictionary::IterateEntries() {
+  return IterateEntriesOrdered();
 }
 
 void SwissNameDictionary::SetHash(int32_t hash) {

--- a/src/objects/swiss-name-dictionary.h
+++ b/src/objects/swiss-name-dictionary.h
@@ -163,8 +163,7 @@ class V8_EXPORT_PRIVATE SwissNameDictionary : public HeapObject {
 
   class IndexIterable {
    public:
-    inline explicit IndexIterable(Handle<SwissNameDictionary> dict,
-                                  const KeyIterationParams* params = 0);
+    inline explicit IndexIterable(Handle<SwissNameDictionary> dict);
 
     inline IndexIterator begin();
     inline IndexIterator end();
@@ -173,17 +172,10 @@ class V8_EXPORT_PRIVATE SwissNameDictionary : public HeapObject {
     // This may be an empty handle, but only if the capacity of the table is
     // 0 and pointer compression is disabled.
     Handle<SwissNameDictionary> dict_;
-
-    // Start index constraint (if given).
-    int first_;
-    // End index constraint (if given).
-    int last_;
   };
 
-  inline IndexIterable IterateEntriesOrdered(
-      const KeyIterationParams* params = KeyIterationParams::Default());
-  inline IndexIterable IterateEntries(
-      const KeyIterationParams* params = KeyIterationParams::Default());
+  inline IndexIterable IterateEntriesOrdered();
+  inline IndexIterable IterateEntries();
 
   // For the given enumeration index, returns the entry (= bucket of the Swiss
   // Table) containing the data for the mapping with that enumeration index.


### PR DESCRIPTION
Reverts replayio/chromium-v8#103.
* Caused command crashes.
* Discussed [here](https://linear.app/replay/issue/RUN-1315#comment-26f96699).
* Will fix, and test with an eye on command crashes before sending it back in.