### PR TITLE
[TT-1390] Fix exception reporting for our own sourcemap scripts

### DIFF
--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3771,7 +3771,7 @@ static void RecordReplayRegisterScript(Handle<Script> script) {
 
   if (!strcmp(url.c_str(), "record-replay-internal")) {
     // [TT-1390] Hackfix to not register the sourcemap handling script.
-    // We will have a better fix in the upcoming patch for TT-1111.
+    // We will have a better fix in the upcoming patch for TT-1112.
     return;
   }
 

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3769,6 +3769,12 @@ static void RecordReplayRegisterScript(Handle<Script> script) {
     url = name.get();
   }
 
+  if (!strcmp(url.c_str(), "record-replay-internal")) {
+    // [TT-1390] Hackfix to not register the sourcemap handling script.
+    // We will have a better fix in the upcoming patch for TT-1111.
+    return;
+  }
+
   if (!RecordReplayIsInternalScriptURL(url.c_str())) {
     RecordReplayAddInterestingSource(url.c_str());
   }


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1267
* https://linear.app/replay/issue/TT-1390/fix-exception-reporting-for-our-own-sourcemap-scripts