### PR TITLE
[RUN-2439] Disable Events for JSDate::CurrentTimeValue

### DIFF
--- a/src/objects/js-objects.cc
+++ b/src/objects/js-objects.cc
@@ -5531,7 +5531,7 @@ double JSDate::CurrentTimeValue(Isolate* isolate) {
   if (v8_flags.log_internal_timer_events) LOG(isolate, CurrentTimeEvent());
   if (v8_flags.correctness_fuzzer_suppressions) return 4.2;
 
-  recordreplay::Assert("[RUN-1675-1826] JSDate::CurrentTimeValue");
+  recordreplay::AutoDisallowEvents disallowed("JSDate::CurrentTimeValue");
 
   // According to ECMA-262, section 15.9.1, page 117, the precision of
   // the number in a Date object representing a particular instant in


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-2439/mismatch-expected-mach-absolute-time-got-cfabsolutetimegetcurrent#comment-9c8ecc21