### PR TITLE
RUN-2406: Add breakpoints to ternary sub-expressions

### DIFF
--- a/src/interpreter/bytecode-generator.cc
+++ b/src/interpreter/bytecode-generator.cc
@@ -45,7 +45,7 @@ extern bool RecordReplayTrackThisObjectAssignment(const std::string& property);
 /**
  * We are currently primarily only interested in calls.
  */
-static bool RecordReplayShouldBeBreakable(AstNode* node) {
+static bool RecordReplayShouldBeBreakable(Expression* node) {
   return node->IsCall() || node->IsCallNew() || node->IsImportCallExpression();
 }
 

--- a/src/interpreter/bytecode-generator.cc
+++ b/src/interpreter/bytecode-generator.cc
@@ -3017,6 +3017,7 @@ void BytecodeGenerator::VisitConditional(Conditional* expr) {
   } else {
     VisitForTest(expr->condition(), conditional_builder.then_labels(),
                  conditional_builder.else_labels(), TestFallthrough::kThen);
+
     conditional_builder.Then();
 
     if (RecordReplayShouldBeBreakable(expr->then_expression())) {

--- a/src/interpreter/bytecode-generator.cc
+++ b/src/interpreter/bytecode-generator.cc
@@ -42,6 +42,13 @@ namespace internal {
 extern bool gRecordReplayAssertValues;
 extern bool RecordReplayTrackThisObjectAssignment(const std::string& property);
 
+/**
+ * We are currently primarily only interested in calls.
+ */
+static bool RecordReplayShouldBeBreakable(AstNode* node) {
+  return node->IsCall() || node->IsCallNew() || node->IsImportCallExpression();
+}
+
 namespace interpreter {
 
 // Scoped class tracking context objects created by the visitor. Represents
@@ -3015,16 +3022,20 @@ void BytecodeGenerator::VisitConditional(Conditional* expr) {
                  conditional_builder.else_labels(), TestFallthrough::kThen);
     conditional_builder.Then();
 
-    builder()->RecordReplayInstrumentation("breakpoint",
-                                           expr->then_expression()->position());
+    if (RecordReplayShouldBeBreakable(expr->then_expression())) {
+      builder()->RecordReplayInstrumentation(
+          "breakpoint", expr->then_expression()->position());
+      }
 
     VisitForAccumulatorValue(expr->then_expression());
     conditional_builder.JumpToEnd();
 
     conditional_builder.Else();
 
-    builder()->RecordReplayInstrumentation("breakpoint",
-                                           expr->else_expression()->position());
+    if (RecordReplayShouldBeBreakable(expr->else_expression())) {
+      builder()->RecordReplayInstrumentation(
+          "breakpoint", expr->else_expression()->position());
+    }
 
     VisitForAccumulatorValue(expr->else_expression());
   }

--- a/src/interpreter/bytecode-generator.cc
+++ b/src/interpreter/bytecode-generator.cc
@@ -3006,9 +3006,6 @@ void BytecodeGenerator::VisitConditional(Conditional* expr) {
   ConditionalControlFlowBuilder conditional_builder(
       builder(), block_coverage_builder_, expr);
 
-  // [Replay Instrumentation] We don't emit breakpoints before the call,
-  // because those should generally be emitted by the nesting statement.
-
   if (expr->condition()->ToBooleanIsTrue()) {
     // Generate then block unconditionally as always true.
     conditional_builder.Then();

--- a/src/interpreter/bytecode-generator.cc
+++ b/src/interpreter/bytecode-generator.cc
@@ -3023,7 +3023,7 @@ void BytecodeGenerator::VisitConditional(Conditional* expr) {
     if (RecordReplayShouldBeBreakable(expr->then_expression())) {
       builder()->RecordReplayInstrumentation(
           "breakpoint", expr->then_expression()->position());
-      }
+    }
 
     VisitForAccumulatorValue(expr->then_expression());
     conditional_builder.JumpToEnd();


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/889
* https://linear.app/replay/issue/RUN-2406#comment-44cd075b