### PR TITLE
Set proper `contextGroupId` for `resumeData`'s console message data collection

### DIFF
--- a/src/inspector/v8-console-message.cc
+++ b/src/inspector/v8-console-message.cc
@@ -580,6 +580,15 @@ void V8ConsoleMessageStorage::addMessage(
   // After notifying the inspector about the message, listeners will know about
   // the message contents if any commands are sent within RecordReplayOnConsoleMessage.
   if (message->origin() == V8MessageOrigin::kConsole && v8::IsMainThread()) {
+    // Preserve the originating inspector context group while Replay handles this
+    // console message, so any follow-up CDP preview/unwrap commands resolve
+    // object ids through the same group that emitted Runtime.consoleAPICalled.
+    //
+    // Otherwise those commands fall back to the context group derived from the
+    // isolate's current frame root. That usually matches the originating group,
+    // but can differ after navigation, when late microtasks from the old frame
+    // still produce console messages after the new frame has already become the
+    // current context group.
     SetContextGroupIdForSendCDPMessage(contextGroupId);
     V8RecordReplayOnConsoleMessage(0);
     ClearContextGroupIdForSendCDPMessage();

--- a/src/inspector/v8-console-message.cc
+++ b/src/inspector/v8-console-message.cc
@@ -555,6 +555,8 @@ void TraceV8ConsoleMessageEvent(V8MessageOrigin origin, ConsoleAPIType type) {
 }  // anonymous namespace
 
 extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);
+extern "C" void SetContextGroupIdForSendCDPMessage(int contextGroupId);
+extern "C" void ClearContextGroupIdForSendCDPMessage();
 
 void V8ConsoleMessageStorage::addMessage(
     std::unique_ptr<V8ConsoleMessage> message) {
@@ -578,7 +580,9 @@ void V8ConsoleMessageStorage::addMessage(
   // After notifying the inspector about the message, listeners will know about
   // the message contents if any commands are sent within RecordReplayOnConsoleMessage.
   if (message->origin() == V8MessageOrigin::kConsole && v8::IsMainThread()) {
+    SetContextGroupIdForSendCDPMessage(contextGroupId);
     V8RecordReplayOnConsoleMessage(0);
+    ClearContextGroupIdForSendCDPMessage();
   }
 
   if (!inspector->hasConsoleMessageStorage(contextGroupId)) return;


### PR DESCRIPTION
pairs with https://github.com/replayio/chromium/pull/1354