### PR TITLE
RUN-1478: stop trying to access unsanctioned getters

### DIFF
--- a/src/inspector/value-mirror.cc
+++ b/src/inspector/value-mirror.cc
@@ -1313,9 +1313,24 @@ std::unique_ptr<ValueMirror> createNativeSetter(v8::Local<v8::Context> context,
   return ValueMirror::create(context, function);
 }
 
+static const char* allowed_getters[] = {"type", "fromElement", "target",
+                                        "isTrusted"};
+
 bool doesAttributeHaveObservableSideEffectOnGet(v8::Local<v8::Context> context,
                                                 v8::Local<v8::Object> object,
                                                 v8::Local<v8::Name> name) {
+  if (v8::recordreplay::HasDivergedFromRecording()) {
+    // Disallow most getters during Pause, since they cause unwanted crashes.
+    // -> https://linear.app/replay/issue/RUN-1478
+    for (auto allowed : allowed_getters) {
+      v8::String::Utf8Value nameRaw(context->GetIsolate(), name.As<v8::String>());
+      if (!strcmp(allowed, *nameRaw)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   // TODO(dgozman): we should remove this, annotate more embedder properties as
   // side-effect free, and call all getters which do not produce side effects.
   if (!name->IsString()) return false;


### PR DESCRIPTION
* Warning: This is currently the released V8 HEAD.
* I rolled these back accidentally as part of the `RUN-1315` commit that caused more command crashes. But this change actually prevents crashes. Bringing it back in.
* Discussed [here](https://discord.com/channels/779097926135054346/798654183115980840/threads/1084143544450687095).
* Tests passed:
  * [livetests](https://github.com/replayio/build-test-dashboard/blob/master/270993b0-7294-47c1-8947-657e2027cc1f): 28 vs 2
  * [playwright tests](https://github.com/replayio/build-test-dashboard/blob/master/4a559703-0128-4fda-89ce-8227d4b3f878) seem to be buggy 🤷‍♀️