### PR TITLE
RUN-1908: Don't crash when opening CDT

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11620,9 +11620,9 @@ extern "C" DLLEXPORT void* V8RecordReplayIdPointer(int id) {
 }
 
 extern "C" DLLEXPORT uint64_t V8RecordReplayNewBookmark() {
-  Isolate* isolate = Isolate::Current();
+  internal::Isolate* isolate = internal::Isolate::Current();
   if (internal::gRecordReplayHasCheckpoint &&
-      isolate && AllowJavascriptExecution::IsAllowed(isolate)) {
+      isolate && internal::AllowJavascriptExecution::IsAllowed(isolate)) {
     // Our bookmark code invokes JS. Make sure that that is possible and allowed.
     // https://linear.app/replay/issue/RUN-1908/fix-devtools-crashes
     return gRecordReplayNewBookmark();

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11620,7 +11620,11 @@ extern "C" DLLEXPORT void* V8RecordReplayIdPointer(int id) {
 }
 
 extern "C" DLLEXPORT uint64_t V8RecordReplayNewBookmark() {
-  if (internal::gRecordReplayHasCheckpoint) {
+  Isolate* isolate = Isolate::Current();
+  if (internal::gRecordReplayHasCheckpoint &&
+      isolate && AllowJavascriptExecution::IsAllowed(isolate)) {
+    // Our bookmark code invokes JS. Make sure that that is possible and allowed.
+    // https://linear.app/replay/issue/RUN-1908/fix-devtools-crashes
     return gRecordReplayNewBookmark();
   }
   return 0;

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -2793,7 +2793,13 @@ bool Debug::PerformSideEffectCheck(Handle<JSFunction> function,
                          &is_compiled_scope)) {
     return false;
   }
-  DCHECK(is_compiled_scope.is_compiled());
+  if (recordreplay::IsReplaying() && recordreplay::AreEventsDisallowed()) {
+    // TODO: IsInReplayCode (RUN-1502)
+    // Always allow Replay code.
+    // https://linear.app/replay/issue/RUN-1908/fix-devtools-crashes
+    return true;
+  }
+  CHECK(is_compiled_scope.is_compiled());
   Handle<SharedFunctionInfo> shared(function->shared(), isolate_);
   Handle<DebugInfo> debug_info = GetOrCreateDebugInfo(shared);
   DebugInfo::SideEffectState side_effect_state =


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/647
* https://linear.app/replay/issue/RUN-1908/devtools-crashes-collect-garbage-button