### PR TITLE
Add execution context ID to CDP call frames

### DIFF
--- a/include/js_protocol.pdl
+++ b/include/js_protocol.pdl
@@ -108,7 +108,7 @@ domain Debugger
       # sent `Debugger.scriptParsed` event.
       deprecated string url
       # Execution context associated with this frame.
-      ExecutionContextId contextId
+      Runtime.ExecutionContextId contextId
       # Scope chain for this call frame.
       array of Scope scopeChain
       # `this` object for this call frame.

--- a/include/js_protocol.pdl
+++ b/include/js_protocol.pdl
@@ -107,6 +107,8 @@ domain Debugger
       # Deprecated in favor of using the `location.scriptId` to resolve the URL via a previously
       # sent `Debugger.scriptParsed` event.
       deprecated string url
+      # Execution context associated with this frame.
+      ExecutionContextId contextId
       # Scope chain for this call frame.
       array of Scope scopeChain
       # `this` object for this call frame.

--- a/src/inspector/v8-debugger-agent-impl.cc
+++ b/src/inspector/v8-debugger-agent-impl.cc
@@ -1742,6 +1742,7 @@ Response V8DebuggerAgentImpl::currentCallFrames(
                          m_isolate, iterator->GetFunctionDebugName()))
                      .setLocation(std::move(location))
                      .setUrl(String16())
+                     .setContextId(contextId)
                      .setScopeChain(std::move(scopes))
                      .setThis(std::move(protocolReceiver))
                      .setCanBeRestarted(iterator->CanBeRestarted())


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-1799