### PR TITLE
[TT-743] Disallow events in Heap::CollectGarbageOnMemoryPressure

### DIFF
--- a/src/heap/heap.cc
+++ b/src/heap/heap.cc
@@ -3999,6 +3999,8 @@ void Heap::CheckMemoryPressure() {
 }
 
 void Heap::CollectGarbageOnMemoryPressure() {
+  recordreplay::AutoDisallowEvents disallow("Heap::CollectGarbageOnMemoryPressure");
+
   const int kGarbageThresholdInBytes = 8 * MB;
   const double kGarbageThresholdAsFractionOfTotalMemory = 0.1;
   // This constant is the maximum response time in RAIL performance model.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1167
* https://linear.app/replay/issue/TT-743/mismatch-in-heapcollectgarbageonmemorypressure#comment-6aa5a5b5