### PR TITLE
RUN-1832 + RUN-1190: Add `objectGroup` to `getPendingException` and make `exception` optional

### DIFF
--- a/include/js_protocol.pdl
+++ b/include/js_protocol.pdl
@@ -567,6 +567,8 @@ domain Debugger
       optional integer maxFrames
       # Don't generate scopes or "this" object for returned frames.
       optional boolean noContents
+      # Symbolic group name that can be used to release multiple objects.
+      optional string objectGroup
     returns
       array of CallFrame callFrames
 

--- a/include/js_protocol.pdl
+++ b/include/js_protocol.pdl
@@ -575,9 +575,11 @@ domain Debugger
       optional Location location
 
   command getPendingException
+    parameters
+      # Symbolic group name that can be used to release multiple objects.
+      optional string objectGroup
     returns
       optional Runtime.RemoteObject exception
-      optional string objectGroup
 
   # Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria.
   event paused

--- a/include/js_protocol.pdl
+++ b/include/js_protocol.pdl
@@ -576,7 +576,8 @@ domain Debugger
 
   command getPendingException
     returns
-      Runtime.RemoteObject exception
+      optional Runtime.RemoteObject exception
+      optional string objectGroup
 
   # Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria.
   event paused

--- a/src/inspector/v8-debugger-agent-impl.cc
+++ b/src/inspector/v8-debugger-agent-impl.cc
@@ -1662,7 +1662,7 @@ Response V8DebuggerAgentImpl::getTopFrameLocation(Maybe<protocol::Debugger::Loca
 extern "C" void V8RecordReplayGetCurrentException(v8::MaybeLocal<v8::Value>* exception);
 
 Response V8DebuggerAgentImpl::getPendingException(
-    Maybe<StringView> objectGroup, Maybe<RemoteObject>* out_exception) {
+    Maybe<String16> objectGroup, Maybe<RemoteObject>* out_exception) {
   v8::MaybeLocal<v8::Value> maybe_exception;
   V8RecordReplayGetCurrentException(&maybe_exception);
 
@@ -1670,7 +1670,7 @@ Response V8DebuggerAgentImpl::getPendingException(
     v8::Local<v8::Context> context = m_isolate->GetCurrentContext();
     v8::Local<v8::Value> exception = maybe_exception.ToLocalChecked();
     std::unique_ptr<RemoteObject> obj =
-        m_session->wrapObject(context, exception, String16(objectGroup), false);
+        m_session->wrapObject(context, exception, objectGroup.fromMaybe(""), false);
 
     *out_exception = std::move(obj);
   }

--- a/src/inspector/v8-debugger-agent-impl.cc
+++ b/src/inspector/v8-debugger-agent-impl.cc
@@ -1662,7 +1662,7 @@ Response V8DebuggerAgentImpl::getTopFrameLocation(Maybe<protocol::Debugger::Loca
 extern "C" void V8RecordReplayGetCurrentException(v8::MaybeLocal<v8::Value>* exception);
 
 Response V8DebuggerAgentImpl::getPendingException(
-  Maybe<RemoteObject>* out_exception, Maybe<StringView> objectGroup) {
+    Maybe<StringView> objectGroup, Maybe<RemoteObject>* out_exception) {
   v8::MaybeLocal<v8::Value> maybe_exception;
   V8RecordReplayGetCurrentException(&maybe_exception);
 

--- a/src/inspector/v8-debugger-agent-impl.cc
+++ b/src/inspector/v8-debugger-agent-impl.cc
@@ -279,6 +279,7 @@ String16 scopeType(v8::debug::ScopeIterator::ScopeType type) {
 
 Response buildScopes(v8::Isolate* isolate, v8::debug::ScopeIterator* iterator,
                      InjectedScript* injectedScript,
+                     const String16& objectGroup,
                      std::unique_ptr<Array<Scope>>* scopes) {
   *scopes = std::make_unique<Array<Scope>>();
   if (!injectedScript) return Response::Success();
@@ -289,7 +290,7 @@ Response buildScopes(v8::Isolate* isolate, v8::debug::ScopeIterator* iterator,
   for (; !iterator->Done(); iterator->Advance()) {
     std::unique_ptr<RemoteObject> object;
     Response result =
-        injectedScript->wrapObject(iterator->GetObject(), kBacktraceObjectGroup,
+        injectedScript->wrapObject(iterator->GetObject(), objectGroup,
                                    WrapMode::kNoPreview, &object);
     if (!result.IsSuccess()) return result;
 
@@ -1632,8 +1633,10 @@ Response V8DebuggerAgentImpl::setBlackboxedRanges(
 
 Response V8DebuggerAgentImpl::getCallFrames(
     Maybe<int> maxFrames, Maybe<bool> noContents,
+    Maybe<String16> objectGroup,
     std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>* out_callFrames) {
-  return currentCallFrames(std::move(maxFrames), std::move(noContents), out_callFrames);
+  return currentCallFrames(std::move(maxFrames), std::move(noContents),
+                           std::move(objectGroup), out_callFrames);
 }
 
 Response V8DebuggerAgentImpl::getTopFrameLocation(Maybe<protocol::Debugger::Location>* out_location) {
@@ -1680,6 +1683,7 @@ Response V8DebuggerAgentImpl::getPendingException(
 
 Response V8DebuggerAgentImpl::currentCallFrames(
     Maybe<int> maxFrames, Maybe<bool> noContentsRaw,
+    Maybe<String16> objectGroup,
     std::unique_ptr<Array<CallFrame>>* result) {
   if (!isPaused()) {
     *result = std::make_unique<Array<CallFrame>>();
@@ -1708,7 +1712,7 @@ Response V8DebuggerAgentImpl::currentCallFrames(
       scopes = std::make_unique<Array<Scope>>();
     } else {
       auto scopeIterator = iterator->GetScopeIterator();
-      res = buildScopes(m_isolate, scopeIterator.get(), injectedScript, &scopes);
+      res = buildScopes(m_isolate, scopeIterator.get(), injectedScript, objectGroup.fromMaybe(kBacktraceObjectGroup), &scopes);
       if (!res.IsSuccess()) return res;
     }
 
@@ -1717,7 +1721,7 @@ Response V8DebuggerAgentImpl::currentCallFrames(
       v8::Local<v8::Value> receiver;
       if (iterator->GetReceiver().ToLocal(&receiver)) {
         res =
-            injectedScript->wrapObject(receiver, kBacktraceObjectGroup,
+            injectedScript->wrapObject(receiver, objectGroup.fromMaybe(kBacktraceObjectGroup),
                                        WrapMode::kNoPreview, &protocolReceiver);
         if (!res.IsSuccess()) return res;
       }
@@ -1762,7 +1766,7 @@ Response V8DebuggerAgentImpl::currentCallFrames(
     v8::Local<v8::Value> returnValue = iterator->GetReturnValue();
     if (!returnValue.IsEmpty() && injectedScript) {
       std::unique_ptr<RemoteObject> value;
-      res = injectedScript->wrapObject(returnValue, kBacktraceObjectGroup,
+      res = injectedScript->wrapObject(returnValue, objectGroup.fromMaybe(kBacktraceObjectGroup),
                                        WrapMode::kNoPreview, &value);
       if (!res.IsSuccess()) return res;
       frame->setReturnValue(std::move(value));
@@ -2011,7 +2015,7 @@ void V8DebuggerAgentImpl::didPauseOnInstrumentation(
   std::unique_ptr<protocol::DictionaryValue> breakAuxData;
 
   std::unique_ptr<Array<CallFrame>> protocolCallFrames;
-  Response response = currentCallFrames(Maybe<int>(), Maybe<bool>(), &protocolCallFrames);
+  Response response = currentCallFrames(Maybe<int>(), Maybe<bool>(), Maybe<String16>(), &protocolCallFrames);
   if (!response.IsSuccess())
     protocolCallFrames = std::make_unique<Array<CallFrame>>();
 
@@ -2141,7 +2145,7 @@ void V8DebuggerAgentImpl::didPause(
   }
 
   std::unique_ptr<Array<CallFrame>> protocolCallFrames;
-  Response response = currentCallFrames(Maybe<int>(), Maybe<bool>(), &protocolCallFrames);
+  Response response = currentCallFrames(Maybe<int>(), Maybe<bool>(), Maybe<String16>(), &protocolCallFrames);
   if (!response.IsSuccess())
     protocolCallFrames = std::make_unique<Array<CallFrame>>();
 

--- a/src/inspector/v8-debugger-agent-impl.h
+++ b/src/inspector/v8-debugger-agent-impl.h
@@ -151,8 +151,8 @@ class V8DebuggerAgentImpl : public protocol::Debugger::Backend {
       Maybe<int> maxFrames, Maybe<bool> noContents,
       std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>* out_callFrames) override;
   Response getTopFrameLocation(Maybe<protocol::Debugger::Location>* out_location) override;
-  DispatchResponse getPendingException(
-      Maybe<String> objectGroup,
+  Response getPendingException(
+      Maybe<String16> objectGroup,
       Maybe<protocol::Runtime::RemoteObject>* out_exception) override;
 
   bool enabled() const { return m_enabled; }

--- a/src/inspector/v8-debugger-agent-impl.h
+++ b/src/inspector/v8-debugger-agent-impl.h
@@ -149,6 +149,7 @@ class V8DebuggerAgentImpl : public protocol::Debugger::Backend {
           positions) override;
   Response getCallFrames(
       Maybe<int> maxFrames, Maybe<bool> noContents,
+      Maybe<String16> objectGroup,
       std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>* out_callFrames) override;
   Response getTopFrameLocation(Maybe<protocol::Debugger::Location>* out_location) override;
   Response getPendingException(
@@ -194,6 +195,7 @@ class V8DebuggerAgentImpl : public protocol::Debugger::Backend {
 
   Response currentCallFrames(
       Maybe<int> maxFrames, Maybe<bool> noContents,
+      Maybe<String16> objectGroup,
       std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>*);
   std::unique_ptr<protocol::Runtime::RemoteObject> wrapObject(int contextId,
                                                               v8::Local<v8::Value> val);

--- a/src/inspector/v8-debugger-agent-impl.h
+++ b/src/inspector/v8-debugger-agent-impl.h
@@ -152,7 +152,7 @@ class V8DebuggerAgentImpl : public protocol::Debugger::Backend {
       std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>* out_callFrames) override;
   Response getTopFrameLocation(Maybe<protocol::Debugger::Location>* out_location) override;
   Response getPendingException(
-      std::unique_ptr<protocol::Runtime::RemoteObject>* out_exception) override;
+      Maybe<protocol::Runtime::RemoteObject>* out_exception) override;
 
   bool enabled() const { return m_enabled; }
 

--- a/src/inspector/v8-debugger-agent-impl.h
+++ b/src/inspector/v8-debugger-agent-impl.h
@@ -151,7 +151,8 @@ class V8DebuggerAgentImpl : public protocol::Debugger::Backend {
       Maybe<int> maxFrames, Maybe<bool> noContents,
       std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>* out_callFrames) override;
   Response getTopFrameLocation(Maybe<protocol::Debugger::Location>* out_location) override;
-  Response getPendingException(
+  DispatchResponse getPendingException(
+      Maybe<String> objectGroup,
       Maybe<protocol::Runtime::RemoteObject>* out_exception) override;
 
   bool enabled() const { return m_enabled; }


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/663
* main fix: https://linear.app/replay/issue/RUN-1832#comment-95230d9f
* sneaky fix: optional `getPendingException` - https://linear.app/replay/issue/RUN-1190/fix-our-custom-v8-debuggergetpendingexception-to-mark-the-exception-as
* Tests passing ✔