### PR TITLE
RUN-1988: Detect and Report PC mismatches due to Replay command handling

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11406,12 +11406,14 @@ extern "C" DLLEXPORT void V8RecordReplayEndPassThroughEvents() {
 void recordreplay::BeginDisallowEvents() {
   if (IsRecordingOrReplaying()) {
     gRecordReplayBeginDisallowEvents();
+    if (!recordreplay::HasDivergedFromRecording()) ++internal::gRecordReplayCheckProgress;
   }
 }
 
 void recordreplay::BeginDisallowEventsWithLabel(const char* label) {
   if (IsRecordingOrReplaying()) {
     gRecordReplayBeginDisallowEventsWithLabel(label);
+    if (!recordreplay::HasDivergedFromRecording()) ++internal::gRecordReplayCheckProgress;
   }
 }
 
@@ -11425,6 +11427,7 @@ extern "C" DLLEXPORT void V8RecordReplayBeginDisallowEventsWithLabel(const char*
 
 void recordreplay::EndDisallowEvents() {
   if (IsRecordingOrReplaying()) {
+    if (!recordreplay::HasDivergedFromRecording()) --internal::gRecordReplayCheckProgress;
     gRecordReplayEndDisallowEvents();
   }
 }

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -10893,7 +10893,7 @@ extern char* CommandCallback(const char* command, const char* params);
 extern void ClearPauseDataCallback();
 
 bool gRecordReplayAssertValues;
-bool gRecordReplayAssertProgress;
+int gRecordReplayAssertProgress;
 bool gRecordReplayAssertTrackedObjects;
 
 // Only finish recordings if there were interesting sources loaded
@@ -12033,7 +12033,8 @@ void recordreplay::SetRecordingOrReplaying(void* handle) {
 
   internal::gRecordReplayAssertValues = !!getenv("RECORD_REPLAY_JS_ASSERTS");
   internal::gRecordReplayAssertProgress =
-      internal::gRecordReplayAssertValues || !!getenv("RECORD_REPLAY_JS_PROGRESS_ASSERTS");
+      (internal::gRecordReplayAssertValues || !!getenv("RECORD_REPLAY_JS_PROGRESS_ASSERTS")) ?
+        -1 : 0;
   internal::gRecordReplayAssertTrackedObjects =
       internal::gRecordReplayAssertValues || !!getenv("RECORD_REPLAY_JS_OBJECT_ASSERTS");
 

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -10893,8 +10893,9 @@ extern char* CommandCallback(const char* command, const char* params);
 extern void ClearPauseDataCallback();
 
 bool gRecordReplayAssertValues;
-int gRecordReplayAssertProgress;
+bool gRecordReplayAssertProgress;
 bool gRecordReplayAssertTrackedObjects;
+int gRecordReplayCheckProgress;
 
 // Only finish recordings if there were interesting sources loaded
 // into the process.
@@ -12038,10 +12039,11 @@ void recordreplay::SetRecordingOrReplaying(void* handle) {
 
   internal::gRecordReplayAssertValues = !!getenv("RECORD_REPLAY_JS_ASSERTS");
   internal::gRecordReplayAssertProgress =
-      (internal::gRecordReplayAssertValues || !!getenv("RECORD_REPLAY_JS_PROGRESS_ASSERTS")) ?
-        -1 : 0;
+      internal::gRecordReplayAssertValues || !!getenv("RECORD_REPLAY_JS_PROGRESS_ASSERTS");
   internal::gRecordReplayAssertTrackedObjects =
       internal::gRecordReplayAssertValues || !!getenv("RECORD_REPLAY_JS_OBJECT_ASSERTS");
+  internal::gRecordReplayCheckProgress =
+      internal::gRecordReplayAssertProgress || !!getenv("RECORD_REPLAY_JS_PROGRESS_CHECKS");
 
   // Set flags to disable non-deterministic posting of tasks to other threads.
   // We don't support this yet when recording/replaying.

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11908,12 +11908,11 @@ void recordreplay::SetRecordingOrReplaying(void* handle) {
   gARMRecording = RecordReplayValue("ARMRecording", gARMRecording);
 
   internal::gRecordReplayAssertValues = !!getenv("RECORD_REPLAY_JS_ASSERTS");
+  internal::gRecordReplayCheckProgress = !!getenv("RECORD_REPLAY_JS_PROGRESS_CHECKS");
   internal::gRecordReplayAssertProgress =
       internal::gRecordReplayAssertValues || !!getenv("RECORD_REPLAY_JS_PROGRESS_ASSERTS");
   internal::gRecordReplayAssertTrackedObjects =
       internal::gRecordReplayAssertValues || !!getenv("RECORD_REPLAY_JS_OBJECT_ASSERTS");
-  internal::gRecordReplayCheckProgress =
-      internal::gRecordReplayAssertProgress || !!getenv("RECORD_REPLAY_JS_PROGRESS_CHECKS");
 
   if (internal::gRecordReplayAssertProgress) {
     void (*setAssertDataCallbacks)(void (*aGetData)(void**, size_t*),

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11908,7 +11908,8 @@ void recordreplay::SetRecordingOrReplaying(void* handle) {
   gARMRecording = RecordReplayValue("ARMRecording", gARMRecording);
 
   internal::gRecordReplayAssertValues = !!getenv("RECORD_REPLAY_JS_ASSERTS");
-  internal::gRecordReplayCheckProgress = !!getenv("RECORD_REPLAY_JS_PROGRESS_CHECKS");
+  internal::gRecordReplayCheckProgress =
+      internal::gRecordReplayAssertValues || !!getenv("RECORD_REPLAY_JS_PROGRESS_CHECKS");
   internal::gRecordReplayAssertProgress =
       internal::gRecordReplayAssertValues || !!getenv("RECORD_REPLAY_JS_PROGRESS_ASSERTS");
   internal::gRecordReplayAssertTrackedObjects =

--- a/src/baseline/baseline-compiler.cc
+++ b/src/baseline/baseline-compiler.cc
@@ -62,7 +62,7 @@
 namespace v8 {
 namespace internal {
 
-extern bool gRecordReplayAssertProgress;
+extern int gRecordReplayAssertProgress;
 
 namespace baseline {
 

--- a/src/baseline/baseline-compiler.cc
+++ b/src/baseline/baseline-compiler.cc
@@ -62,8 +62,6 @@
 namespace v8 {
 namespace internal {
 
-extern int gRecordReplayAssertProgress;
-
 namespace baseline {
 
 template <typename IsolateT>

--- a/src/compiler/bytecode-graph-builder.cc
+++ b/src/compiler/bytecode-graph-builder.cc
@@ -31,7 +31,6 @@
 namespace v8 {
 namespace internal {
 
-extern int gRecordReplayAssertProgress;
 extern bool gRecordReplayInstrumentationEnabled;
 
 namespace compiler {

--- a/src/compiler/bytecode-graph-builder.cc
+++ b/src/compiler/bytecode-graph-builder.cc
@@ -31,7 +31,7 @@
 namespace v8 {
 namespace internal {
 
-extern bool gRecordReplayAssertProgress;
+extern int gRecordReplayAssertProgress;
 extern bool gRecordReplayInstrumentationEnabled;
 
 namespace compiler {

--- a/src/objects/value-serializer.cc
+++ b/src/objects/value-serializer.cc
@@ -1230,7 +1230,8 @@ ValueDeserializer::ValueDeserializer(Isolate* isolate,
       end_(data.end()),
       id_map_(isolate->global_handles()->Create(
           ReadOnlyRoots(isolate_).empty_fixed_array())) {
-  recordreplay::Assert("[RUN-1618] ValueDeserializer::ValueDeserializer #1 %u %d",
+
+  recordreplay::Assert("[RUN-2037] ValueDeserializer::ValueDeserializer #1 %u %d",
                        data.size(), HashBytes(&data[0], data.size()));
 }
 
@@ -1242,8 +1243,9 @@ ValueDeserializer::ValueDeserializer(Isolate* isolate, const uint8_t* data,
       end_(data + size),
       id_map_(isolate->global_handles()->Create(
           ReadOnlyRoots(isolate_).empty_fixed_array())) {
-  recordreplay::Assert("[RUN-1618] ValueDeserializer::ValueDeserializer #2 %u %d",
-                       size, HashBytes(data, size));
+  recordreplay::Assert(
+      "[RUN-2037] ValueDeserializer::ValueDeserializer #2 %u %d", size,
+      HashBytes(data, size));
 }
 
 ValueDeserializer::~ValueDeserializer() {

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1098,9 +1098,9 @@ RUNTIME_FUNCTION(Runtime_RecordReplayAssertExecutionProgress) {
     RecordReplayOnTargetProgressReached();
   }
 
-  // if (!gRecordReplayCheckProgress) {
-  //   return ReadOnlyRoots(isolate).undefined_value();
-  // }
+  if (!gRecordReplayCheckProgress) {
+    return ReadOnlyRoots(isolate).undefined_value();
+  }
 
   if (!gProgressData) {
     gProgressData = new std::vector<uint64_t>();
@@ -1127,9 +1127,7 @@ RUNTIME_FUNCTION(Runtime_RecordReplayAssertExecutionProgress) {
   // }
   // CHECK(gRecordReplayHasCheckpoint);
 
-  if (RecordReplayIsDivergentUserJSWithoutPause(function->shared()) ||
-      (gRecordReplayAssertProgress && recordreplay::IsReplaying() &&
-       recordreplay::HadMismatch())) {
+  if (RecordReplayIsDivergentUserJSWithoutPause(function->shared())) {
     // Print JS stack if user JS was executed non-deterministically
     // and we were not paused, or if we had a mismatch.
     // if (!gHasPrintedStack) {  // Prevent flood.

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1103,7 +1103,6 @@ RUNTIME_FUNCTION(Runtime_RecordReplayAssertExecutionProgress) {
   }
 
   if (gRecordReplayAssertProgress) {
-    CHECK_EQ(1, args.length());
     Handle<JSFunction> function = args.at<JSFunction>(0);
 
     if (!gProgressData) {
@@ -1113,7 +1112,6 @@ RUNTIME_FUNCTION(Runtime_RecordReplayAssertExecutionProgress) {
   }
 
   if (gRecordReplayCheckProgress) {
-    CHECK_EQ(1, args.length());
     Handle<JSFunction> function = args.at<JSFunction>(0);
 
     Handle<SharedFunctionInfo> shared(function->shared(), isolate);

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1102,7 +1102,6 @@ RUNTIME_FUNCTION(Runtime_RecordReplayAssertExecutionProgress) {
     RecordReplayOnTargetProgressReached();
   }
 
-
   if (gRecordReplayAssertProgress) {
     Handle<JSFunction> function = args.at<JSFunction>(0);
 

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1131,7 +1131,7 @@ RUNTIME_FUNCTION(Runtime_RecordReplayAssertExecutionProgress) {
         isolate->PrintCurrentStackTrace(stack);
 
         recordreplay::Warning(
-            "JS ExecutionProgress in non-deterministic user JS PC=%zu "
+            "[RUN-1919] JS ExecutionProgress in non-deterministic user JS PC=%zu "
             "scriptId=%d @%s stack=%s",
             *gProgressCounter, script->id(),
             GetScriptLocationString(script->id(), shared->StartPosition())

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1111,6 +1111,7 @@ RUNTIME_FUNCTION(Runtime_RecordReplayAssertExecutionProgress) {
   Handle<SharedFunctionInfo> shared(function->shared(), isolate);
   Handle<Script> script(Script::cast(shared->script()), isolate);
 
+  CHECK(RecordReplayBytecodeAllowed());
   CHECK(gRecordReplayHasCheckpoint);
   CHECK(RecordReplayHasRegisteredScript(*script));
 
@@ -1191,10 +1192,10 @@ static std::string GetStackLocation(Isolate* isolate) {
     Script::GetPositionInfo(script, source_position, &info, Script::WITH_OFFSET);
 
     if (script->name().IsUndefined()) {
-      snprintf(location, sizeof(location), "@<none>:%d:%d", info.line + 1, info.column);
+      snprintf(location, sizeof(location), "<none>:%d:%d", info.line + 1, info.column);
     } else {
       std::unique_ptr<char[]> name = String::cast(script->name()).ToCString();
-      snprintf(location, sizeof(location), "@%s:%d:%d", name.get(), info.line + 1, info.column);
+      snprintf(location, sizeof(location), "%s:%d:%d", name.get(), info.line + 1, info.column);
     }
     location[sizeof(location) - 1] = 0;
     break;

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1124,7 +1124,7 @@ RUNTIME_FUNCTION(Runtime_RecordReplayAssertExecutionProgress) {
 
   if (recordreplay::AreEventsDisallowed() && !recordreplay::HasDivergedFromRecording()) {
     // Print JS stack if user JS was executed non-deterministically
-    // and we were not paused, or if we had a mismatch.
+    // and we were not paused.
     if (!gHasPrintedStack) {  // Prevent flood.
       gHasPrintedStack = true;
       HandleScope scope(isolate);

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1102,6 +1102,7 @@ RUNTIME_FUNCTION(Runtime_RecordReplayAssertExecutionProgress) {
     RecordReplayOnTargetProgressReached();
   }
 
+
   if (gRecordReplayAssertProgress) {
     Handle<JSFunction> function = args.at<JSFunction>(0);
 

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1102,42 +1102,43 @@ RUNTIME_FUNCTION(Runtime_RecordReplayAssertExecutionProgress) {
     RecordReplayOnTargetProgressReached();
   }
 
-  if (gRecordReplayAssertProgress || gRecordReplayCheckProgress) {
+  if (gRecordReplayAssertProgress) {
     CHECK_EQ(1, args.length());
     Handle<JSFunction> function = args.at<JSFunction>(0);
 
-    if (gRecordReplayAssertProgress) {
-      if (!gProgressData) {
-        gProgressData = new std::vector<uint64_t>();
-      }
-      gProgressData->push_back(BuildScriptProgressEntry(function));
+    if (!gProgressData) {
+      gProgressData = new std::vector<uint64_t>();
     }
+    gProgressData->push_back(BuildScriptProgressEntry(function));
+  }
 
-    if (gRecordReplayCheckProgress) {
-      Handle<SharedFunctionInfo> shared(function->shared(), isolate);
-      Handle<Script> script(Script::cast(shared->script()), isolate);
+  if (gRecordReplayCheckProgress) {
+    CHECK_EQ(1, args.length());
+    Handle<JSFunction> function = args.at<JSFunction>(0);
 
-      CHECK(RecordReplayBytecodeAllowed());
-      CHECK(gRecordReplayHasCheckpoint);
-      CHECK(RecordReplayHasRegisteredScript(*script));
+    Handle<SharedFunctionInfo> shared(function->shared(), isolate);
+    Handle<Script> script(Script::cast(shared->script()), isolate);
 
-      if (recordreplay::AreEventsDisallowed() && !recordreplay::HasDivergedFromRecording()) {
-        // Print JS stack if user JS was executed non-deterministically
-        // and we were not paused.
-        if (!gHasPrintedStack) {  // Prevent flood.
-          gHasPrintedStack = true;
-          HandleScope scope(isolate);
-          std::stringstream stack;
-          isolate->PrintCurrentStackTrace(stack);
+    CHECK(RecordReplayBytecodeAllowed());
+    CHECK(gRecordReplayHasCheckpoint);
+    CHECK(RecordReplayHasRegisteredScript(*script));
 
-          recordreplay::Warning(
-              "JS ExecutionProgress in non-deterministic user JS PC=%zu "
-              "scriptId=%d @%s stack=%s",
-              *gProgressCounter, script->id(),
-              GetScriptLocationString(script->id(), shared->StartPosition())
-                  .c_str(),
-              stack.str().c_str());
-        }
+    if (recordreplay::AreEventsDisallowed() && !recordreplay::HasDivergedFromRecording()) {
+      // Print JS stack if user JS was executed non-deterministically
+      // and we were not paused.
+      if (!gHasPrintedStack) {  // Prevent flood.
+        gHasPrintedStack = true;
+        HandleScope scope(isolate);
+        std::stringstream stack;
+        isolate->PrintCurrentStackTrace(stack);
+
+        recordreplay::Warning(
+            "JS ExecutionProgress in non-deterministic user JS PC=%zu "
+            "scriptId=%d @%s stack=%s",
+            *gProgressCounter, script->id(),
+            GetScriptLocationString(script->id(), shared->StartPosition())
+                .c_str(),
+            stack.str().c_str());
       }
     }
   }

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -944,7 +944,7 @@ RUNTIME_FUNCTION(Runtime_ProfileCreateSnapshotDataBlob) {
 
 extern uint64_t* gProgressCounter;
 extern uint64_t gTargetProgress;
-extern bool gRecordReplayAssertProgress;
+extern int gRecordReplayAssertProgress;
 
 // Define this to check preconditions for using record/replay opcodes.
 //#define RECORD_REPLAY_CHECK_OPCODES
@@ -1020,6 +1020,10 @@ RUNTIME_FUNCTION(Runtime_RecordReplayAssertExecutionProgress) {
 
   if (RecordReplayIsDivergentUserJSWithoutPause(function->shared()) ||
       (recordreplay::IsReplaying() && recordreplay::HadMismatch())) {
+
+    // [RUN-1988] We only want some JS Asserts. Dial it back down, once we hit a mismatch.
+    if (gRecordReplayAssertProgress > 0) --gRecordReplayAssertProgress;
+
     // Print JS stack if user JS was executed non-deterministically
     // and we were not paused, or if we had a mismatch.
     if (!gHasPrintedStack) {  // Prevent flood.


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-1988/detect-and-report-pc-mismatches-due-to-replay-command-handling
* Sneaky change:
  * More `PerformSideEffectCheck` fixes (`RUN-1908`).
  * Peg fixed `RUN-1618` to new `RUN-2037`