### PR TITLE
RUN-1920: Workaround for "Missing deoptimization information for OptimizedFrame::Summarize"

### DIFF
--- a/src/debug/debug-stack-trace-iterator.cc
+++ b/src/debug/debug-stack-trace-iterator.cc
@@ -219,13 +219,12 @@ void DebugStackTraceIterator::UpdateInlineFrameIndexAndResumableFnOnStack() {
   iterator_.frame()->Summarize(&frames);
   inlined_frame_index_ = static_cast<int>(frames.size());
 
+  if (resumable_fn_on_stack_) return;
+
   if (recordreplay::IsRecordingOrReplaying() && !frames.size()) {
-    // Replay workaround: Summarize sometimes won't work for an unknown reason.
-    // https://linear.app/replay/issue/RUN-1920
+    recordreplay::Warning("[RUN-1920] Frame summary was empty.");
     return;
   }
-
-  if (resumable_fn_on_stack_) return;
 
   StackFrame* frame = iterator_.frame();
   if (!frame->is_java_script()) return;

--- a/src/debug/debug-stack-trace-iterator.cc
+++ b/src/debug/debug-stack-trace-iterator.cc
@@ -219,6 +219,12 @@ void DebugStackTraceIterator::UpdateInlineFrameIndexAndResumableFnOnStack() {
   iterator_.frame()->Summarize(&frames);
   inlined_frame_index_ = static_cast<int>(frames.size());
 
+  if (recordreplay::IsRecordingOrReplaying() && !frames.size()) {
+    // Replay workaround: Summarize sometimes won't work for an unknown reason.
+    // https://linear.app/replay/issue/RUN-1920
+    return;
+  }
+
   if (resumable_fn_on_stack_) return;
 
   StackFrame* frame = iterator_.frame();

--- a/src/execution/frames.cc
+++ b/src/execution/frames.cc
@@ -2194,9 +2194,10 @@ void OptimizedFrame::Summarize(std::vector<FrameSummary>* frames) const {
 
     CHECK(data.is_null());
 
-    // Replay workaround: let failure be no-op instead of crash.
-    // https://linear.app/replay/issue/RUN-1920
     if (recordreplay::IsRecordingOrReplaying()) {
+      // Replay workaround: Sometimes, DeoptimizationData could not be found for an unknown reason.
+      // → Let this be a no-op instead of a crash.
+      recordreplay::Warning("[RUN-1920] Missing deoptimization information for OptimizedFrame::Summarize.");
       return;
     }
     FATAL("Missing deoptimization information for OptimizedFrame::Summarize.");

--- a/src/execution/frames.cc
+++ b/src/execution/frames.cc
@@ -2193,6 +2193,12 @@ void OptimizedFrame::Summarize(std::vector<FrameSummary>* frames) const {
     }
 
     CHECK(data.is_null());
+
+    // Replay workaround: let failure be no-op instead of crash.
+    // https://linear.app/replay/issue/RUN-1920
+    if (recordreplay::IsRecordingOrReplaying()) {
+      return;
+    }
     FATAL("Missing deoptimization information for OptimizedFrame::Summarize.");
   }
 


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/649
* https://linear.app/replay/issue/RUN-1920#comment-192befe2