### PR TITLE
[TT-1177] Add `HandleScope` to `GetScriptLocationString`

### DIFF
--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1008,6 +1008,7 @@ static inline std::string GetScriptName(Handle<Script> script) {
 
 std::string GetScriptLocationString(int script_id, int start_position) {
   Isolate* isolate = Isolate::Current();
+  HandleScope scope(isolate);
   Handle<Script> script = GetScript(isolate, script_id);
   std::string script_name = GetScriptName(script);
 


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1231
* https://linear.app/replay/issue/TT-1177/js-asserts-cannot-create-a-handle-without-a-handlescope#comment-9b70b9b6