### PR TITLE
Fix mismatches when dependency graph is enabled

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -7907,20 +7907,12 @@ Maybe<bool> Promise::Resolver::Reject(Local<Context> context,
   auto self = Utils::OpenHandle(this);
   auto promise = i::Handle<i::JSPromise>::cast(self);
 
-  recordreplay::Assert("[TT-1361] Promise::Resolver::Reject Start %d", promise->has_handler());
-
   if (promise->status() != Promise::kPending) {
-    recordreplay::Assert("[TT-1361] Promise::Resolver::Reject #1");
     return Just(true);
   }
 
-  recordreplay::Assert("[TT-1361] Promise::Resolver::Reject #2");
-
   has_pending_exception =
       i::JSPromise::Reject(promise, Utils::OpenHandle(*value)).is_null();
-
-  recordreplay::Assert("[TT-1361] Promise::Resolver::Reject #3");
-
   RETURN_ON_FAILED_EXECUTION_PRIMITIVE(bool);
   return Just(true);
 }
@@ -12174,7 +12166,7 @@ ForEachRecordReplaySymbolVoid(LoadRecordReplaySymbolVoid)
 
   // Currently the dependency graph is disabled by default.
   i::gRecordReplayEnableDependencyGraph =
-    V8RecordReplayFeatureEnabled("v8-dependency-graph", nullptr);
+    V8RecordReplayFeatureEnabled("dependency-graph", "v8");
 
   // Disable wasm background compilation.
   if (V8RecordReplayFeatureEnabled("disable-v8-flags-wasm-compilation-tasks", nullptr)) {

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -7907,12 +7907,20 @@ Maybe<bool> Promise::Resolver::Reject(Local<Context> context,
   auto self = Utils::OpenHandle(this);
   auto promise = i::Handle<i::JSPromise>::cast(self);
 
+  recordreplay::Assert("[TT-1029-1030] Promise::Resolver::Reject");
+
   if (promise->status() != Promise::kPending) {
+    recordreplay::Assert("[TT-1029-1030] Promise::Resolver::Reject #1");
     return Just(true);
   }
 
+  recordreplay::Assert("[TT-1029-1030] Promise::Resolver::Reject #2");
+
   has_pending_exception =
       i::JSPromise::Reject(promise, Utils::OpenHandle(*value)).is_null();
+
+  recordreplay::Assert("[TT-1029-1030] Promise::Resolver::Reject #3");
+
   RETURN_ON_FAILED_EXECUTION_PRIMITIVE(bool);
   return Just(true);
 }

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -12174,7 +12174,7 @@ ForEachRecordReplaySymbolVoid(LoadRecordReplaySymbolVoid)
 
   // Currently the dependency graph is disabled by default.
   i::gRecordReplayEnableDependencyGraph =
-    V8RecordReplayFeatureEnabled("dependency-graph", nullptr);
+    V8RecordReplayFeatureEnabled("v8-dependency-graph", nullptr);
 
   // Disable wasm background compilation.
   if (V8RecordReplayFeatureEnabled("disable-v8-flags-wasm-compilation-tasks", nullptr)) {

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -7907,19 +7907,19 @@ Maybe<bool> Promise::Resolver::Reject(Local<Context> context,
   auto self = Utils::OpenHandle(this);
   auto promise = i::Handle<i::JSPromise>::cast(self);
 
-  recordreplay::Assert("[TT-1029-1030] Promise::Resolver::Reject");
+  recordreplay::Assert("[TT-1361] Promise::Resolver::Reject %d", promise->has_handler());
 
   if (promise->status() != Promise::kPending) {
-    recordreplay::Assert("[TT-1029-1030] Promise::Resolver::Reject #1");
+    recordreplay::Assert("[TT-1361] Promise::Resolver::Reject #1");
     return Just(true);
   }
 
-  recordreplay::Assert("[TT-1029-1030] Promise::Resolver::Reject #2");
+  recordreplay::Assert("[TT-1361] Promise::Resolver::Reject #2");
 
   has_pending_exception =
       i::JSPromise::Reject(promise, Utils::OpenHandle(*value)).is_null();
 
-  recordreplay::Assert("[TT-1029-1030] Promise::Resolver::Reject #3");
+  recordreplay::Assert("[TT-1361] Promise::Resolver::Reject #3");
 
   RETURN_ON_FAILED_EXECUTION_PRIMITIVE(bool);
   return Just(true);

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -7907,7 +7907,7 @@ Maybe<bool> Promise::Resolver::Reject(Local<Context> context,
   auto self = Utils::OpenHandle(this);
   auto promise = i::Handle<i::JSPromise>::cast(self);
 
-  recordreplay::Assert("[TT-1361] Promise::Resolver::Reject %d", promise->has_handler());
+  recordreplay::Assert("[TT-1361] Promise::Resolver::Reject Start %d", promise->has_handler());
 
   if (promise->status() != Promise::kPending) {
     recordreplay::Assert("[TT-1361] Promise::Resolver::Reject #1");

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -4267,10 +4267,10 @@ void RecordReplayOnPromiseHook(Isolate* isolate, PromiseHookType type,
     return;
   }
 
-  // The promise hook is normally only needed when replaying, but can assign
-  // persistent IDs to objects so needs to be called while recording if we are
-  // asserting on these.
-  if (!IsReplaying() && !gRecordReplayAssertTrackedObjects) {
+  // The promise hook only needs to report nodes/edges while replaying,
+  // but can assign persistent IDs to objects so the calls below are needed
+  // while recording if we are asserting on those IDs.
+  if (!recordreplay::IsReplaying() && !gRecordReplayAssertTrackedObjects) {
     return;
   }
 

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -4256,6 +4256,8 @@ bool RecordReplayShouldCallOnPromiseHook() {
   // the hook gets called have effects on the state of certain promises that
   // affect how the process behaves and are not fully understood.
   //
+  // See https://linear.app/replay/issue/TT-1361
+  //
   // For now we workaround this problem by setting this state consistently and
   // add a small amount of recording overhead.
   return gRecordReplayEnableDependencyGraph && IsMainThread();

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -4255,6 +4255,7 @@ bool RecordReplayShouldCallOnPromiseHook() {
   // persistent IDs to objects so needs to be called while recording if we are
   // asserting on these.
   return gRecordReplayEnableDependencyGraph
+      && FeatureEnabled("call-on-promise-hook")
       && (recordreplay::IsReplaying() || gRecordReplayAssertTrackedObjects)
       && IsMainThread();
 }

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -4255,7 +4255,7 @@ bool RecordReplayShouldCallOnPromiseHook() {
   // persistent IDs to objects so needs to be called while recording if we are
   // asserting on these.
   return gRecordReplayEnableDependencyGraph
-      && FeatureEnabled("call-on-promise-hook")
+      && recordreplay::FeatureEnabled("call-on-promise-hook")
       && (recordreplay::IsReplaying() || gRecordReplayAssertTrackedObjects)
       && IsMainThread();
 }

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -4251,20 +4251,26 @@ GetOrCreatePromiseDependencyGraphData(Isolate* isolate, Handle<Object> promise) 
 extern bool gRecordReplayEnableDependencyGraph;
 
 bool RecordReplayShouldCallOnPromiseHook() {
-  // The promise hook is normally only used when replaying, but can assign
-  // persistent IDs to objects so needs to be called while recording if we are
-  // asserting on these.
-  return gRecordReplayEnableDependencyGraph
-      && recordreplay::FeatureEnabled("call-on-promise-hook")
-      && (recordreplay::IsReplaying() || gRecordReplayAssertTrackedObjects)
-      && IsMainThread();
+  // Ideally we would be able to avoid calling the promise hook when recording
+  // and its results aren't needed, but the isolate state we set to ensure
+  // the hook gets called have effects on the state of certain promises that
+  // affect how the process behaves and are not fully understood.
+  //
+  // For now we workaround this problem by setting this state consistently and
+  // add a small amount of recording overhead.
+  return gRecordReplayEnableDependencyGraph && IsMainThread();
 }
 
 void RecordReplayOnPromiseHook(Isolate* isolate, PromiseHookType type,
                                Handle<JSPromise> promise, Handle<Object> parent) {
-  CHECK(RecordReplayShouldCallOnPromiseHook());
-
   if (!gRecordReplayEnableDependencyGraph) {
+    return;
+  }
+
+  // The promise hook is normally only needed when replaying, but can assign
+  // persistent IDs to objects so needs to be called while recording if we are
+  // asserting on these.
+  if (!IsReplaying() && !gRecordReplayAssertTrackedObjects) {
     return;
   }
 

--- a/src/objects/objects.cc
+++ b/src/objects/objects.cc
@@ -5523,8 +5523,6 @@ Handle<Object> JSPromise::Reject(Handle<JSPromise> promise,
   DCHECK(
       !reinterpret_cast<v8::Isolate*>(isolate)->GetCurrentContext().IsEmpty());
 
-  recordreplay::Assert("[TT-1361] JSPromise::Reject %d", promise->has_handler());
-
   if (isolate->debug()->is_active()) MoveMessageToPromise(isolate, promise);
 
   if (debug_event) isolate->debug()->OnPromiseReject(promise, reason);

--- a/src/objects/objects.cc
+++ b/src/objects/objects.cc
@@ -5543,21 +5543,16 @@ Handle<Object> JSPromise::Reject(Handle<JSPromise> promise,
   // 6. Set promise.[[PromiseState]] to "rejected".
   promise->set_status(Promise::kRejected);
 
-  {
-    v8::replayio::AutoMaybeDisallowEvents disallow(promise->has_handler(),
-                                                   "[TT-1029-1030] JSPromise::Reject %d");
-
-    // 7. If promise.[[PromiseIsHandled]] is false, perform
-    //    HostPromiseRejectionTracker(promise, "reject").
-    if (!promise->has_handler()) {
-      isolate->ReportPromiseReject(promise, reason,
-                                   kPromiseRejectWithNoHandler);
-    }
-
-    // 8. Return TriggerPromiseReactions(reactions, reason).
-    return TriggerPromiseReactions(isolate, reactions, reason,
-                                   PromiseReaction::kReject);
+  // 7. If promise.[[PromiseIsHandled]] is false, perform
+  //    HostPromiseRejectionTracker(promise, "reject").
+  if (!promise->has_handler()) {
+    isolate->ReportPromiseReject(promise, reason,
+                                 kPromiseRejectWithNoHandler);
   }
+
+  // 8. Return TriggerPromiseReactions(reactions, reason).
+  return TriggerPromiseReactions(isolate, reactions, reason,
+                                 PromiseReaction::kReject);
 }
 
 // https://tc39.es/ecma262/#sec-promise-resolve-functions

--- a/src/objects/objects.cc
+++ b/src/objects/objects.cc
@@ -5523,6 +5523,8 @@ Handle<Object> JSPromise::Reject(Handle<JSPromise> promise,
   DCHECK(
       !reinterpret_cast<v8::Isolate*>(isolate)->GetCurrentContext().IsEmpty());
 
+  recordreplay::Assert("[TT-1361] JSPromise::Reject %d", promise->has_handler());
+
   if (isolate->debug()->is_active()) MoveMessageToPromise(isolate, promise);
 
   if (debug_event) isolate->debug()->OnPromiseReject(promise, reason);


### PR DESCRIPTION
https://linear.app/replay/issue/TT-1361/%5Bsuperblocks-framercom-replit%5D-mismatch-in-jspromisereject