### PR TITLE
Disallow events in FutexEmulation::WaitSync interrupt loop.

### DIFF
--- a/src/execution/futex-emulation.cc
+++ b/src/execution/futex-emulation.cc
@@ -105,22 +105,11 @@ namespace {
 // and `interrupted_` fields for each individual list node that is currently
 // part of the list. It must be the mutex used together with the `cond_`
 // condition variable of such nodes.
-struct RecordReplayOrderedFutexEmulationMutexConstructor {
-  // Constructs the mutex with an ordered name.
-  static void Construct(void* allocated_ptr) { new (allocated_ptr) base::Mutex("FutexEmulation"); }
-};
-using LazyMutex =
-  base::LazyStaticInstance<
-    base::Mutex,
-    RecordReplayOrderedFutexEmulationMutexConstructor,
-    base::ThreadSafeInitOnceTrait
-  >::type;
-LazyMutex g_mutex = LAZY_MUTEX_INITIALIZER;
+base::LazyMutex g_mutex = LAZY_MUTEX_INITIALIZER;
 base::LazyInstance<FutexWaitList>::type g_wait_list = LAZY_INSTANCE_INITIALIZER;
 }  // namespace
 
 FutexWaitListNode::~FutexWaitListNode() {
-  recordreplay::UnregisterPointer(this);
   // Assert that the timeout task was cancelled.
   DCHECK_EQ(CancelableTaskManager::kInvalidTaskId, timeout_task_id_);
 }
@@ -146,9 +135,6 @@ void FutexWaitListNode::NotifyWake() {
   // if not waiting, this will not have any effect.
   cond_.NotifyOne();
   interrupted_ = true;
-  recordreplay::Assert("[RUN-2378-2433] FutexWaitListNode::NotifyWake %d",
-    recordreplay::PointerId(this)
-  );
 }
 
 class ResolveAsyncWaiterPromisesTask : public CancelableTask {
@@ -415,9 +401,6 @@ Object FutexEmulation::WaitSync(Isolate* isolate,
     node->wait_location_ = wait_location;
     node->waiting_ = true;
 
-    int node_record_replay_id = recordreplay::PointerId(node);
-    recordreplay::Assert("[RUN-2378-2433] FutexEmulation::WaitSync #105 node=%d",
-      node_record_replay_id);
 
     // Reset node->waiting_ = false when leaving this scope (but while
     // still holding the lock).
@@ -456,11 +439,21 @@ Object FutexEmulation::WaitSync(Isolate* isolate,
     g_wait_list.Pointer()->AddNode(node);
 
     while (true) {
+      // [RecordReplay]
+      // The node->interrupted_ below can be set non-deterministically,
+      // guarded by the `g_mutex` unordered lock.
+      //
+      // The call to `HandleInterrupts` below has already been modified,
+      // prior to this comment, to be a no-op when events are disallowed.
+      //
+      // We wrap the entire first part of this loop in an `EventsDisallowed`
+      // context.
+
+      { // BEGIN AutoDisallowEvents
+      recordreplay::AutoDisallowEvents no_events("FutexEmulation::WaitSync");
+
       bool interrupted = node->interrupted_;
       node->interrupted_ = false;
-
-      recordreplay::Assert("[RUN-2378-2418] FutexEmulation::WaitSync #131 node=%d intr=%d",
-        node_record_replay_id, (int) interrupted);
 
       // Unlock the mutex here to prevent deadlock from lock ordering between
       // mutex and mutexes locked by HandleInterrupts.
@@ -488,14 +481,14 @@ Object FutexEmulation::WaitSync(Isolate* isolate,
         }
       }
 
-      recordreplay::Assert("[RUN-2378-2418] FutexEmulation::WaitSync #132");
-
       lock_guard.Lock();
 
       if (node->interrupted_) {
         // An interrupt occurred while the mutex was unlocked. Don't wait yet.
         continue;
       }
+
+      } // END AutoDisallowEvents
 
       recordreplay::Assert("[RUN-2378-2418] FutexEmulation::WaitSync #133");
 
@@ -560,9 +553,6 @@ Object FutexEmulation::WaitSync(Isolate* isolate,
   return *result;
 }
 
-FutexWaitListNode::FutexWaitListNode() {
-  recordreplay::RegisterPointer("FutexWaitListNode", this);
-}
 FutexWaitListNode::FutexWaitListNode(
     const std::shared_ptr<BackingStore>& backing_store, size_t wait_addr,
     Handle<JSObject> promise, Isolate* isolate)
@@ -572,7 +562,6 @@ FutexWaitListNode::FutexWaitListNode(
       wait_location_(
           FutexWaitList::ToWaitLocation(backing_store.get(), wait_addr)),
       waiting_(true) {
-  recordreplay::RegisterPointer("FutexWaitListNode", this);
   auto v8_isolate = reinterpret_cast<v8::Isolate*>(isolate);
   task_runner_ = V8::GetCurrentPlatform()->GetForegroundTaskRunner(v8_isolate);
   cancelable_task_manager_ = isolate->cancelable_task_manager();

--- a/src/execution/futex-emulation.h
+++ b/src/execution/futex-emulation.h
@@ -58,7 +58,7 @@ class AtomicsWaitWakeHandle {
 class FutexWaitListNode {
  public:
   // Create a sync FutexWaitListNode.
-  FutexWaitListNode();
+  FutexWaitListNode() = default;
 
   // Create an async FutexWaitListNode.
   FutexWaitListNode(const std::shared_ptr<BackingStore>& backing_store,


### PR DESCRIPTION
For RUN-2447 (https://linear.app/replay/issue/RUN-2447/disallow-events-in-futexemulationwaitsync-interrupt-loop)

Bucket issue RUN-2378.