### PR TITLE
Allow overriding some Replay globals

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11081,7 +11081,7 @@ void RecordReplayOnMainThreadIsolateCreated(Isolate* isolate) {
 static Eternal<v8::Context>* gDefaultContext;
 
 extern "C" void V8RecordReplaySetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context> cx) {
-  if (IsMainThread() && !gDefaultContext) {
+  if (IsMainThread()) {
     gDefaultContext = new Eternal<v8::Context>(isolate, cx);
   }
 }

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -4198,7 +4198,6 @@ namespace i = internal;
 void FunctionCallbackRecordReplaySetCommandCallback(const FunctionCallbackInfo<Value>& callArgs) {
   CHECK(recordreplay::IsRecordingOrReplaying());
   CHECK(IsMainThread());
-  CHECK(!i::gCommandCallback);
 
   Isolate* v8isolate = callArgs.GetIsolate();
   i::gCommandCallback = new Eternal<Value>(v8isolate, callArgs[0]);
@@ -4207,7 +4206,6 @@ void FunctionCallbackRecordReplaySetCommandCallback(const FunctionCallbackInfo<V
 void FunctionCallbackRecordReplaySetClearPauseDataCallback(const FunctionCallbackInfo<Value>& callArgs) {
   CHECK(recordreplay::IsRecordingOrReplaying());
   CHECK(IsMainThread());
-  CHECK(!i::gClearPauseDataCallback);
 
   Isolate* v8isolate = callArgs.GetIsolate();
   i::gClearPauseDataCallback = new Eternal<Value>(v8isolate, callArgs[0]);


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1052
* https://linear.app/replay/issue/RUN-2965/-record-replay-and-other-replay-only-props-are-not-available-after#comment-0070ead6