### PR TITLE
RUN-2178: Disallow events in Heap::StartTearDown

### DIFF
--- a/src/heap/cppgc/sweeper.cc
+++ b/src/heap/cppgc/sweeper.cc
@@ -867,6 +867,8 @@ class Sweeper::SweeperImpl final {
   }
 
   bool FinishIfRunning() {
+    v8::recordreplay::AutoDisallowEvents disallow("SweeperImpl::FinishIfRunning");
+
     if (!is_in_progress_) return false;
 
     // Bail out for recursive sweeping calls. This can happen when finalizers

--- a/src/heap/heap.cc
+++ b/src/heap/heap.cc
@@ -5765,6 +5765,8 @@ void Heap::RegisterExternallyReferencedObject(Address* location) {
 }
 
 void Heap::StartTearDown() {
+  recordreplay::AutoDisallowEvents disallow("Heap::StartTearDown");
+
   // Finish any ongoing sweeping to avoid stray background tasks still accessing
   // the heap during teardown.
   CompleteSweepingFull();


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/736
* https://linear.app/replay/issue/RUN-2178#comment-425628a4