### PR TITLE
[TT-1396] Prevent out-of-bounds access in `RecordReplayOnExceptionUnwind`

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -10967,14 +10967,16 @@ void RecordReplayOnExceptionUnwind(Isolate* isolate) {
       // information to get canonical location information.
       std::vector<FrameSummary> frames;
       it.frame()->Summarize(&frames);
-      auto& summary = frames.back().AsJavaScript();
-      Handle<SharedFunctionInfo> shared(summary.function()->shared(), isolate);
-      Handle<Object> script(shared->script(), isolate);
-      if (script->IsScript()) {
-        Handle<Script> casted_script = Handle<Script>::cast(script);
-        if (!RecordReplayHasRegisteredScript(*casted_script)) {
-          // Don't repor errors from unregistered.
-          return;
+      if (!frames.empty()) { // There might not always be a frame due to RUN-1920.
+        auto& summary = frames.back().AsJavaScript();
+        Handle<SharedFunctionInfo> shared(summary.function()->shared(), isolate);
+        Handle<Object> script(shared->script(), isolate);
+        if (script->IsScript()) {
+          Handle<Script> casted_script = Handle<Script>::cast(script);
+          if (!RecordReplayHasRegisteredScript(*casted_script)) {
+            // Don't repor errors from unregistered.
+            return;
+          }
         }
       }
     }

--- a/src/execution/messages.cc
+++ b/src/execution/messages.cc
@@ -761,6 +761,7 @@ bool ComputeLocation(Isolate* isolate, MessageLocation* target) {
     // information to get canonical location information.
     std::vector<FrameSummary> frames;
     it.frame()->Summarize(&frames);
+    CHECK(frames.size()); // There might not always be a frame due to RUN-1920.
     auto& summary = frames.back().AsJavaScript();
     Handle<SharedFunctionInfo> shared(summary.function()->shared(), isolate);
     Handle<Object> script(shared->script(), isolate);


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1268
* https://linear.app/replay/issue/TT-1396/fix-a-recorder-and-linker-crash-in-recordreplayonexceptionunwind#comment-f1881f1e