### PR TITLE
RUN-2172: don't flag as `inlineScript` if `url.empty()`

### DIFF
--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3703,7 +3703,12 @@ static void RecordReplayRegisterScript(Handle<Script> script) {
   // than line zero / column zero, the script must be inlined into another file.
   Script::PositionInfo start_info;
   Script::GetPositionInfo(script, 0, &start_info, Script::WITH_OFFSET);
-  const char* kind = (start_info.line || start_info.column) ? "inlineScript" : "scriptSource";
+
+  // [RUN-2172] Inline scripts sometimes might have line and column but no
+  // URL in case of blink-internal scripts.
+  const char* kind = ((start_info.line || start_info.column) && !url.empty())
+                         ? "inlineScript"
+                         : "scriptSource";
 
   recordreplay::Diagnostic("OnNewSource %s %s", id.get(), kind);
 


### PR DESCRIPTION
* 
* https://linear.app/replay/issue/RUN-2172#comment-50439236