### PR TITLE
Don't crash in `GetScriptLocationString`  when not on main thread

### DIFF
--- a/include/v8.h
+++ b/include/v8.h
@@ -83,6 +83,9 @@ class Platform;
  * \example process.cc
  */
 
+/**
+ * @deprecated Use |recordreplay::IsMainThread| instead
+ */
 bool IsMainThread();
 
 // Static container class for record/replay methods.
@@ -144,6 +147,14 @@ static bool IsInReplayCode(const char* why = nullptr);
 static bool HasDivergedFromRecording();
 static bool AllowSideEffects();
 
+static void RegisterPointer(const char* name, const void* ptr);
+static void UnregisterPointer(const void* ptr);
+static int PointerId(const void* ptr);
+static void* IdPointer(int id);
+
+static bool IsMainThread();
+static size_t GetCurrentThreadId();
+
 static int NewDependencyGraphNode(const char* json);
 static void AddDependencyGraphEdge(int source, int target, const char* json);
 static void BeginDependencyExecution(int node);
@@ -190,11 +201,6 @@ struct AutoAssertBufferAllocations {
   AutoAssertBufferAllocations(const char* issueLabel = "");
   ~AutoAssertBufferAllocations();
 };
-
-static void RegisterPointer(const char* name, const void* ptr);
-static void UnregisterPointer(const void* ptr);
-static int PointerId(const void* ptr);
-static void* IdPointer(int id);
 
 }; // class recordreplay
 

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1007,6 +1007,13 @@ static inline std::string GetScriptName(Handle<Script> script) {
 }
 
 std::string GetScriptLocationString(int script_id, int start_position) {
+  if (!IsMainThread()) {
+    // We might sometimes call this from another thread, e.g. when
+    // dumping after a hang.
+    std::ostringstream os;
+    os << script_id << "@" << start_position;
+    return os.str();
+  }
   Isolate* isolate = Isolate::Current();
   Handle<Script> script = GetScript(isolate, script_id);
   std::string script_name = GetScriptName(script);

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1007,7 +1007,7 @@ static inline std::string GetScriptName(Handle<Script> script) {
 }
 
 std::string GetScriptLocationString(int script_id, int start_position) {
-  if (!IsMainThread()) {
+  if (!recordreplay::IsMainThread()) {
     // We might sometimes call this from another thread, e.g. when
     // dumping after a hang.
     std::ostringstream os;

--- a/src/runtime/runtime-internal.cc
+++ b/src/runtime/runtime-internal.cc
@@ -197,7 +197,7 @@ RUNTIME_FUNCTION(Runtime_UnwindAndFindExceptionHandler) {
   // frame unwind instead of an initial throw and we can ignore it.
   if (recordreplay::IsRecordingOrReplaying() &&
       !recordreplay::AreEventsDisallowed() &&
-      IsMainThread() &&
+      recordreplay::IsMainThread() &&
       *gProgressCounter != gLastExceptionUnwindProgress) {
     RecordReplayOnExceptionUnwind(isolate);
     gLastExceptionUnwindProgress = *gProgressCounter;


### PR DESCRIPTION
* paired w/
  * https://github.com/replayio/chromium/pull/1221
  * https://github.com/replayio/backend/pull/10111
* https://linear.app/replay/issue/TT-1127/crash-when-dumping-asserts-after-hang-with-record-replay-js-progress#comment-e9a2507f