### PR TITLE
Avoid GC when allocating on background threads while replaying

### DIFF
--- a/src/heap/heap.cc
+++ b/src/heap/heap.cc
@@ -5082,6 +5082,11 @@ bool Heap::ShouldOptimizeForLoadTime() {
 bool Heap::ShouldExpandOldGenerationOnSlowAllocation(LocalHeap* local_heap) {
   recordreplay::AutoDisallowEvents disallow("Heap::ShouldExpandOldGenerationOnSlowAllocation");
 
+  // Always allow background threads to allocate while replaying without triggering GC.
+  // Waiting on a main thread GC can introduce deadlocks if the main thread
+  // is itself waiting on an ordered lock which this thread is next in line to acquire.
+  if (recordreplay::IsReplaying() && !local_heap->is_main_thread()) return true;
+
   if (always_allocate() || OldGenerationSpaceAvailable() > 0) return true;
   // We reached the old generation allocation limit.
 


### PR DESCRIPTION
https://linear.app/replay/issue/RUN-851