### PR TITLE
Assert JSPromise::set_has_handler

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -7979,6 +7979,8 @@ Promise::PromiseState Promise::State() {
 
 void Promise::MarkAsHandled() {
   i::Handle<i::JSPromise> js_promise = Utils::OpenHandle(this);
+
+  recordreplay::Assert("[TT-187-935] Promise::MarkAsHandled");
   js_promise->set_has_handler(true);
 }
 

--- a/src/compiler/js-call-reducer.cc
+++ b/src/compiler/js-call-reducer.cc
@@ -70,6 +70,7 @@ class JSCallReducerAssembler : public JSGraphAssembler {
     // Finish initializing the outermost catch scope.
     bool has_handler =
         NodeProperties::IsExceptionalCall(node, &outermost_handler_);
+    recordreplay::Assert("[TT-187-935] JSCallReducerAssembler %d", has_handler);
     outermost_catch_scope_.set_has_handler(has_handler);
     outermost_catch_scope_.set_gasm(this);
   }

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -849,6 +849,7 @@ RUNTIME_FUNCTION(Runtime_DebugAsyncFunctionSuspended) {
 
   // The Promise will be thrown away and not handled, but it
   // shouldn't trigger unhandled reject events as its work is done
+  recordreplay::Assert("[TT-187-935] Runtime_DebugAsyncFunctionSuspended");
   throwaway->set_has_handler(true);
 
   // Enable proper debug support for promises.


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1189
* https://linear.app/replay/issue/TT-187/[superblocks]-mismatch-involving-promisereject#comment-663e6944