### PR TITLE
RUN-2022: Fix JS exception regression

### DIFF
--- a/src/base/logging.cc
+++ b/src/base/logging.cc
@@ -155,7 +155,7 @@ void V8_Fatal(const char* format, ...) {
 #endif
 
   {
-    char str[4192];
+    char str[4096];
     va_list arguments;
     va_start(arguments, format);
     vsnprintf(str, sizeof(str), format, arguments);

--- a/src/base/logging.cc
+++ b/src/base/logging.cc
@@ -155,7 +155,7 @@ void V8_Fatal(const char* format, ...) {
 #endif
 
   {
-    char str[1024];
+    char str[4192];
     va_list arguments;
     va_start(arguments, format);
     vsnprintf(str, sizeof(str), format, arguments);

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3807,11 +3807,7 @@ char* CommandCallback(const char* command, const char* params) {
       // If we get back an object from the call with a "is_error" property on it, set to true,
       // then our command experienced an error.  Report it to the log (in such a way as it
       // can be recovered by our error reporting), and then crash.
-
-      // TODO: Replace this with an API call to `RecordReplaySetCrashReasonCallback`
-      // See RUN-1562: https://linear.app/replay/issue/RUN-1562
-      recordreplay::Print("ErrorFatal %s:%d %s", "js", 0, rvCStr.get());
-      IMMEDIATE_CRASH();
+      V8_Fatal("%s", rvCStr.get());
     }
   }
 


### PR DESCRIPTION
* https://github.com/replayio/chromium/pull/676
* https://linear.app/replay/issue/RUN-2022/js-exceptions-are-not-reported-anymore-when-we-crash-in