### PR TITLE
Add back `MicrotaskQueue::PerformCheckpoint` Assert

### DIFF
--- a/src/execution/microtask-queue.h
+++ b/src/execution/microtask-queue.h
@@ -45,7 +45,7 @@ class V8_EXPORT_PRIVATE MicrotaskQueue final : public v8::MicrotaskQueue {
                         void* data) override;
   void PerformCheckpoint(v8::Isolate* isolate) override {
 
-    if (v8::recordreplay::IsRecordingOrReplaying() && v8::recordreplay::AreEventsDisallowed())
+    if (v8::recordreplay::IsRecordingOrReplaying() && !v8::recordreplay::AreEventsDisallowed())
       v8::recordreplay::Assert(
           "[RUN-1593] MicrotaskQueue::PerformCheckpoint %d",
           ShouldPerfomCheckpoint());

--- a/src/execution/microtask-queue.h
+++ b/src/execution/microtask-queue.h
@@ -44,6 +44,12 @@ class V8_EXPORT_PRIVATE MicrotaskQueue final : public v8::MicrotaskQueue {
   void EnqueueMicrotask(v8::Isolate* isolate, v8::MicrotaskCallback callback,
                         void* data) override;
   void PerformCheckpoint(v8::Isolate* isolate) override {
+
+    if (v8::recordreplay::IsRecordingOrReplaying() && v8::recordreplay::AreEventsDisallowed())
+      v8::recordreplay::Assert(
+          "[RUN-1593] MicrotaskQueue::PerformCheckpoint %d",
+          ShouldPerfomCheckpoint());
+
     if (!ShouldPerfomCheckpoint()) return;
     PerformCheckpointInternal(isolate);
   }


### PR DESCRIPTION
Paired w/ https://github.com/replayio/chromium/pull/490

* I removed this `Assert` [here](https://github.com/replayio/chromium-v8/pull/117/files).
* But it ended up being very useful!
* https://linear.app/replay/issue/RUN-1593/divergence-in-performmicrotaskcheckpoint