### PR TITLE
Expose V8RecordReplayAddMetadata

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11830,6 +11830,10 @@ extern "C" void V8RecordReplayNotifyActivity() {
   gRecordReplayNotifyActivity();
 }
 
+extern "C" void V8RecordReplayAddMetadata(const char* jsonString) {
+  gRecordReplayAddMetadata(jsonString);
+}
+
 extern "C" DLLEXPORT void V8RecordReplayOnAnnotation(const char* kind, const char* contents) {
   DCHECK(recordreplay::IsRecordingOrReplaying());
   if (internal::gRecordReplayHasCheckpoint) {


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1176
* https://linear.app/replay/issue/TT-211/mark-iframesextensionsdevtools-recordings-with-different-metadata