### PR TITLE
AutoDisallowEvents for `SweeperImpl::Start`

### DIFF
--- a/src/heap/cppgc/sweeper.cc
+++ b/src/heap/cppgc/sweeper.cc
@@ -775,6 +775,7 @@ class Sweeper::SweeperImpl final {
   ~SweeperImpl() { CancelSweepers(); }
 
   void Start(SweepingConfig config, cppgc::Platform* platform) {
+    v8::recordreplay::AutoDisallowEvents disallow("SweeperImpl::Start");
     StatsCollector::EnabledScope stats_scope(stats_collector_,
                                              StatsCollector::kAtomicSweep);
     is_in_progress_ = true;


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/670
* https://linear.app/replay/issue/RUN-1974/mismatch-in-sweepersweeperimplstart