### PR TITLE
RUN-1335: add `clear-idle-callbacks` feature flag

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11130,7 +11130,10 @@ static std::set<std::string>* gRecordReplayKnownFeatures = new std::set<std::str
   "browser-event",
 
   // Collect generic event data (RUN-1609)
-  "collect-events"
+  "collect-events",
+
+  // Clear idle callbacks on |Document::Shutdown| (RUN-1335)
+  "clear-idle-callbacks",
 });
 
 // The set of all experimental flags pertaining to features we are currently developing.


### PR DESCRIPTION
Paired w/ https://github.com/replayio/chromium/pull/519
* https://linear.app/replay/issue/RUN-1335/mismatch-in-singlethreadidletaskrunnerruntask#comment-6a4cbb7b