### PR TITLE
[RUN-3123] Prevent context group switching after pause started

### DIFF
--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3843,6 +3843,7 @@ static Eternal<Value>* gCommandCallback;
 extern "C" void V8RecordReplayGetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context>* cx);
 extern uint64_t* gProgressCounter;
 extern int gRecordReplayCheckProgress;
+static int gPauseContextGroupId = 0;
 
 // Make sure that the isolate has a context by switching to the default
 // context if necessary.
@@ -3855,6 +3856,7 @@ static void EnsureIsolateContext(Isolate* isolate, base::Optional<SaveAndSwitchC
   }
 }
 
+
 char* CommandCallback(const char* command, const char* params) {
   CHECK(IsMainThread());
   AutoMarkReplayCode amrc;
@@ -3864,6 +3866,27 @@ char* CommandCallback(const char* command, const char* params) {
   Isolate* isolate = Isolate::Current();
   base::Optional<SaveAndSwitchContext> ssc;
   EnsureIsolateContext(isolate, ssc);
+
+  if (recordreplay::HasDivergedFromRecording()) {
+    v8_inspector::V8Inspector* inspectorRaw = v8::debug::GetInspector((v8::Isolate*)isolate);
+    if (!inspectorRaw) {
+      recordreplay::Warning("[CommandCallback] NO_INSPECTOR %s", command);
+    } else {
+      v8_inspector::V8InspectorImpl* inspector =
+          static_cast<v8_inspector::V8InspectorImpl*>(inspectorRaw);
+      int contextId = v8_inspector::InspectedContext::contextId(
+        ((v8::Isolate*)isolate)->GetCurrentContext()
+      );
+      int currentGroupId = inspector->contextGroupId(contextId);
+      if (!gPauseContextGroupId) {
+        gPauseContextGroupId = currentGroupId;
+      } else {
+        // [RUN-3123] Don't allow querying different context groups on the
+        // same pause.
+        CHECK(gPauseContextGroupId == currentGroupId);
+      }
+    }
+  }
 
   HandleScope scope(isolate);
 


### PR DESCRIPTION
* https://linear.app/replay/issue/RUN-3123/prevent-context-group-switching-after-pause-started