### PR TITLE
RUN-2341: Break on all call expressions + prevent duplicates

### DIFF
--- a/src/interpreter/bytecode-array-builder.cc
+++ b/src/interpreter/bytecode-array-builder.cc
@@ -1399,9 +1399,17 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayInstrumentation(const ch
   // Instrumentation opcodes aren't needed when recording.
   if (emit_record_replay_opcodes_ && recordreplay::IsReplaying()) {
     int bytecode_offset = bytecode_array_writer_.size();
-    int index = RegisterInstrumentationSite(kind, source_position, bytecode_offset);
-    if (index > 0) {
-      OutputRecordReplayInstrumentation(index);
+    int last_bytecode_offset = bytecode_offset;
+    if (replay_most_recent_instrumentation_offset_ != last_bytecode_offset) {
+      // Prevent duplicate Replay instrumentation site.
+      // Only emit an instrumentation site if the previous entry was not also
+      // one.
+      int index =
+          RegisterInstrumentationSite(kind, source_position, bytecode_offset);
+      if (index > 0) {
+        OutputRecordReplayInstrumentation(index);
+      }
+      replay_most_recent_instrumentation_offset_ = bytecode_array_writer_.size();
     }
   }
   return *this;
@@ -1413,9 +1421,17 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayInstrumentationGenerator
   // encountered values and need consistent IDs for these objects when recording.
   if (emit_record_replay_opcodes_ && (recordreplay::IsReplaying() || gRecordReplayAssertValues)) {
     int bytecode_offset = bytecode_array_writer_.size();
-    int index = RegisterInstrumentationSite(kind, kNoSourcePosition, bytecode_offset);
-    if (index > 0) {
-      OutputRecordReplayInstrumentationGenerator(index, generator_object);
+    int last_bytecode_offset = bytecode_offset;
+    if (replay_most_recent_instrumentation_offset_ != last_bytecode_offset) {
+      // Prevent duplicate Replay instrumentation site.
+      // Only emit an instrumentation site if the previous entry was not also
+      // one.
+      int index =
+          RegisterInstrumentationSite(kind, kNoSourcePosition, bytecode_offset);
+      if (index > 0) {
+        OutputRecordReplayInstrumentationGenerator(index, generator_object);
+      }
+      replay_most_recent_instrumentation_offset_ = bytecode_array_writer_.size();
     }
   }
   return *this;

--- a/src/interpreter/bytecode-array-builder.cc
+++ b/src/interpreter/bytecode-array-builder.cc
@@ -1396,9 +1396,10 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayAssertValue(const std::s
 
 int BytecodeArrayBuilder::RecordReplayRegisterInstrumentationSite(
     const char* kind, int source_position) {
-  if (record_replay_instrumentation_site_locations_.find(source_position) !=
-      record_replay_instrumentation_site_locations_.end()) {
-    // Don't insert a site at the same location more than once.
+  if (!strcmp(kind, "breakpoint") && source_position != kNoSourcePosition &&
+      record_replay_instrumentation_site_locations_.find(source_position) !=
+          record_replay_instrumentation_site_locations_.end()) {
+    // Don't insert a breakpoint at the same location more than once.
     return -1;
   }
   record_replay_instrumentation_site_locations_.insert(source_position);

--- a/src/interpreter/bytecode-array-builder.cc
+++ b/src/interpreter/bytecode-array-builder.cc
@@ -1400,7 +1400,9 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayInstrumentation(const ch
   if (emit_record_replay_opcodes_ && recordreplay::IsReplaying()) {
     int bytecode_offset = bytecode_array_writer_.size();
     int index = RegisterInstrumentationSite(kind, source_position, bytecode_offset);
-    OutputRecordReplayInstrumentation(index);
+    if (index > 0) {
+      OutputRecordReplayInstrumentation(index);
+    }
   }
   return *this;
 }
@@ -1412,7 +1414,9 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayInstrumentationGenerator
   if (emit_record_replay_opcodes_ && (recordreplay::IsReplaying() || gRecordReplayAssertValues)) {
     int bytecode_offset = bytecode_array_writer_.size();
     int index = RegisterInstrumentationSite(kind, kNoSourcePosition, bytecode_offset);
-    OutputRecordReplayInstrumentationGenerator(index, generator_object);
+    if (index > 0) {
+      OutputRecordReplayInstrumentationGenerator(index, generator_object);
+    }
   }
   return *this;
 }

--- a/src/interpreter/bytecode-array-builder.h
+++ b/src/interpreter/bytecode-array-builder.h
@@ -466,8 +466,8 @@ class V8_EXPORT_PRIVATE BytecodeArrayBuilder final {
   BytecodeArrayBuilder& RecordReplayOnProgress();
   BytecodeArrayBuilder& RecordReplayAssertValue(const std::string& desc);
 
-  void OutputRecordReplayInstrumentation(
-      const char* kind, int source_position);
+  int RecordReplayRegisterInstrumentationSite(const char* kind,
+                                               int source_position);
   BytecodeArrayBuilder& RecordReplayInstrumentation(const char* kind,
                                                     int source_position = kNoSourcePosition);
   BytecodeArrayBuilder& RecordReplayInstrumentationGenerator(const char* kind,

--- a/src/interpreter/bytecode-array-builder.h
+++ b/src/interpreter/bytecode-array-builder.h
@@ -465,6 +465,9 @@ class V8_EXPORT_PRIVATE BytecodeArrayBuilder final {
 
   BytecodeArrayBuilder& RecordReplayOnProgress();
   BytecodeArrayBuilder& RecordReplayAssertValue(const std::string& desc);
+
+  void OutputRecordReplayInstrumentation(
+      const char* kind, int source_position);
   BytecodeArrayBuilder& RecordReplayInstrumentation(const char* kind,
                                                     int source_position = kNoSourcePosition);
   BytecodeArrayBuilder& RecordReplayInstrumentationGenerator(const char* kind,
@@ -669,7 +672,7 @@ class V8_EXPORT_PRIVATE BytecodeArrayBuilder final {
   BytecodeSourceInfo deferred_source_info_;
   int most_recent_source_position_ = -1;
   bool emit_record_replay_opcodes_ = false;
-  int replay_most_recent_instrumentation_offset_ = -1;
+  std::unordered_set<int> record_replay_instrumentation_site_locations_;
 };
 
 V8_EXPORT_PRIVATE std::ostream& operator<<(

--- a/src/interpreter/bytecode-array-builder.h
+++ b/src/interpreter/bytecode-array-builder.h
@@ -669,6 +669,7 @@ class V8_EXPORT_PRIVATE BytecodeArrayBuilder final {
   BytecodeSourceInfo deferred_source_info_;
   int most_recent_source_position_ = -1;
   bool emit_record_replay_opcodes_ = false;
+  int replay_most_recent_instrumentation_offset_ = -1;
 };
 
 V8_EXPORT_PRIVATE std::ostream& operator<<(

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1344,6 +1344,13 @@ int RegisterInstrumentationSite(const char* kind, int source_position,
   base::MutexGuard lock(gInstrumentationSitesMutex);
 
   int index = (int)gInstrumentationSites->size();
+
+  if (index > 0 && gInstrumentationSites->at(index - 1).source_position_ ==
+                       source_position) {
+    // Don't insert the same location more than once.
+    return -1;
+  }
+
   gInstrumentationSites->push_back(site);
 
   return index + BytecodeSiteOffset;

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1344,13 +1344,6 @@ int RegisterInstrumentationSite(const char* kind, int source_position,
   base::MutexGuard lock(gInstrumentationSitesMutex);
 
   int index = (int)gInstrumentationSites->size();
-
-  if (index > 0 && gInstrumentationSites->at(index - 1).source_position_ ==
-                       source_position) {
-    // Don't insert the same location more than once.
-    return -1;
-  }
-
   gInstrumentationSites->push_back(site);
 
   return index + BytecodeSiteOffset;


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/903
* https://linear.app/replay/issue/RUN-2341/breakpoint-in-nested-expressions-missing#comment-3cc4cc02