### PR TITLE
[RUN-3317] Move breakpoints into nested expressions

### DIFF
--- a/src/interpreter/bytecode-generator.cc
+++ b/src/interpreter/bytecode-generator.cc
@@ -1790,7 +1790,6 @@ void BytecodeGenerator::VisitBreakStatement(BreakStatement* stmt) {
 
 void BytecodeGenerator::VisitReturnStatement(ReturnStatement* stmt) {
   AllocateBlockCoverageSlotIfEnabled(stmt, SourceRangeKind::kContinuation);
-  recordreplay::Print("DDBG VisitReturnStatement %d", stmt->expression()->position());
   if (stmt->expression()->position() >= 0) {
     builder()->SetExpressionAsStatementPosition(stmt->expression());
   } else {

--- a/src/interpreter/bytecode-generator.cc
+++ b/src/interpreter/bytecode-generator.cc
@@ -1790,7 +1790,12 @@ void BytecodeGenerator::VisitBreakStatement(BreakStatement* stmt) {
 
 void BytecodeGenerator::VisitReturnStatement(ReturnStatement* stmt) {
   AllocateBlockCoverageSlotIfEnabled(stmt, SourceRangeKind::kContinuation);
-  builder()->SetStatementPosition(stmt);
+  recordreplay::Print("DDBG VisitReturnStatement %d", stmt->expression()->position());
+  if (stmt->expression()->position() >= 0) {
+    builder()->SetExpressionAsStatementPosition(stmt->expression());
+  } else {
+    builder()->SetStatementPosition(stmt);
+  }
   VisitForAccumulatorValue(stmt->expression());
   int return_position = stmt->end_position();
   if (return_position == ReturnStatement::kFunctionLiteralReturnPosition) {

--- a/src/interpreter/bytecode-generator.cc
+++ b/src/interpreter/bytecode-generator.cc
@@ -1731,7 +1731,6 @@ void BytecodeGenerator::VisitStatements(
   }
 }
 
-// [RUN-3317] Shift breakpoint from STMT to STMT->EXPR().
 void BytecodeGenerator::ReplayShiftedBreakpointPosition(Statement* stmt, Expression* expr) {
   if (
     recordreplay::IsRecordingOrReplaying("ReplayShiftedBreakpointPosition") &&

--- a/src/interpreter/bytecode-generator.h
+++ b/src/interpreter/bytecode-generator.h
@@ -58,6 +58,9 @@ class BytecodeGenerator final : public AstVisitor<BytecodeGenerator> {
   void VisitDeclarations(Declaration::List* declarations);
   void VisitStatements(const ZonePtrList<Statement>* statments);
 
+  // [RUN-3317] Shift breakpoint from STMT to STMT->EXPR().
+  void ReplayShiftedBreakpointPosition(Statement* stmt, Expression* expr);
+
  private:
   class AccumulatorPreservingScope;
   class ContextScope;

--- a/src/interpreter/bytecode-generator.h
+++ b/src/interpreter/bytecode-generator.h
@@ -58,7 +58,7 @@ class BytecodeGenerator final : public AstVisitor<BytecodeGenerator> {
   void VisitDeclarations(Declaration::List* declarations);
   void VisitStatements(const ZonePtrList<Statement>* statments);
 
-  // [RUN-3317] Shift breakpoint from STMT to STMT->EXPR().
+  // [RUN-3317] Shift breakpoint from |stmt| to |expr|, if |expr| exists.
   void ReplayShiftedBreakpointPosition(Statement* stmt, Expression* expr);
 
  private:


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1137
* https://linear.app/replay/issue/RUN-3317/fix-sourcemapping-of-breakpoints-on-tokens-before-nested-expressions#comment-d1993788