### PR TITLE
[TT-187] Don't report in `JSPromise::Reject` if recording did not have a handler

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -7979,8 +7979,6 @@ Promise::PromiseState Promise::State() {
 
 void Promise::MarkAsHandled() {
   i::Handle<i::JSPromise> js_promise = Utils::OpenHandle(this);
-
-  recordreplay::Assert("[TT-187-935] Promise::MarkAsHandled");
   js_promise->set_has_handler(true);
 }
 

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11282,8 +11282,6 @@ extern "C" DLLEXPORT void V8RecordReplayTrace(const char* format,
 }
 
 extern "C" DLLEXPORT void V8RecordReplayCrash(const char* format, va_list args) {
-  DCHECK(recordreplay::IsRecordingOrReplaying());
-
   char str[4096];
   vsnprintf(str, sizeof(str), format, args);
   str[sizeof(str) - 1] = 0;

--- a/src/base/replayio.h
+++ b/src/base/replayio.h
@@ -14,7 +14,6 @@
 #include "src/base/optional.h"
 
 namespace v8 {
-namespace base {
 namespace replayio {
 
 struct AutoMaybeDisallowEvents {
@@ -29,7 +28,6 @@ private:
 };
 
 }  // namespace replayio
-}  // namespace base
 }  // namespace v8
 
 #endif  // V8_BASE_REPLAYIO_H

--- a/src/compiler/js-call-reducer.cc
+++ b/src/compiler/js-call-reducer.cc
@@ -70,7 +70,6 @@ class JSCallReducerAssembler : public JSGraphAssembler {
     // Finish initializing the outermost catch scope.
     bool has_handler =
         NodeProperties::IsExceptionalCall(node, &outermost_handler_);
-    recordreplay::Assert("[TT-187-935] JSCallReducerAssembler %d", has_handler);
     outermost_catch_scope_.set_has_handler(has_handler);
     outermost_catch_scope_.set_gasm(this);
   }

--- a/src/inspector/v8-runtime-agent-impl.cc
+++ b/src/inspector/v8-runtime-agent-impl.cc
@@ -874,7 +874,7 @@ Response V8RuntimeAgentImpl::getExceptionDetails(
 void V8RuntimeAgentImpl::bindingCalled(const String16& name,
                                        const String16& payload,
                                        int executionContextId) {
-  v8::base::replayio::AutoMaybeDisallowEvents disallow(
+  v8::replayio::AutoMaybeDisallowEvents disallow(
       m_replay_owned, "V8RuntimeAgentImpl::bindingCalled");
 
   if (!m_activeBindings.count(name)) return;
@@ -903,7 +903,7 @@ void V8RuntimeAgentImpl::addBindings(InspectedContext* context) {
 }
 
 void V8RuntimeAgentImpl::restore() {
-  v8::base::replayio::AutoMaybeDisallowEvents disallow(m_replay_owned,
+  v8::replayio::AutoMaybeDisallowEvents disallow(m_replay_owned,
                                                "V8RuntimeAgentImpl::restore");
 
   if (!m_state->booleanProperty(V8RuntimeAgentImplState::runtimeEnabled, false))
@@ -964,7 +964,7 @@ Response V8RuntimeAgentImpl::disable() {
 }
 
 void V8RuntimeAgentImpl::reset() {
-  v8::base::replayio::AutoMaybeDisallowEvents disallow(m_replay_owned,
+  v8::replayio::AutoMaybeDisallowEvents disallow(m_replay_owned,
                                                "V8RuntimeAgentImpl::reset");
 
   m_compiledScripts.clear();
@@ -980,7 +980,7 @@ void V8RuntimeAgentImpl::reset() {
 
 void V8RuntimeAgentImpl::reportExecutionContextCreated(
     InspectedContext* context) {
-  v8::base::replayio::AutoMaybeDisallowEvents disallow(
+  v8::replayio::AutoMaybeDisallowEvents disallow(
       m_replay_owned, "V8RuntimeAgentImpl::reportExecutionContextCreated");
 
   if (!m_enabled) return;
@@ -1005,7 +1005,7 @@ void V8RuntimeAgentImpl::reportExecutionContextCreated(
 
 void V8RuntimeAgentImpl::reportExecutionContextDestroyed(
     InspectedContext* context) {
-  v8::base::replayio::AutoMaybeDisallowEvents disallow(
+  v8::replayio::AutoMaybeDisallowEvents disallow(
       m_replay_owned, "V8RuntimeAgentImpl::reportExecutionContextDestroyed");
 
   if (m_enabled && context->isReported(m_session->sessionId())) {
@@ -1017,7 +1017,7 @@ void V8RuntimeAgentImpl::reportExecutionContextDestroyed(
 void V8RuntimeAgentImpl::inspect(
     std::unique_ptr<protocol::Runtime::RemoteObject> objectToInspect,
     std::unique_ptr<protocol::DictionaryValue> hints, int executionContextId) {
-  v8::base::replayio::AutoMaybeDisallowEvents disallow(m_replay_owned,
+  v8::replayio::AutoMaybeDisallowEvents disallow(m_replay_owned,
                                                "V8RuntimeAgentImpl::inspect");
 
   if (m_enabled)
@@ -1031,7 +1031,7 @@ void V8RuntimeAgentImpl::messageAdded(V8ConsoleMessage* message) {
 
 bool V8RuntimeAgentImpl::reportMessage(V8ConsoleMessage* message,
                                        bool generatePreview) {
-  v8::base::replayio::AutoMaybeDisallowEvents disallow(
+  v8::replayio::AutoMaybeDisallowEvents disallow(
       m_replay_owned, "V8RuntimeAgentImpl::reportMessage");
 
   message->reportToFrontend(&m_frontend, m_session, generatePreview);

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -855,11 +855,11 @@ RUNTIME_FUNCTION(Runtime_DebugAsyncFunctionSuspended) {
   isolate->OnAsyncFunctionSuspended(throwaway, promise);
 
   if (IsMainThread()) {
-    // The Promise will be thrown away and not handled, but it
-    // shouldn't trigger unhandled reject events as its work is done
     recordreplay::AssertMaybeEventsDisallowed(
         "[TT-187-935] Runtime_DebugAsyncFunctionSuspended");
   }
+  // The Promise will be thrown away and not handled, but it
+  // shouldn't trigger unhandled reject events as its work is done
   throwaway->set_has_handler(true);
 
   // Enable proper debug support for promises.

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -139,6 +139,7 @@ RUNTIME_FUNCTION(Runtime_DebugBreakAtEntry) {
   return ReadOnlyRoots(isolate).undefined_value();
 }
 
+extern int g_record_replay_recording_hooks_enabled;
 extern "C" void V8RecordReplayOnDebuggerStatement();
 
 RUNTIME_FUNCTION(Runtime_HandleDebuggerStatement) {

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -34,6 +34,7 @@
 #endif
 
 #include "src/api/api-inl.h"
+#include "src/base/replayio.h"
 
 namespace v8 {
 namespace internal {
@@ -836,7 +837,7 @@ RUNTIME_FUNCTION(Runtime_IncBlockCounter) {
 RUNTIME_FUNCTION(Runtime_DebugAsyncFunctionSuspended) {
   DCHECK_EQ(5, args.length());
 
-  v8::base::replayio::AutoMaybeDisallowEvents disallow(
+  v8::replayio::AutoMaybeDisallowEvents disallow(
       IsMainThread() && !g_record_replay_recording_hooks_enabled,
       "Runtime_DebugAsyncFunctionSuspended");
 

--- a/src/runtime/runtime-promise.cc
+++ b/src/runtime/runtime-promise.cc
@@ -113,7 +113,7 @@ extern int g_record_replay_recording_hooks_enabled;
 
 RUNTIME_FUNCTION(Runtime_PromiseHookInit) {
   // [TT-187] This is divergent if the recorder did not have hooks enabled.
-  v8::base::replayio::AutoMaybeDisallowEvents disallow(
+  v8::replayio::AutoMaybeDisallowEvents disallow(
     IsMainThread() &&
       !g_record_replay_recording_hooks_enabled,
     "Runtime_PromiseHookInit"
@@ -129,7 +129,7 @@ RUNTIME_FUNCTION(Runtime_PromiseHookInit) {
 
 RUNTIME_FUNCTION(Runtime_PromiseHookBefore) {
   // [TT-187] This is divergent if the recorder did not have hooks enabled.
-  v8::base::replayio::AutoMaybeDisallowEvents disallow(
+  v8::replayio::AutoMaybeDisallowEvents disallow(
     IsMainThread() &&
       !g_record_replay_recording_hooks_enabled,
     "Runtime_PromiseHookBefore"
@@ -146,7 +146,7 @@ RUNTIME_FUNCTION(Runtime_PromiseHookBefore) {
 
 RUNTIME_FUNCTION(Runtime_PromiseHookAfter) {
   // [TT-187] This is divergent if the recorder did not have hooks enabled.
-  v8::base::replayio::AutoMaybeDisallowEvents disallow(
+  v8::replayio::AutoMaybeDisallowEvents disallow(
     IsMainThread() &&
       !g_record_replay_recording_hooks_enabled,
     "Runtime_PromiseHookAfter"
@@ -171,7 +171,7 @@ RUNTIME_FUNCTION(Runtime_RejectPromise) {
   // [TT-187] This is divergent if promise has handler and neither hooks nor
   // debugger were enabled during recording, as per
   // promise-abstract-operations.tq.
-  v8::base::replayio::AutoMaybeDisallowEvents disallow(
+  v8::replayio::AutoMaybeDisallowEvents disallow(
     IsMainThread() &&
       promise->has_handler() &&
       !g_record_replay_recording_debug_enabled &&


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1193
* SLN: https://linear.app/replay/issue/TT-187/[superblocks]-mismatch-involving-promisereject#comment-191d5fc4
* Improved Asserts: https://linear.app/replay/issue/TT-187/[superblocks]-mismatch-involving-promisereject#comment-2ef701e6