### PR TITLE
[RUN-3149] send large KeyIterationParams while iterating to accumulate keys, and shrink the PropertyMirrors array after

### DIFF
--- a/src/inspector/value-mirror.cc
+++ b/src/inspector/value-mirror.cc
@@ -1434,7 +1434,13 @@ bool ValueMirror::getProperties(v8::Local<v8::Context> context,
   }
 
   auto iterator = v8::debug::PropertyIterator::Create(context, object,
-                                                      nonIndexedPropertiesOnly, params);
+                                                      nonIndexedPropertiesOnly
+                                                      // RUN-3149 instead of passing the params down here,
+                                                      // let v8 do whatever it needs to gather keys/value,
+                                                      // and shrink the array to the requested size.
+                                                      //
+                                                      //, params
+  );
   if (!iterator) {
     CHECK(tryCatch.HasCaught());
     return false;

--- a/src/inspector/value-mirror.cc
+++ b/src/inspector/value-mirror.cc
@@ -1433,15 +1433,17 @@ bool ValueMirror::getProperties(v8::Local<v8::Context> context,
     }
   }
 
+  // [RUN-3149] we're only interested in a subset of the properties on this
+  // object. In order to make sure we get enough own properties to satisfy
+  // expected behavior for objects, always request 100k keys.  we will
+  // later prune returned properties down to the originally requested size.
+  v8::KeyIterationParams subsetIterationParams(100000, 0);
   const v8::KeyIterationParams *keyIterationParams;
   if (*params) {
-    // [RUN-3149] we're only interested in a subset of the properties on this
-    // object. In order to make sure we get enough own properties to satisfy
-    // expected behavior for objects, always request 100k keys.  we will
-    // later prune returned properties down to the originally requested size.
-    keyIterationParams = new v8::KeyIterationParams(100000, 0);
+    // we're grabbing a subset.  use the larger subset params.
+    keyIterationParams = &subsetIterationParams;
   } else {
-    // we're grabbing everything anyway, so just use the passed in params.
+    // we're grabbing everything.  use the passed-in params.
     keyIterationParams = params;
   }
   auto iterator = v8::debug::PropertyIterator::Create(context, object,

--- a/src/inspector/value-mirror.cc
+++ b/src/inspector/value-mirror.cc
@@ -1433,14 +1433,20 @@ bool ValueMirror::getProperties(v8::Local<v8::Context> context,
     }
   }
 
+  const v8::KeyIterationParams *keyIterationParams;
+  if (*params) {
+    // [RUN-3149] we're only interested in a subset of the properties on this
+    // object. In order to make sure we get enough own properties to satisfy
+    // expected behavior for objects, always request 100k keys.  we will
+    // later prune returned properties down to the originally requested size.
+    keyIterationParams = new v8::KeyIterationParams(100000, 0);
+  } else {
+    // we're grabbing everything anyway, so just use the passed in params.
+    keyIterationParams = params;
+  }
   auto iterator = v8::debug::PropertyIterator::Create(context, object,
-                                                      nonIndexedPropertiesOnly
-                                                      // RUN-3149 instead of passing the params down here,
-                                                      // let v8 do whatever it needs to gather keys/value,
-                                                      // and shrink the array to the requested size.
-                                                      //
-                                                      //, params
-  );
+                                                      nonIndexedPropertiesOnly,
+                                                      keyIterationParams);
   if (!iterator) {
     CHECK(tryCatch.HasCaught());
     return false;

--- a/src/inspector/value-mirror.cc
+++ b/src/inspector/value-mirror.cc
@@ -1435,9 +1435,12 @@ bool ValueMirror::getProperties(v8::Local<v8::Context> context,
 
   // [RUN-3149] we're only interested in a subset of the properties on this
   // object. In order to make sure we get enough own properties to satisfy
-  // expected behavior for objects, always request 100k keys.  we will
-  // later prune returned properties down to the originally requested size.
-  v8::KeyIterationParams subsetIterationParams(100000, 0);
+  // expected behavior for objects, always request a much larger set of keys
+  // we will later prune returned properties down to the originally requested
+  // size.
+  const int SubsetPageSize = 100000;
+
+  v8::KeyIterationParams subsetIterationParams(SubsetPageSize, 0);
   const v8::KeyIterationParams *keyIterationParams;
   if (*params) {
     // we're grabbing a subset.  use the larger subset params.

--- a/src/objects/keys.cc
+++ b/src/objects/keys.cc
@@ -547,7 +547,7 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysFast(
   // The properties-only case failed because there were probably elements on the
   // receiver.
   return GetOwnKeysWithElements<true>(isolate_, object, keys_conversion,
-                                      skip_indices_);
+                                      skip_indices_, key_iteration_params_);
 }
 
 MaybeHandle<FixedArray>


### PR DESCRIPTION
My hope is this won't result in much of a perf hit.  It seems (using the benchmark mode in https://github.com/replayio/backend/pull/9634) that it increases object preview durations by a constant factor, and things are still largely in the same ballpark as master.

Keep track of the passed-in params in the PropertyAccumulator, and in the case of `canOverflow` or `full` pass a MUCH larger params page size (currently 100k) down to the rest of the v8 machinery.  That way we're very likely to get enough keys for a given object that when we sort them we'll end up with the keys we expect.  This is coupled with early out'ing from the loop where we create PropertyMirrors, so the result sent back to the command JS is always min(num-properties, requested-size).

I did also find one spot where the key params weren't being passed, which looked like it resulted in getProperties on arrays returning all elements instead of just pageSize.  This makes a pretty huge difference in the benchmark durations for large arrays.