### PR TITLE
[TT-4] Use breakpoint `function_index` instead of `offset`

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -10796,7 +10796,7 @@ typedef char* (CommandCallbackRaw)(const char* params);
   Macro(RecordReplayJSONFree, (void*))                                        \
   Macro(RecordReplayOnAnnotation, (const char* kind, const char* contents))   \
   Macro(RecordReplayAddPossibleBreakpoint,                                    \
-        (int line, int column, const char* function_id, int offset))          \
+        (int line, int column, const char* function_id, int rank))          \
   Macro(RecordReplayOnEvent, (const char* aEvent, bool aBefore))              \
   Macro(RecordReplayOnMouseEvent,                                             \
         (const char* aKind, size_t aClientX, size_t aClientY))                \
@@ -11840,8 +11840,8 @@ extern "C" DLLEXPORT bool V8RecordReplayGetStack(char* aStack, size_t aSize) {
 
 namespace internal {
 
-void RecordReplayAddPossibleBreakpoint(int line, int column, const char* function_id, int offset) {
-  gRecordReplayAddPossibleBreakpoint(line, column, function_id, offset);
+void RecordReplayAddPossibleBreakpoint(int line, int column, const char* function_id, int rank) {
+  gRecordReplayAddPossibleBreakpoint(line, column, function_id, rank);
 }
 
 } // namespace internal

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -10796,7 +10796,7 @@ typedef char* (CommandCallbackRaw)(const char* params);
   Macro(RecordReplayJSONFree, (void*))                                        \
   Macro(RecordReplayOnAnnotation, (const char* kind, const char* contents))   \
   Macro(RecordReplayAddPossibleBreakpoint,                                    \
-        (int line, int column, const char* function_id, int rank))          \
+        (int line, int column, const char* function_id, int function_index))  \
   Macro(RecordReplayOnEvent, (const char* aEvent, bool aBefore))              \
   Macro(RecordReplayOnMouseEvent,                                             \
         (const char* aKind, size_t aClientX, size_t aClientY))                \
@@ -10959,8 +10959,8 @@ static void RecordReplayProgressInterruptCallback() {
   isolate->RecordReplayInvokeApiInterruptCallbacksAtProgress();
 }
 
-void RecordReplayInstrument(const char* kind, const char* function, int offset) {
-  gRecordReplayOnInstrument(kind, function, offset);
+void RecordReplayInstrument(const char* kind, const char* function, int function_index) {
+  gRecordReplayOnInstrument(kind, function, function_index);
 }
 
 extern void TrackObjectsCallback(bool track_objects);
@@ -11840,8 +11840,8 @@ extern "C" DLLEXPORT bool V8RecordReplayGetStack(char* aStack, size_t aSize) {
 
 namespace internal {
 
-void RecordReplayAddPossibleBreakpoint(int line, int column, const char* function_id, int rank) {
-  gRecordReplayAddPossibleBreakpoint(line, column, function_id, rank);
+void RecordReplayAddPossibleBreakpoint(int line, int column, const char* function_id, int function_index) {
+  gRecordReplayAddPossibleBreakpoint(line, column, function_id, function_index);
 }
 
 } // namespace internal

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3216,7 +3216,7 @@ static std::string BreakpointPositionKey(std::string function_id,
 
 extern const char* InstrumentationSiteKind(int index);
 extern int InstrumentationSiteSourcePosition(int index);
-extern int InstrumentationSiteRank(int index);
+extern int InstrumentationSiteFunctionIndex(int index);
 extern std::string GetRecordReplayFunctionId(Handle<SharedFunctionInfo> shared);
 
 static void GetInstrumentationSiteLocation(Handle<Script> script, int instrumentation_index,
@@ -3265,7 +3265,7 @@ static void ForEachInstrumentationOpInRange(
       return;
     }
 
-    int bytecode_offset = InstrumentationSiteRank(instrumentation_index);
+    int bytecode_offset = InstrumentationSiteFunctionIndex(instrumentation_index);
 
     std::string function_id = GetRecordReplayFunctionId(shared);
     callback(script, bytecode_offset, function_id, line, column);
@@ -3286,7 +3286,7 @@ static void GenerateBreakpointInfo(Isolate* isolate, Handle<Script> script) {
     GetInstrumentationSiteLocation(script, instrumentation_index, &line, &column);
 
     std::string function_id = GetRecordReplayFunctionId(shared);
-    int bytecode_offset = InstrumentationSiteRank(instrumentation_index);
+    int bytecode_offset = InstrumentationSiteFunctionIndex(instrumentation_index);
 
     std::string key = BreakpointKey(script->id(), line, column);
     BreakpointInfo value(function_id, bytecode_offset);
@@ -3415,7 +3415,7 @@ v8::Local<v8::Object> RecordReplayGetBytecode(v8::Isolate* isolate_,
   return v8::Utils::ToLocal(rv);
 }
 
-extern void RecordReplayAddPossibleBreakpoint(int line, int column, const char* function_id, int offset);
+extern void RecordReplayAddPossibleBreakpoint(int line, int column, const char* function_id, int function_index);
 
 static void EnsureIsolateContext(Isolate* isolate, base::Optional<SaveAndSwitchContext>& ssc);
 
@@ -3444,10 +3444,10 @@ void RecordReplayGetPossibleBreakpointsCallback(const char* script_id_str) {
     int line, column;
     GetInstrumentationSiteLocation(script, instrumentation_index, &line, &column);
 
-    int rank = InstrumentationSiteRank(instrumentation_index);
+    int function_index = InstrumentationSiteFunctionIndex(instrumentation_index);
 
     std::string function_id = GetRecordReplayFunctionId(shared);
-    RecordReplayAddPossibleBreakpoint(line, column, function_id.c_str(), rank);
+    RecordReplayAddPossibleBreakpoint(line, column, function_id.c_str(), function_index);
   });
 }
 

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3216,7 +3216,7 @@ static std::string BreakpointPositionKey(std::string function_id,
 
 extern const char* InstrumentationSiteKind(int index);
 extern int InstrumentationSiteSourcePosition(int index);
-extern int InstrumentationSiteBytecodeOffset(int index);
+extern int InstrumentationSiteRank(int index);
 extern std::string GetRecordReplayFunctionId(Handle<SharedFunctionInfo> shared);
 
 static void GetInstrumentationSiteLocation(Handle<Script> script, int instrumentation_index,
@@ -3265,7 +3265,7 @@ static void ForEachInstrumentationOpInRange(
       return;
     }
 
-    int bytecode_offset = InstrumentationSiteBytecodeOffset(instrumentation_index);
+    int bytecode_offset = InstrumentationSiteRank(instrumentation_index);
 
     std::string function_id = GetRecordReplayFunctionId(shared);
     callback(script, bytecode_offset, function_id, line, column);
@@ -3286,7 +3286,7 @@ static void GenerateBreakpointInfo(Isolate* isolate, Handle<Script> script) {
     GetInstrumentationSiteLocation(script, instrumentation_index, &line, &column);
 
     std::string function_id = GetRecordReplayFunctionId(shared);
-    int bytecode_offset = InstrumentationSiteBytecodeOffset(instrumentation_index);
+    int bytecode_offset = InstrumentationSiteRank(instrumentation_index);
 
     std::string key = BreakpointKey(script->id(), line, column);
     BreakpointInfo value(function_id, bytecode_offset);
@@ -3444,10 +3444,10 @@ void RecordReplayGetPossibleBreakpointsCallback(const char* script_id_str) {
     int line, column;
     GetInstrumentationSiteLocation(script, instrumentation_index, &line, &column);
 
-    int bytecode_offset = InstrumentationSiteBytecodeOffset(instrumentation_index);
+    int rank = InstrumentationSiteRank(instrumentation_index);
 
     std::string function_id = GetRecordReplayFunctionId(shared);
-    RecordReplayAddPossibleBreakpoint(line, column, function_id.c_str(), bytecode_offset);
+    RecordReplayAddPossibleBreakpoint(line, column, function_id.c_str(), rank);
   });
 }
 

--- a/src/interpreter/bytecode-array-builder.cc
+++ b/src/interpreter/bytecode-array-builder.cc
@@ -1405,8 +1405,8 @@ int BytecodeArrayBuilder::RecordReplayRegisterInstrumentationSite(
   }
   record_replay_instrumentation_site_locations_.insert(source_position);
 
-  int bytecode_offset = bytecode_array_writer_.size();
-  return RegisterInstrumentationSite(kind, source_position, bytecode_offset);
+  int rank = (int)record_replay_instrumentation_site_locations_.size();
+  return RegisterInstrumentationSite(kind, source_position, rank);
 }
 
 BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayInstrumentation(

--- a/src/interpreter/bytecode-array-builder.cc
+++ b/src/interpreter/bytecode-array-builder.cc
@@ -1405,8 +1405,8 @@ int BytecodeArrayBuilder::RecordReplayRegisterInstrumentationSite(
   }
   record_replay_instrumentation_site_locations_.insert(source_position);
 
-  int rank = (int)record_replay_instrumentation_site_locations_.size();
-  return RegisterInstrumentationSite(kind, source_position, rank);
+  int function_index = (int)record_replay_instrumentation_site_locations_.size();
+  return RegisterInstrumentationSite(kind, source_position, function_index);
 }
 
 BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayInstrumentation(

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1304,7 +1304,8 @@ RUNTIME_FUNCTION(Runtime_RecordReplayAssertValue) {
 struct InstrumentationSite {
   const char* kind_ = nullptr;
   int source_position_ = 0;
-  int bytecode_offset_ = 0;
+  // The index of this site within its function.
+  int rank_ = 0;
 
   // Set on the first use of the instrumentation site.
   std::string function_id_;
@@ -1332,11 +1333,11 @@ static void CopyMainThreadInstrumentationSites() {
 }
 
 int RegisterInstrumentationSite(const char* kind, int source_position,
-                                int bytecode_offset) {
+                                int rank) {
   InstrumentationSite site;
   site.kind_ = kind;
   site.source_position_ = source_position;
-  site.bytecode_offset_ = bytecode_offset;
+  site.rank_ = rank;
 
   base::MutexGuard lock(gInstrumentationSitesMutex);
 
@@ -1368,8 +1369,8 @@ int InstrumentationSiteSourcePosition(int index) {
   return GetInstrumentationSite("SourcePosition", index).source_position_;
 }
 
-int InstrumentationSiteBytecodeOffset(int index) {
-  return GetInstrumentationSite("BytecodeOffset", index).bytecode_offset_;
+int InstrumentationSiteRank(int index) {
+  return GetInstrumentationSite("Rank", index).rank_;
 }
 
 void RecordReplayInitInstrumentationState() {
@@ -1434,7 +1435,7 @@ static inline void OnInstrumentation(Isolate* isolate,
   }
 
   RecordReplayInstrument(site.kind_, site.function_id_.c_str(),
-                         site.bytecode_offset_);
+                         site.rank_);
 }
 
 extern bool gRecordReplayInstrumentationEnabled;

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1305,7 +1305,7 @@ struct InstrumentationSite {
   const char* kind_ = nullptr;
   int source_position_ = 0;
   // The index of this site within its function.
-  int rank_ = 0;
+  int function_index_ = 0;
 
   // Set on the first use of the instrumentation site.
   std::string function_id_;
@@ -1333,11 +1333,11 @@ static void CopyMainThreadInstrumentationSites() {
 }
 
 int RegisterInstrumentationSite(const char* kind, int source_position,
-                                int rank) {
+                                int function_index) {
   InstrumentationSite site;
   site.kind_ = kind;
   site.source_position_ = source_position;
-  site.rank_ = rank;
+  site.function_index_ = function_index;
 
   base::MutexGuard lock(gInstrumentationSitesMutex);
 
@@ -1369,8 +1369,8 @@ int InstrumentationSiteSourcePosition(int index) {
   return GetInstrumentationSite("SourcePosition", index).source_position_;
 }
 
-int InstrumentationSiteRank(int index) {
-  return GetInstrumentationSite("Rank", index).rank_;
+int InstrumentationSiteFunctionIndex(int index) {
+  return GetInstrumentationSite("Rank", index).function_index_;
 }
 
 void RecordReplayInitInstrumentationState() {
@@ -1382,7 +1382,7 @@ void RecordReplayInitInstrumentationState() {
   gMainThreadInstrumentationSites = new InstrumentationSiteVector();
 }
 
-extern void RecordReplayInstrument(const char* kind, const char* function, int offset);
+extern void RecordReplayInstrument(const char* kind, const char* function, int function_index);
 
 // Enable to dump locations of each function to stderr.
 static bool gDumpFunctionLocations;
@@ -1435,7 +1435,7 @@ static inline void OnInstrumentation(Isolate* isolate,
   }
 
   RecordReplayInstrument(site.kind_, site.function_id_.c_str(),
-                         site.rank_);
+                         site.function_index_);
 }
 
 extern bool gRecordReplayInstrumentationEnabled;


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1163
* https://linear.app/replay/issue/TT-4/fix-gethitcounts-replace-breakpoint-offsets-with-more-consistent-ids#comment-a7bbd0f6