### PR TITLE
Revert "[RUN-2739] add V8RecordReplayCrash + fix SetRecordReplayIgnore checks"

### DIFF
--- a/include/v8.h
+++ b/include/v8.h
@@ -107,7 +107,6 @@ static void CommandDiagnostic(const char* format, ...);
 static void CommandDiagnosticTrace(const char* format, ...);
 static void Warning(const char* format, ...);
 static void Trace(const char* format, ...);
-static void Crash(const char* format, ...);
 static bool HadMismatch();
 static void Assert(const char* format, ...);
 static void AssertMaybeEventsDisallowed(const char* format, ...);

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11270,31 +11270,11 @@ void recordreplay::Trace(const char* format, ...) {
 }
 
 extern "C" DLLEXPORT void V8RecordReplayTrace(const char* format,
-                                              va_list args) {
+                                                va_list args) {
   if (recordreplay::IsRecordingOrReplaying()) {
     gRecordReplayTrace(format, args);
   }
 }
-
-extern "C" void V8RecordReplayCrash(const char* format, va_list args) {
-  DCHECK(recordreplay::IsRecordingOrReplaying());
-
-  char str[4096];
-  vsnprintf(str, sizeof(str), format, args);
-  str[sizeof(str) - 1] = 0;
-
-  V8_Fatal("%s", str);
-}
-
-void recordreplay::Crash(const char* format, ...) {
-  if (IsRecordingOrReplaying()) {
-    va_list args;
-    va_start(args, format);
-    V8RecordReplayCrash(format, args);
-    va_end(args);
-  }
-}
-
 
 bool recordreplay::HadMismatch() {
   if (IsRecordingOrReplaying()) {

--- a/src/codegen/compiler.cc
+++ b/src/codegen/compiler.cc
@@ -1609,8 +1609,7 @@ static void SetRecordReplayIgnore(UnoptimizedCompileFlags& flags) {
 
   if (!IsMainThread() ||
       !RecordReplayHasDefaultContext() ||
-      recordreplay::AreEventsDisallowed("CompileFlags") ||
-      recordreplay::IsInReplayCode("CompileFlags")) {
+      recordreplay::AreEventsDisallowed()) {
     flags.set_record_replay_ignore(true);
     return;
   }


### PR DESCRIPTION
* This caused Windows CI recordings to just timeout indefinitely.
* → Revert replayio/chromium-v8#194