### PR TITLE
Remove Assert warnings due to promise hooks

### DIFF
--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -5048,7 +5048,11 @@ void Isolate::PromiseHookStateUpdated() {
     );
     g_record_replay_recording_hooks_enabled = (int)v8::recordreplay::RecordReplayValue(
       "hooks-enabled",
-      (uintptr_t)!!(promise_hook_ || RecordReplayShouldCallOnPromiseHook())
+      (uintptr_t)!!(promise_hook_flags_ & (
+        Isolate::PromiseHookFields::HasIsolatePromiseHook::kMask |
+        Isolate::PromiseHookFields::HasAsyncEventDelegate::kMask |
+        Isolate::PromiseHookFields::IsDebugActive::kMask
+      ))
     );
   }
 

--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -5048,7 +5048,7 @@ void Isolate::PromiseHookStateUpdated() {
     );
     g_record_replay_recording_hooks_enabled = (int)v8::recordreplay::RecordReplayValue(
       "hooks-enabled",
-      (uintptr_t)!!promise_hook_
+      (uintptr_t)!!(promise_hook_ || RecordReplayShouldCallOnPromiseHook())
     );
   }
 


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1183
* https://linear.app/replay/issue/TT-844/many-runtime-promise-hook-warnings-when-asserting-on-tracked-objects#comment-623d803f