### PR TITLE
RUN-1609: enable events by default in the chromium runtime (v8)

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11129,15 +11129,14 @@ static std::set<std::string>* gRecordReplayKnownFeatures = new std::set<std::str
   // Send certain event information to render thread.
   "browser-event",
 
-  // Record/replay events are turned off by default (for now) (RUN-1251)
-  "disable-collect-events"
+  // Whether to collect generic event data (RUN-1609)
+  "collect-events"
 });
 
 // The set of all experimental flags pertaining to features we are currently developing.
 // Ideally, this should always be a short list.
 // NOTE: These should generally be "double-negative" flags which we need to convert to positive in the near future.
 static const char* gExperimentalFlags[] = {
-  "disable-collect-events"
 };
 
 static inline void RecordReplayCheckKnownFeature(const char* feature) {

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11129,7 +11129,7 @@ static std::set<std::string>* gRecordReplayKnownFeatures = new std::set<std::str
   // Send certain event information to render thread.
   "browser-event",
 
-  // Whether to collect generic event data (RUN-1609)
+  // Collect generic event data (RUN-1609)
   "collect-events"
 });
 


### PR DESCRIPTION
* Paired w/ https://github.com/replayio/chromium/pull/489
* https://linear.app/replay/issue/RUN-1609/flip-the-switch-in-the-chromium-runtime-to-enable-events-everywhere-%F0%9F%98%B2