### PR TITLE
[TT-492] force slowpath in value serializer

### DIFF
--- a/src/objects/value-serializer.cc
+++ b/src/objects/value-serializer.cc
@@ -670,10 +670,10 @@ Maybe<bool> ValueSerializer::WriteJSReceiver(Handle<JSReceiver> receiver) {
 
 Maybe<bool> ValueSerializer::WriteJSObject(Handle<JSObject> object) {
   DCHECK(!object->map().IsCustomElementsReceiverMap());
-  // [TT-492] slow path all serialization so we're guaranteed to always match
-  const bool can_serialize_fast = false;
-  // const bool can_serialize_fast =
-  //     object->HasFastProperties(isolate_) && object->elements().length() == 0;
+  const bool can_serialize_fast =
+    // [TT-492] slow path all serialization so we're guaranteed to always match
+    !recordreplay::IsRecordingOrReplaying("values", "ValueSerializer::WriteJSObject") &&
+    object->HasFastProperties(isolate_) && object->elements().length() == 0;
 
   if (recordreplay::HasAsserts()) {
     recordreplay::AssertBufferAllocationState* bufferAssertsState =
@@ -758,10 +758,10 @@ Maybe<bool> ValueSerializer::WriteJSArray(Handle<JSArray> array) {
   // existed (as only indices which were enumerable own properties at this point
   // should be serialized).
 
-  // [TT-492] slow path all serialization so we're guaranteed to always match
-  const bool should_serialize_densely = false;
-  // const bool should_serialize_densely =
-  //     array->HasFastElements(cage_base) && !array->HasHoleyElements(cage_base);
+  const bool should_serialize_densely =
+    // [TT-492] slow path all serialization so we're guaranteed to always match
+    !recordreplay::IsRecordingOrReplaying("values", "ValueSerializer::WriteJSObject") &&
+    array->HasFastElements(cage_base) && !array->HasHoleyElements(cage_base);
 
   if (recordreplay::HasAsserts()) {
     recordreplay::AssertBufferAllocationState* bufferAssertsState =

--- a/src/objects/value-serializer.cc
+++ b/src/objects/value-serializer.cc
@@ -760,7 +760,7 @@ Maybe<bool> ValueSerializer::WriteJSArray(Handle<JSArray> array) {
 
   const bool should_serialize_densely =
     // [TT-492] slow path all serialization so we're guaranteed to always match
-    !recordreplay::IsRecordingOrReplaying("values", "ValueSerializer::WriteJSObject") &&
+    !recordreplay::IsRecordingOrReplaying("values", "ValueSerializer::WriteJSArray") &&
     array->HasFastElements(cage_base) && !array->HasHoleyElements(cage_base);
 
   if (recordreplay::HasAsserts()) {

--- a/src/objects/value-serializer.cc
+++ b/src/objects/value-serializer.cc
@@ -361,7 +361,7 @@ void ValueSerializer::WriteRawBytes(const void* source, size_t length) {
 
 Maybe<uint8_t*> ValueSerializer::ReserveRawBytes(size_t bytes) {
   if (recordreplay::HasAsserts()) {
-    recordreplay::AssertBufferAllocationState* bufferAssertsState = 
+    recordreplay::AssertBufferAllocationState* bufferAssertsState =
       recordreplay::AutoAssertBufferAllocations::GetState();
     if (bufferAssertsState) {
       recordreplay::Diagnostic("ValueSerializer::ReserveRawBytes");
@@ -441,9 +441,9 @@ Maybe<bool> ValueSerializer::WriteObject(Handle<Object> object) {
   // memory. Bail immediately, as this likely implies that some write has
   // previously failed and so the buffer is corrupt.
   if (V8_UNLIKELY(out_of_memory_)) return ThrowIfOutOfMemory();
-  
+
   if (recordreplay::HasAsserts()) {
-    recordreplay::AssertBufferAllocationState* bufferAssertsState = 
+    recordreplay::AssertBufferAllocationState* bufferAssertsState =
       recordreplay::AutoAssertBufferAllocations::GetState();
     if (bufferAssertsState) {
       recordreplay::Assert("[%s] ValueSerializer::WriteObject %d",
@@ -670,10 +670,13 @@ Maybe<bool> ValueSerializer::WriteJSReceiver(Handle<JSReceiver> receiver) {
 
 Maybe<bool> ValueSerializer::WriteJSObject(Handle<JSObject> object) {
   DCHECK(!object->map().IsCustomElementsReceiverMap());
-  const bool can_serialize_fast =
-      object->HasFastProperties(isolate_) && object->elements().length() == 0;
+  // [TT-492] slow path all serialization so we're guaranteed to always match
+  const bool can_serialize_fast = false;
+  // const bool can_serialize_fast =
+  //     object->HasFastProperties(isolate_) && object->elements().length() == 0;
+
   if (recordreplay::HasAsserts()) {
-    recordreplay::AssertBufferAllocationState* bufferAssertsState = 
+    recordreplay::AssertBufferAllocationState* bufferAssertsState =
       recordreplay::AutoAssertBufferAllocations::GetState();
     if (bufferAssertsState) {
       recordreplay::Assert("[%s] ValueSerializer::WriteJSObject %d %d",
@@ -754,10 +757,14 @@ Maybe<bool> ValueSerializer::WriteJSArray(Handle<JSArray> array) {
   // count the elements, but would need to take care to note which indices
   // existed (as only indices which were enumerable own properties at this point
   // should be serialized).
-  const bool should_serialize_densely =
-      array->HasFastElements(cage_base) && !array->HasHoleyElements(cage_base);
+
+  // [TT-492] slow path all serialization so we're guaranteed to always match
+  const bool should_serialize_densely = false;
+  // const bool should_serialize_densely =
+  //     array->HasFastElements(cage_base) && !array->HasHoleyElements(cage_base);
+
   if (recordreplay::HasAsserts()) {
-    recordreplay::AssertBufferAllocationState* bufferAssertsState = 
+    recordreplay::AssertBufferAllocationState* bufferAssertsState =
       recordreplay::AutoAssertBufferAllocations::GetState();
     if (bufferAssertsState) {
       recordreplay::Assert("[%s] ValueSerializer::WriteJSArray %d %d %d",


### PR DESCRIPTION
Disable switching serialization formats based on storage representations for JS objects and arrays.

counterpart to https://github.com/replayio/chromium/pull/1251