### PR TITLE
Add diagnostics for heap allocation failures on background threads

### DIFF
--- a/src/heap/concurrent-allocator.cc
+++ b/src/heap/concurrent-allocator.cc
@@ -232,6 +232,11 @@ ConcurrentAllocator::AllocateFromSpaceFreeList(size_t min_size_in_bytes,
                                                       space_->AreaSize())) {
     result = space_->TryExpandBackground(max_size_in_bytes);
     if (result) return result;
+    recordreplay::Diagnostic("[RUN-851] ConcurrentAllocator::AllocateFromSpaceFreeList TryExpandBackgroundFailed");
+  } else {
+    recordreplay::Diagnostic("[RUN-851] ConcurrentAllocator::AllocateFromSpaceFreeList CantExpand %d %d",
+                             owning_heap()->ShouldExpandOldGenerationOnSlowAllocation(local_heap_),
+                             owning_heap()->CanExpandOldGenerationBackground(local_heap_, space_->AreaSize()));
   }
 
   if (owning_heap()->sweeping_in_progress()) {

--- a/src/heap/large-spaces.cc
+++ b/src/heap/large-spaces.cc
@@ -176,6 +176,9 @@ AllocationResult OldLargeObjectSpace::AllocateRawBackground(
   // If so, fail the allocation.
   if (!heap()->CanExpandOldGenerationBackground(local_heap, object_size) ||
       !heap()->ShouldExpandOldGenerationOnSlowAllocation(local_heap)) {
+    recordreplay::Diagnostic("[RUN-851] OldLargeObjectSpace::AllocateRawBackground Failed %d %d",
+                             heap()->CanExpandOldGenerationBackground(local_heap, object_size),
+                             heap()->ShouldExpandOldGenerationOnSlowAllocation(local_heap));
     return AllocationResult::Failure();
   }
 


### PR DESCRIPTION
For https://linear.app/replay/issue/RUN-851