### PR TITLE
PRO-2368: runtime crash recording a nextjs 15 example app

### DIFF
--- a/src/execution/messages.cc
+++ b/src/execution/messages.cc
@@ -439,7 +439,8 @@ MaybeHandle<Object> ErrorUtils::FormatStackTrace(Isolate* isolate,
   }
 
   MaybeHandle<String> rv = builder.Finish();
-  if (recordreplay::IsRecordingOrReplaying("ErrorUtils::FormatStackTrace")) {
+  if (recordreplay::IsRecordingOrReplaying("ErrorUtils::FormatStackTrace") &&
+      !recordreplay::AreEventsDisallowed()) {
     // [PRO-1150] Replay Error.stack
     std::string str = rv.ToHandleChecked()->ToCString().get();
     recordreplay::RecordReplayString("ErrorUtils::FormatStackTrace", str);
@@ -1062,6 +1063,8 @@ MaybeHandle<Object> ErrorUtils::GetFormattedStack(
   if (error_stack->IsErrorStackData()) {
     Handle<ErrorStackData> error_stack_data =
         Handle<ErrorStackData>::cast(error_stack);
+    REPLAY_ASSERT(
+      "[PRO-2368] ErrorUtils::GetFormattedStack A %d", (int)error_stack_data->HasFormattedStack());
     if (error_stack_data->HasFormattedStack()) {
       return handle(error_stack_data->formatted_stack(), isolate);
     }
@@ -1072,7 +1075,10 @@ MaybeHandle<Object> ErrorUtils::GetFormattedStack(
         FormatStackTrace(isolate, error_object,
                          handle(error_stack_data->call_site_infos(), isolate)),
         Object);
-    error_stack_data->set_formatted_stack(*formatted_stack);
+    if (!recordreplay::AreEventsDisallowed()) {
+      // [PRO-2368] Don't cache the formatted stack during replay-only invocations.
+      error_stack_data->set_formatted_stack(*formatted_stack);
+    }
     return formatted_stack;
   }
 


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1352
* https://linear.app/replay/issue/PRO-2368/runtime-crash-recording-a-nextjs-15-example-app

## Problem
* As we can see in [the final crashreport](http://admin.replay.io/sessions/4bf73af0-02d9-4ed9-bc1f-928752998b5a/crash), the divergence was on the control flow during access of Error.stack:
  * recorded: we produced a fresh stack.
  * replayed: we accessed a previously produced/cached stack.

## SLN
* Do not cache Error.stack if events disallowed.
* Do not try to replay the error stack in FormatStackTrace when events disallowed.
* In Error.stack accessor: REPLAY_ASSERT on error stack existing (if not events disallowed).