### PR TITLE
RUN-2604: Keep all bindings available in inner scopes when replaying

### DIFF
--- a/src/ast/scopes.cc
+++ b/src/ast/scopes.cc
@@ -376,6 +376,15 @@ void Scope::SetDefaults() {
   num_heap_slots_ = ContextHeaderLength();
 
   set_language_mode(LanguageMode::kSloppy);
+
+  // While replaying, tell v8 that inner scopes contain an eval().  This will
+  // keep scope analysis from optimizing away unreferenced variables in
+  // closures.
+  // (RUN-2604)
+  if (recordreplay::FeatureEnabled("OptimizedAway") &&
+      recordreplay::IsReplaying()) {
+    inner_scope_calls_eval_ = true;
+  }
 }
 
 bool Scope::HasSimpleParameters() {

--- a/src/ast/scopes.cc
+++ b/src/ast/scopes.cc
@@ -381,7 +381,7 @@ void Scope::SetDefaults() {
   // keep scope analysis from optimizing away unreferenced variables in
   // closures.
   // (RUN-2604)
-  if (recordreplay::FeatureEnabled("OptimizedAway") &&
+  if (!recordreplay::FeatureEnabled("optimize-away") &&
       recordreplay::IsReplaying()) {
     inner_scope_calls_eval_ = true;
   }

--- a/src/ast/scopes.cc
+++ b/src/ast/scopes.cc
@@ -1046,7 +1046,7 @@ Variable* DeclarationScope::DeclareParameter(const AstRawString* name,
   // immediately obvious how to do that at this level.
   // (RUN-2604)
   if (recordreplay::IsReplaying() &&
-      recordreplay::FeatureEnabled("optimize-away")) {
+      !recordreplay::FeatureEnabled("optimize-away")) {
     var->ForceContextAllocation();
   }
   return var;
@@ -1183,7 +1183,7 @@ Variable* Scope::DeclareVariable(
   // immediately obvious how to do that at this level.
   // (RUN-2604)
   if (recordreplay::IsReplaying() &&
-      recordreplay::FeatureEnabled("optimize-away") &&
+      !recordreplay::FeatureEnabled("optimize-away") &&
       kind == VariableKind::NORMAL_VARIABLE) {
         var->ForceContextAllocation();
   }

--- a/src/ast/scopes.cc
+++ b/src/ast/scopes.cc
@@ -1041,6 +1041,14 @@ Variable* DeclarationScope::DeclareParameter(const AstRawString* name,
   // TODO(verwaest): Reevaluate whether we always need to do this, since
   // strict-mode function.arguments does not make the arguments available.
   var->set_is_used();
+  // While replaying, force all variables to be context-allocated.
+  // Ideally we'd only do this for non-leaf functions, but it's not
+  // immediately obvious how to do that at this level.
+  // (RUN-2604)
+  if (recordreplay::IsReplaying() &&
+      recordreplay::FeatureEnabled("optimize-away")) {
+    var->ForceContextAllocation();
+  }
   return var;
 }
 

--- a/src/ast/scopes.cc
+++ b/src/ast/scopes.cc
@@ -381,8 +381,8 @@ void Scope::SetDefaults() {
   // keep scope analysis from optimizing away unreferenced variables in
   // closures.
   // (RUN-2604)
-  if (!recordreplay::FeatureEnabled("optimize-away") &&
-      recordreplay::IsReplaying()) {
+  if (recordreplay::IsReplaying() &&
+      !recordreplay::FeatureEnabled("optimize-away")) {
     inner_scope_calls_eval_ = true;
   }
 }


### PR DESCRIPTION
This makes all outer bindings visible within inner scopes, regardless if they're referenced.  Behind a flag to check perf/memory effects.