### PR TITLE
RUN-2232: Make OnProgressReached a no-op when events disallowed

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11368,10 +11368,7 @@ extern "C" DLLEXPORT void V8RecordReplayEndDisallowEvents() {
 
 void recordreplay::InvalidateRecording(const char* why) {
   if (IsRecordingOrReplaying()) {
-    constexpr int N = 16386;
-    char stack[N];
-    gRecordReplayGetStack(stack, N);
-    gRecordReplayInvalidateRecording("%s %s", why, stack);
+    gRecordReplayInvalidateRecording("%s", why);
   }
 }
 

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -10739,7 +10739,8 @@ typedef char* (CommandCallbackRaw)(const char* params);
   Macro(RecordReplayJSONCreateObject,                                         \
         (size_t, const char**, void**), void*, nullptr)                       \
   Macro(RecordReplayJSONToString, (void*), char*, nullptr)                    \
-  Macro(RecordReplayProgressCounter, (), uint64_t*, nullptr)
+  Macro(RecordReplayProgressCounter, (), uint64_t*, nullptr)                  \
+  Macro(RecordReplayGetStack, (char* aStack, size_t aSize), bool, false)
 
 #define ForEachRecordReplaySymbolVoidShared(Macro)                            \
   Macro(RecordReplayDisableFeatures, (const char* json))                      \
@@ -10923,8 +10924,25 @@ void RecordReplayTriggerProgressInterrupt() {
   gRecordReplayTriggerProgressInterrupt();
 }
 
-void RecordReplayOnTargetProgressReached() {
+extern std::string GetScriptLocationString(int script_id, int start_position);
+
+    void RecordReplayOnTargetProgressReached() {
   CHECK(IsMainThread());
+  if (recordreplay::AreEventsDisallowed()) {
+    // We should not have progress updates when events disallowed.
+    if (!recordreplay::HasDivergedFromRecording()) {
+      // TODO: [RUN-2235] Replace with GetCurrentLocationStringExtended.
+      std::ostringstream os;
+      os << "PC=" << *gProgressCounter;
+      Isolate* isolate = Isolate::Current();
+      HandleScope scope(isolate);
+      os << " stack=";
+      isolate->PrintCurrentStackTrace(os);
+
+      recordreplay::Warning("OnProgressReached %s", os.str().c_str());
+    }
+    return;
+  }
   gRecordReplayProgressReached();
 }
 
@@ -11350,7 +11368,10 @@ extern "C" DLLEXPORT void V8RecordReplayEndDisallowEvents() {
 
 void recordreplay::InvalidateRecording(const char* why) {
   if (IsRecordingOrReplaying()) {
-    gRecordReplayInvalidateRecording("%s", why);
+    constexpr int N = 16386;
+    char stack[N];
+    gRecordReplayGetStack(stack, N);
+    gRecordReplayInvalidateRecording("%s %s", why, stack);
   }
 }
 
@@ -11621,6 +11642,11 @@ extern "C" DLLEXPORT void V8RecordReplayOnAnnotation(const char* kind, const cha
   if (internal::gRecordReplayHasCheckpoint) {
     gRecordReplayOnAnnotation(kind, contents);
   }
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayGetStack(char* aStack, size_t aSize) {
+  DCHECK(recordreplay::IsRecordingOrReplaying());
+  return gRecordReplayGetStack(aStack, aSize);
 }
 
 namespace internal {

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -10926,7 +10926,7 @@ void RecordReplayTriggerProgressInterrupt() {
 
 extern std::string GetScriptLocationString(int script_id, int start_position);
 
-    void RecordReplayOnTargetProgressReached() {
+void RecordReplayOnTargetProgressReached() {
   CHECK(IsMainThread());
   if (recordreplay::AreEventsDisallowed()) {
     // We should not have progress updates when events disallowed.

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -995,8 +995,7 @@ static inline std::string GetScriptName(Handle<Script> script) {
     : "(anonymous script)";
 }
 
-static std::string GetScriptLocationString(int script_id,
-                                           int start_position) {
+std::string GetScriptLocationString(int script_id, int start_position) {
   Isolate* isolate = Isolate::Current();
   Handle<Script> script = GetScript(isolate, script_id);
   std::string script_name = GetScriptName(script);


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/768
* https://linear.app/replay/issue/RUN-2232#comment-0fcda91b