### PR TITLE
add `why` to V8RecordReplayIsInReplayCode

### DIFF
--- a/include/v8.h
+++ b/include/v8.h
@@ -135,6 +135,10 @@ static void EndDisallowEvents();
 // resulting from this check.
 static bool AreEventsDisallowed(const char* why = nullptr);
 
+// A "why" string should be used whenever there are substantive behavior changes
+// resulting from this check.
+static bool IsInReplayCode(const char* why = nullptr);
+
 static bool HasDivergedFromRecording();
 static bool AllowSideEffects();
 

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11110,7 +11110,7 @@ bool recordreplay::FeatureEnabled(const char* feature, const char* subfeature) {
 }
 
 extern "C" DLLEXPORT bool V8RecordReplayFeatureEnabled(const char* feature, const char* subfeature) {
-  return recordreplay::FeatureEnabled(feature);
+  return recordreplay::FeatureEnabled(feature, subfeature);
 }
 
 bool recordreplay::HasDisabledFeatures() {

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -12063,8 +12063,14 @@ extern "C" DLLEXPORT bool V8IsMainThread() {
 
 static size_t gInReplayCode;
 
-extern "C" DLLEXPORT bool V8RecordReplayIsInReplayCode() {
-  return IsMainThread() && gInReplayCode;
+bool recordreplay::IsInReplayCode(const char* why) {
+  return V8IsRecordingOrReplaying("replay-code", why) && 
+        IsMainThread() &&
+        gInReplayCode;
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayIsInReplayCode(const char* why) {
+  return recordreplay::IsInReplayCode(why);
 }
 
 extern "C" DLLEXPORT void V8RecordReplayEnterReplayCode() {

--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -5575,7 +5575,7 @@ static int gNextDisallowedScriptId = 1 << 30;
 int Isolate::GetNextScriptId() {
   // Use a separate pool of IDs when events are disallowed, as these scripts
   // won't be created at consistently when recording vs. replaying.
-  if (recordreplay::AreEventsDisallowed()) {
+  if (recordreplay::AreEventsDisallowed("Isolate::GetNextScriptId")) {
     CHECK(IsMainThread());
     return gNextDisallowedScriptId++;
   }


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/918
* This is to allow better traceable early-outs, which we want to use in #918 and others.
* Sneaky: Also fix a bug with `FeatureEnabled` not passing all parameters through.