### PR TITLE
WIP: Re-apply Replay V8 instrumentation onto V8 15.1 (M151)

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -6342,6 +6342,13 @@ v8_cluster_source_set("v8_base_without_compiler") {
     "src/zone/type-stats.cc",
     "src/zone/zone-segment.cc",
     "src/zone/zone.cc",
+    "src/replay/replay-isolate-data.cc",
+    "src/replay/replay-isolate-data.h",
+    "src/replay/replayio.cc",
+    "src/replay/replayio.h",
+    "src/replay/replay-runtime-weak-refs.cc",
+    "src/replay/weak-refs.cc",
+    "src/replay/weak-refs.h",
     "third_party/siphash/halfsiphash.cc",
   ]
 

--- a/include/js_protocol.pdl
+++ b/include/js_protocol.pdl
@@ -107,6 +107,8 @@ domain Debugger
       # Deprecated in favor of using the `location.scriptId` to resolve the URL via a previously
       # sent `Debugger.scriptParsed` event.
       deprecated string url
+      # Execution context associated with this frame.
+      Runtime.ExecutionContextId contextId
       # Scope chain for this call frame.
       array of Scope scopeChain
       # `this` object for this call frame.
@@ -571,6 +573,28 @@ domain Debugger
       BreakpointId breakpointId
       # Actual breakpoint location.
       Location location
+
+  command getCallFrames
+    parameters
+      # Maximum number of frames to return.
+      optional integer maxFrames
+      # Don't generate scopes or "this" object for returned frames.
+      optional boolean noContents
+      # Symbolic group name that can be used to release multiple objects.
+      optional string objectGroup
+    returns
+      array of CallFrame callFrames
+
+  command getTopFrameLocation
+    returns
+      optional Location location
+
+  command getPendingException
+    parameters
+      # Symbolic group name that can be used to release multiple objects.
+      optional string objectGroup
+    returns
+      optional Runtime.RemoteObject exception
 
   # Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria.
   event paused
@@ -1157,6 +1181,8 @@ domain Runtime
       experimental optional DeepSerializedValue deepSerializedValue
       # Unique object identifier (for non-primitive values).
       optional RemoteObjectId objectId
+      # Any available persistent object identifier when recording/replaying.
+      optional string persistentId
       # Preview containing abbreviated property values. Specified for `object` type values only.
       experimental optional ObjectPreview preview
       experimental optional CustomPreview customPreview
@@ -1589,6 +1615,8 @@ domain Runtime
       # Size in bytes of backing storage for array buffers and external strings.
       number backingStorageSize
 
+  type KeyIterationIndex extends integer
+
   # Returns properties of a given object. Object group of the result is inherited from the target
   # object.
   command getProperties
@@ -1605,6 +1633,10 @@ domain Runtime
       experimental optional boolean generatePreview
       # If true, returns non-indexed properties only.
       experimental optional boolean nonIndexedPropertiesOnly
+      # If > 0, returns up to `pageSize` properties only.
+      optional KeyIterationIndex pageSize
+      # If pageIndex > 0 and pageSize > 0, returns properties starting at pageIndex * pageSize.
+      optional KeyIterationIndex pageIndex
     returns
       # Object properties.
       array of PropertyDescriptor result

--- a/include/replayio-macros.h
+++ b/include/replayio-macros.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 Record Replay Inc.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// API for interacting with the record/replay driver.
+// Some parts are still in v8.h and still need to be migrated.
+
+
+#ifndef INCLUDE_REPLAYIO_MACROS_H_
+#define INCLUDE_REPLAYIO_MACROS_H_
+
+// Use this to wrap Asserts on non-trivial data, to avoid the
+// overhead of argument evaluation when Asserts are disabled.
+#define REPLAY_ASSERT(format, ...) \
+  if (recordreplay::HasAsserts()) \
+    recordreplay::Assert(format, ##__VA_ARGS__); \
+  static_assert(true, "require semicolon")
+
+// Same as |REPLAY_ASSERT| but won't Assert when Events are disallowed.
+#define REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(format, ...) \
+  if (recordreplay::HasAsserts() && !recordreplay::AreEventsDisallowed()) \
+    recordreplay::Assert(format, ##__VA_ARGS__); \
+  static_assert(true, "require semicolon")
+
+#endif  // INCLUDE_REPLAYIO_MACROS_H_

--- a/include/replayio.h
+++ b/include/replayio.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2024 Record Replay Inc.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// API for interacting with the record/replay driver.
+// Some parts are still in v8.h and still need to be migrated.
+
+
+#ifndef INCLUDE_RECORD_REPLAY_H_
+#define INCLUDE_RECORD_REPLAY_H_
+
+#include "v8.h"
+
+namespace v8 {
+namespace replayio {
+  
+struct AutoPassThroughEvents {
+  AutoPassThroughEvents() { v8::recordreplay::BeginPassThroughEvents(); }
+  ~AutoPassThroughEvents() { v8::recordreplay::EndPassThroughEvents(); }
+};
+
+struct AutoDisallowEvents {
+  AutoDisallowEvents() { v8::recordreplay::BeginDisallowEvents(); }
+  AutoDisallowEvents(const char* label) { v8::recordreplay::BeginDisallowEventsWithLabel(label); }
+  ~AutoDisallowEvents() { v8::recordreplay::EndDisallowEvents(); }
+};
+
+}  // namespace replayio
+}  // namespace v8
+
+#endif  // INCLUDE_RECORD_REPLAY_H_

--- a/include/v8-container.h
+++ b/include/v8-container.h
@@ -123,7 +123,8 @@ class V8_EXPORT Map : public Object {
    * Returns an array of length Size() * 2, where index N is the Nth key and
    * index N + 1 is the Nth value.
    */
-  Local<Array> AsArray() const;
+  Local<Array> AsArray(const v8::KeyIterationParams* params =
+                           v8::KeyIterationParams::Default()) const;
 
   /**
    * Creates a new empty Map.
@@ -159,7 +160,7 @@ class V8_EXPORT Set : public Object {
   /**
    * Returns an array of the keys in this Set.
    */
-  Local<Array> AsArray() const;
+  Local<Array> AsArray(const v8::KeyIterationParams* params = v8::KeyIterationParams::Default()) const;
 
   /**
    * Creates a new empty Set.

--- a/include/v8-inspector.h
+++ b/include/v8-inspector.h
@@ -193,6 +193,9 @@ class V8_EXPORT V8InspectorSession {
   virtual void setSkipAllPauses(bool) = 0;
   virtual void resume(bool setTerminateOnResume = false) = 0;
   virtual void stepOver() = 0;
+
+  virtual v8::MaybeLocal<v8::Value> getArgumentsOfCallFrame(StringView callFrameId) = 0;
+
   virtual std::vector<std::unique_ptr<protocol::Debugger::API::SearchMatch>>
   searchInTextByLines(StringView text, StringView query, bool caseSensitive,
                       bool isRegex) = 0;
@@ -201,6 +204,12 @@ class V8_EXPORT V8InspectorSession {
   virtual std::unique_ptr<protocol::Runtime::API::RemoteObject> wrapObject(
       v8::Local<v8::Context>, v8::Local<v8::Value>, StringView groupName,
       bool generatePreview) = 0;
+
+  // Replay edit: Return objectId
+  virtual std::u16string wrapObjectGetObjectId(v8::Local<v8::Context>,
+                                               v8::Local<v8::Value>,
+                                               StringView groupName,
+                                               bool generatePreview) = 0;
 
   virtual bool unwrapObject(std::unique_ptr<StringBuffer>* error,
                             StringView objectId, v8::Local<v8::Value>*,

--- a/include/v8-object.h
+++ b/include/v8-object.h
@@ -260,6 +260,69 @@ enum class KeyConversionMode { kConvertToString, kKeepNumbers, kNoNumbers };
  */
 enum class IntegrityLevel { kFrozen, kSealed };
 
+using KeyIterationIndex = int;
+
+/**
+ * [RecordReplay]
+ * Used to paginate keys for performance reasons (RUN-1315).
+ * This is currently only implemented as part of the debugger's
+ * `Runtime.getProperties` command. It is also not a guarantee on pagination,
+ * but purely a performance improvement. We apply these params in many scenarios
+ * where large key sets would slow things down a lot.
+ * WARNING: |page_index_| has not been fully implemented.
+ * NOTE: In the future, this can be updated to encapsulate all key query
+ * parameters in a single object (`KeyCollectionMode`, `IndexFilter` etc.).
+ */
+class KeyIterationParams {
+  KeyIterationIndex page_size_;
+  /** WARNING: |page_index_| is not fully implemented. */
+  KeyIterationIndex page_index_;
+ public:
+  /**
+   * Create new KeyIterationParams to limit iteration to between |page_index| and
+   * |page_index + page_size|.
+   */
+  KeyIterationParams(KeyIterationIndex page_size, KeyIterationIndex page_index)
+      : page_size_(page_size) , page_index_(page_index) {}
+
+  /**
+   * The min of page_size_ or target size.
+   * Ignores page_size_ if no parameters are given.
+   */
+  KeyIterationIndex PageSize(KeyIterationIndex numberOfElements) const {
+    return (*this && page_size_ < numberOfElements) ? page_size_
+                                                         : numberOfElements;
+  }
+
+  /**
+   * First index of iteration.
+   */
+  KeyIterationIndex KeyFirstIndex() const { return page_index_ * page_size_; }
+
+  /**
+   * Final index of iteration + 1, indicating end of iteration.
+   */
+  KeyIterationIndex KeyEndIndex(KeyIterationIndex numberOfElements) const {
+    return (*this && (KeyFirstIndex() + page_size_) < numberOfElements)
+               ? KeyFirstIndex() + page_size_
+               : numberOfElements;
+  }
+
+  /**
+   * Whether parameters are given.
+   * If no parameters are given, key iteration will iterate all keys at once.
+   */
+  operator bool() const { return page_size_ > 0; }
+
+  /**
+   * Default (i.e. empty) key iteration params.
+   */
+  static const KeyIterationParams* Default() {
+    static KeyIterationParams params(0, 0);
+    return &params;
+  }
+};
+
 /**
  * A JavaScript object (ECMA-262, 4.3.3)
  */
@@ -895,7 +958,8 @@ class V8_EXPORT Object : public Value {
    * For other types, this will return an empty MaybeLocal<Array> (without
    * scheduling an exception).
    */
-  MaybeLocal<Array> PreviewEntries(bool* is_key_value);
+  MaybeLocal<Array> PreviewEntries(bool* is_key_value,
+                                   const v8::KeyIterationParams* params = KeyIterationParams::Default());
 
   static Local<Object> New(Isolate* isolate);
 

--- a/include/v8-platform.h
+++ b/include/v8-platform.h
@@ -52,6 +52,12 @@ class Task {
   virtual ~Task() = default;
 
   virtual void Run() = 0;
+
+  /**
+   * When recording/replaying, whether this task might not consistently occur
+   * between recording and replaying.
+   */
+  virtual bool IsRecordReplayNonDeterministic() const { return false; }
 };
 
 /**

--- a/include/v8-version.h
+++ b/include/v8-version.h
@@ -10,7 +10,7 @@
 // system so their names cannot be changed without changing the scripts.
 #define V8_MAJOR_VERSION 15
 #define V8_MINOR_VERSION 1
-#define V8_BUILD_NUMBER 43
+#define V8_BUILD_NUMBER 0
 #define V8_PATCH_LEVEL 0
 
 // Use 1 for candidates and 0 otherwise.

--- a/include/v8.h
+++ b/include/v8.h
@@ -17,6 +17,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string>
 
 #include <memory>
 
@@ -62,6 +63,8 @@
 #include "v8-wasm.h"               // NOLINT(build/include_directory)
 #include "v8config.h"              // NOLINT(build/include_directory)
 
+#include "replayio-macros.h"
+
 // We reserve the V8_* prefix for macros defined in V8 public API and
 // assume there are no name conflicts with the embedder's code.
 
@@ -82,6 +85,123 @@ class Platform;
  * \example process.cc
  */
 
+bool IsMainThread();
+
+// Static container class for record/replay methods.
+class V8_EXPORT recordreplay {
+  public:
+
+static void SetRecordingOrReplaying(void* handle);
+static bool IsRecordingOrReplaying(const char* feature = nullptr,
+                                   const char* subfeature = nullptr);
+static bool IsRecording();
+static bool IsReplaying();
+static const char* GetRecordingId();
+
+static bool IsARMRecording();
+
+static bool FeatureEnabled(const char* feature, const char* subfeature = nullptr);
+static bool HasDisabledFeatures();
+
+static char* ReadAssetFileContents(const char* path, size_t* size);
+static void Print(const char* format, ...);
+static void Diagnostic(const char* format, ...);
+static void CommandDiagnostic(const char* format, ...);
+static void CommandDiagnosticTrace(const char* format, ...);
+static void Warning(const char* format, ...);
+static void Trace(const char* format, ...);
+static void Crash(const char* format, ...);
+static bool HadMismatch();
+static bool HasAsserts();
+static void AssertRaw(const char* format, ...);
+static void Assert(const char* format, ...);
+static void AssertMaybeEventsDisallowed(const char* format, ...);
+static void AssertBytes(const char* why, const void* buf, size_t size);
+static bool AreAssertsDisabled();
+
+static uintptr_t RecordReplayValue(const char* why, uintptr_t v);
+static void RecordReplayBytes(const char* why, void* buf, size_t size);
+static void RecordReplayString(const char* why, std::string& str);
+
+static size_t CreateOrderedLock(const char* name);
+static void OrderedLock(int lock);
+static void OrderedUnlock(int lock);
+
+static void InvalidateRecording(const char* why);
+static void NewCheckpoint();
+
+static void BeginPassThroughEvents();
+static void EndPassThroughEvents();
+static bool AreEventsPassedThrough(const char* why = nullptr);
+
+static void BeginDisallowEvents();
+static void BeginDisallowEventsWithLabel(const char* label);
+static void EndDisallowEvents();
+
+// A "why" string should be used whenever there are substantive behavior changes
+// resulting from this check.
+static bool AreEventsDisallowed(const char* why = nullptr);
+
+// A "why" string should be used whenever there are substantive behavior changes
+// resulting from this check.
+static bool IsInReplayCode(const char* why = nullptr);
+
+static bool HasDivergedFromRecording();
+static bool AllowSideEffects();
+
+static int NewDependencyGraphNode(const char* json);
+static void AddDependencyGraphEdge(int source, int target, const char* json);
+static void BeginDependencyExecution(int node);
+static void EndDependencyExecution();
+
+struct AutoDependencyExecution {
+  AutoDependencyExecution(int node) {
+    BeginDependencyExecution(node);
+  }
+  ~AutoDependencyExecution() {
+    EndDependencyExecution();
+  }
+};
+
+static void BeginAssertBufferAllocations(const char* issueLabel = "");
+static void EndAssertBufferAllocations();
+
+struct AutoOrderedLock {
+  AutoOrderedLock(int id) : id_(id) { OrderedLock(id_); }
+  ~AutoOrderedLock() { OrderedUnlock(id_); }
+  int id_;
+};
+
+struct AutoAssertMaybeEventsDisallowed {
+  AutoAssertMaybeEventsDisallowed(const char* format, ...);
+  ~AutoAssertMaybeEventsDisallowed();
+  std::string msg_;
+};
+
+struct AssertBufferAllocationState {
+  size_t enabled = 0;
+  std::string issueLabel = "";
+};
+
+
+// RAII class to enable recording assertions on dynamic-length buffer 
+// allocations. Used to track down the allocation causing mismatched message 
+// sizes when replaying.
+// TODO: Merge this with the similar `AuxtoRecordReplayAssertBufferAllocations`
+// in mojo/public/cpp/bindings/lib/buffer.cc (for main-thread only).
+struct AutoAssertBufferAllocations {
+  static AssertBufferAllocationState* GetState();
+
+  AutoAssertBufferAllocations(const char* issueLabel = "");
+  ~AutoAssertBufferAllocations();
+};
+
+static void RegisterPointer(const char* name, const void* ptr);
+static void UnregisterPointer(const void* ptr);
+static int PointerId(const void* ptr);
+static void* IdPointer(int id);
+
+}; // class recordreplay
 
 }  // namespace v8
 

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -45,7 +45,6 @@
 #include "src/base/template-utils.h"
 #include "src/base/utils/random-number-generator.h"
 #include "src/base/vector.h"
-#include "src/base/vector.h"
 #include "src/builtins/accessors.h"
 #include "src/builtins/builtins-promise.h"
 #include "src/builtins/builtins-utils.h"
@@ -2048,6 +2047,14 @@ MaybeLocal<Value> Script::Run(Local<Context> context,
   }
 #endif  // V8_ENABLE_ETW_STACK_WALKING
   auto fun = i::Cast<i::JSFunction>(Utils::OpenDirectHandle(this));
+
+  // TODO: IsInReplayCode (RUN-1502)
+  v8::recordreplay::AssertMaybeEventsDisallowed(
+      "JS Script::Run %d",
+      IsScript(fun->shared()->script())
+          ? i::Cast<i::Script>(fun->shared()->script())->id()
+          : 0);
+
   i::DirectHandle<i::Object> receiver = i_isolate->global_proxy();
   // TODO(cbruni, chromium:1244145): Remove once migrated to the context.
   i::DirectHandle<i::Object> options(
@@ -2306,14 +2313,6 @@ Local<FixedArray> Module::GetModuleRequests() const {
         i_isolate));
   }
 }
-
-  // TODO: IsInReplayCode (RUN-1502)
-  v8::recordreplay::AssertMaybeEventsDisallowed(
-    "JS Script::Run %d",
-    fun->shared().script().IsScript()
-      ? i::Script::cast(fun->shared().script()).id()
-      : 0
-  );
 
 Location Module::SourceOffsetToLocation(int offset) const {
   auto self = Utils::OpenDirectHandle(this);
@@ -2629,11 +2628,11 @@ ReplayingReplaceScriptContents(Isolate* isolate, Handle<String> source) {
   return isolate->factory()->NewStringFromUtf8(base::CStrVector(new_contents)).ToHandleChecked();
 }
 
-MaybeHandle<SharedFunctionInfo>
-ReplayingMaybeReplaceScript(Isolate* isolate,
-                            MaybeHandle<SharedFunctionInfo> maybe_function_info,
-                            const ScriptDetails& script_details,
-                            Handle<String> source) {
+MaybeDirectHandle<SharedFunctionInfo>
+ReplayingMaybeReplaceScript(
+    Isolate* isolate,
+    MaybeDirectHandle<SharedFunctionInfo> maybe_function_info,
+    const ScriptDetails& script_details, Handle<String> source) {
   MaybeHandle<String> new_source = ReplayingReplaceScriptContents(isolate, source);
 
   if (new_source.is_null() || maybe_function_info.is_null()) {
@@ -2641,13 +2640,14 @@ ReplayingMaybeReplaceScript(Isolate* isolate,
   }
 
   CHECK(!gReplaceSourceContentsScriptId);
-  gReplaceSourceContentsScriptId = Script::cast(maybe_function_info.ToHandleChecked()->script()).id();
+  gReplaceSourceContentsScriptId =
+      Cast<Script>(maybe_function_info.ToHandleChecked()->script())->id();
 
   maybe_function_info = Compiler::GetSharedFunctionInfoForScript(
       isolate, new_source.ToHandleChecked(), script_details,
       ScriptCompiler::kNoCompileOptions,
       ScriptCompiler::kNoCacheNoReason,
-      NOT_NATIVES_CODE);
+      NOT_NATIVES_CODE, nullptr);
 
   gReplaceSourceContentsScriptId = 0;
   return maybe_function_info;
@@ -2712,6 +2712,10 @@ MaybeLocal<UnboundScript> ScriptCompiler::CompileUnboundInternal(
         i::NOT_NATIVES_CODE, &source->compilation_details);
   }
 
+  // While replaying, allow the script source to be substituted for another.
+  maybe_function_info = i::ReplayingMaybeReplaceScript(
+      i_isolate, maybe_function_info, script_details, str);
+
   if (!maybe_function_info.ToHandle(&result)) return {};
   DCHECK(!i::HeapLayout::InReadOnlySpace(*result));
   return api_scope.Escape(ToApiHandle<UnboundScript>(result));
@@ -2726,8 +2730,6 @@ MaybeLocal<UnboundScript> ScriptCompiler::CompileUnboundScript(
       "v8::ScriptCompiler::CompileModule must be used to compile modules");
   return CompileUnboundInternal(v8_isolate, source, options, no_cache_reason);
 }
-
-  maybe_function_info = i::ReplayingMaybeReplaceScript(i_isolate, maybe_function_info, script_details, str);
 
 MaybeLocal<Script> ScriptCompiler::Compile(Local<Context> context,
                                            Source* source,

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -45,6 +45,7 @@
 #include "src/base/template-utils.h"
 #include "src/base/utils/random-number-generator.h"
 #include "src/base/vector.h"
+#include "src/base/vector.h"
 #include "src/builtins/accessors.h"
 #include "src/builtins/builtins-promise.h"
 #include "src/builtins/builtins-utils.h"
@@ -172,6 +173,13 @@
 #include <signal.h>
 #include <unistd.h>
 
+#if !V8_OS_WIN
+#include <unistd.h>
+#include <dlfcn.h>
+#endif
+
+extern const char* gCrashReason;
+
 #if V8_ENABLE_WEBASSEMBLY
 #include "include/v8-wasm-trap-handler-posix.h"
 #include "src/trap-handler/handler-inside-posix.h"
@@ -238,6 +246,12 @@ static ScriptOrigin GetScriptOriginForScript(
 
 // --- E x c e p t i o n   B e h a v i o r ---
 
+static __attribute__((noinline)) void BusyWait() {
+  fprintf(stderr, "Busy-waiting ... (pid %d)\n", getpid());
+  volatile int x = 1;
+  while (x) {}
+}
+
 // When V8 cannot allocate memory FatalProcessOutOfMemory is called. The default
 // OOM error handler is called and execution is stopped.
 void i::V8::FatalProcessOutOfMemory(i::Isolate* i_isolate, const char* location,
@@ -293,6 +307,9 @@ void Utils::ReportApiFailure(const char* location, const char* message) {
   if (callback == nullptr) {
     base::OS::PrintError("\n#\n# Fatal error in %s\n# %s\n#\n\n", location,
                          message);
+    if (getenv("RECORD_REPLAY_WAIT_AT_FATAL_ERROR")) {
+      BusyWait();
+    }
     base::OS::Abort();
   } else {
     callback(location, message);
@@ -2290,6 +2307,14 @@ Local<FixedArray> Module::GetModuleRequests() const {
   }
 }
 
+  // TODO: IsInReplayCode (RUN-1502)
+  v8::recordreplay::AssertMaybeEventsDisallowed(
+    "JS Script::Run %d",
+    fun->shared().script().IsScript()
+      ? i::Script::cast(fun->shared().script()).id()
+      : 0
+  );
+
 Location Module::SourceOffsetToLocation(int offset) const {
   auto self = Utils::OpenDirectHandle(this);
   i::Isolate* i_isolate = i::Isolate::Current();
@@ -2424,6 +2449,9 @@ MaybeLocal<Value> Module::Evaluate(Local<Context> context) {
   auto self = Utils::OpenHandle(this);
   Utils::ApiCheck(self->status() >= i::Module::kLinked, "Module::Evaluate",
                   "Expected instantiated module");
+
+  // TODO: IsInReplayCode (RUN-1502)
+  v8::recordreplay::AssertMaybeEventsDisallowed("JS Module::Evaluate %d", ScriptId());
 
   return api_scope.EscapeMaybe(i::Module::Evaluate(i_isolate, self));
 }
@@ -2578,6 +2606,55 @@ i::ScriptDetails GetScriptDetails(
 
 }  // namespace
 
+static const char* RecordReplayReplaceSourceContents(const char* contents);
+
+namespace internal {
+
+// If we are compiling a script while replaying that replaces another one,
+// the ID of the script being replaced. Main thread only.
+int gReplaceSourceContentsScriptId;
+
+MaybeHandle<String>
+ReplayingReplaceScriptContents(Isolate* isolate, Handle<String> source) {
+  if (!recordreplay::IsReplaying() || !IsMainThread()) {
+    return MaybeHandle<String>();
+  }
+
+  std::unique_ptr<char[]> contents = source->ToCString();
+  const char* new_contents = RecordReplayReplaceSourceContents(contents.get());
+  if (!new_contents) {
+    return MaybeHandle<String>();
+  }
+
+  return isolate->factory()->NewStringFromUtf8(base::CStrVector(new_contents)).ToHandleChecked();
+}
+
+MaybeHandle<SharedFunctionInfo>
+ReplayingMaybeReplaceScript(Isolate* isolate,
+                            MaybeHandle<SharedFunctionInfo> maybe_function_info,
+                            const ScriptDetails& script_details,
+                            Handle<String> source) {
+  MaybeHandle<String> new_source = ReplayingReplaceScriptContents(isolate, source);
+
+  if (new_source.is_null() || maybe_function_info.is_null()) {
+    return maybe_function_info;
+  }
+
+  CHECK(!gReplaceSourceContentsScriptId);
+  gReplaceSourceContentsScriptId = Script::cast(maybe_function_info.ToHandleChecked()->script()).id();
+
+  maybe_function_info = Compiler::GetSharedFunctionInfoForScript(
+      isolate, new_source.ToHandleChecked(), script_details,
+      ScriptCompiler::kNoCompileOptions,
+      ScriptCompiler::kNoCacheNoReason,
+      NOT_NATIVES_CODE);
+
+  gReplaceSourceContentsScriptId = 0;
+  return maybe_function_info;
+}
+
+} // namespace internal
+
 MaybeLocal<UnboundScript> ScriptCompiler::CompileUnboundInternal(
     Isolate* v8_isolate, Source* source, CompileOptions options,
     NoCacheReason no_cache_reason) {
@@ -2649,6 +2726,8 @@ MaybeLocal<UnboundScript> ScriptCompiler::CompileUnboundScript(
       "v8::ScriptCompiler::CompileModule must be used to compile modules");
   return CompileUnboundInternal(v8_isolate, source, options, no_cache_reason);
 }
+
+  maybe_function_info = i::ReplayingMaybeReplaceScript(i_isolate, maybe_function_info, script_details, str);
 
 MaybeLocal<Script> ScriptCompiler::Compile(Local<Context> context,
                                            Source* source,
@@ -3192,6 +3271,12 @@ int Message::ErrorLevel() const {
   i::DisallowJavascriptExecutionDebugOnly no_execution;
   i::DisallowExceptionsDebugOnly no_exceptions;
   return self->error_level();
+}
+
+extern "C" int V8GetMessageRecordReplayBookmark(v8::Local<v8::Message> message) {
+  auto self = Utils::OpenHandle(*message);
+  DCHECK_NO_SCRIPT_NO_EXCEPTION(self->GetIsolate());
+  return self->record_replay_bookmark();
 }
 
 int Message::GetStartColumn() const {
@@ -8485,7 +8570,8 @@ enum class SetAsArrayKind {
 
 i::DirectHandle<i::JSArray> MapAsArray(i::Isolate* i_isolate,
                                        i::Tagged<i::Object> table_obj,
-                                       int offset, MapAsArrayKind kind) {
+                                 int offset, MapAsArrayKind kind,
+                                 const KeyIterationParams* params = KeyIterationParams::Default()) {
   i::Factory* factory = i_isolate->factory();
   i::DirectHandle<i::OrderedHashMap> table(
       i::Cast<i::OrderedHashMap>(table_obj), i_isolate);
@@ -8494,8 +8580,10 @@ i::DirectHandle<i::JSArray> MapAsArray(i::Isolate* i_isolate,
   const bool collect_values =
       kind == MapAsArrayKind::kEntries || kind == MapAsArrayKind::kValues;
   int capacity = table->UsedCapacity();
-  int max_length =
-      (capacity - offset) * ((collect_keys && collect_values) ? 2 : 1);
+  
+  auto page_size = params->PageSize(capacity - offset);
+  int max_length = page_size * ((collect_keys && collect_values) ? 2 : 1);
+
   i::DirectHandle<i::FixedArray> result = factory->NewFixedArray(max_length);
   uint32_t result_index = 0;
   {
@@ -8508,9 +8596,11 @@ i::DirectHandle<i::JSArray> MapAsArray(i::Isolate* i_isolate,
       if (key == hash_table_hole) continue;
       if (collect_keys) result->set(result_index++, key);
       if (collect_values) result->set(result_index++, table->ValueAt(entry));
+
+      if (*params && result_index == max_length) break;
     }
   }
-  DCHECK_GE(max_length, result_index);
+  CHECK_GE(max_length, result_index);
   if (result_index == 0) return factory->NewJSArray(0);
   result->RightTrim(i_isolate, result_index);
   return factory->NewJSArrayWithElements(result, i::PACKED_ELEMENTS,
@@ -8610,6 +8700,8 @@ i::DirectHandle<i::JSArray> SetAsArray(i::Isolate* i_isolate,
       if (key == hash_table_hole) continue;
       result->set(result_index++, key);
       if (collect_key_values) result->set(result_index++, key);
+      
+      if (result_index == max_length) break;
     }
   }
   DCHECK_GE(max_length, result_index);
@@ -11404,7 +11496,7 @@ v8::MaybeLocal<v8::Array> v8::Object::PreviewEntries(bool* is_key_value) {
     *is_key_value = kind == MapAsArrayKind::kEntries;
     if (!it->HasMore()) return v8::Array::New(v8_isolate);
     return Utils::ToLocal(
-        MapAsArray(i_isolate, it->table(), i::Smi::ToInt(it->index()), kind));
+        MapAsArray(i_isolate, it->table(), i::Smi::ToInt(it->index()), kind, params));
   }
   if (i::IsJSSetIterator(*object)) {
     auto it = i::Cast<i::JSSetIterator>(object);
@@ -12163,6 +12255,1694 @@ std::shared_ptr<WasmStreaming> WasmStreaming::Unpack(Isolate* v8_isolate,
   FATAL("WebAssembly is disabled");
 }
 #endif  // !V8_ENABLE_WEBASSEMBLY
+
+// On windows we need to export methods called in base/record_replay.cc
+// so that they can be looked up in chrome.dll
+#if V8_OS_WIN
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+static bool gRecordingOrReplaying;
+static bool gARMRecording;
+static bool gHasDisabledFeatures;
+static bool gAssertsDisabled;
+
+typedef char* (CommandCallbackRaw)(const char* params);
+
+#define ForEachRecordReplaySymbol(Macro)                                      \
+  Macro(RecordReplayHasDisabledFeatures, (), bool, false)                     \
+  Macro(RecordReplayFeatureEnabled,                                           \
+        (const char* feature, const char* subfeature), bool, true)            \
+  Macro(RecordReplayHadMismatch, (), bool, false)                             \
+  Macro(RecordReplayValue, (const char* why, uintptr_t v), uintptr_t, v)      \
+  Macro(RecordReplayAreEventsDisallowed, (), bool, false)                     \
+  Macro(RecordReplayAreEventsPassedThrough, (), bool, false)                  \
+  Macro(RecordReplayAreAssertsDisabled, (), bool, false)                      \
+  Macro(RecordReplayCreateOrderedLock, (const char* name), size_t, 0)         \
+  Macro(RecordReplayIsReplaying, (), bool, false)                             \
+  Macro(RecordReplayHasDivergedFromRecording, (), bool, false)                \
+  Macro(RecordReplayNewDependencyGraphNode, (const char* json), int, 0)       \
+  Macro(RecordReplayAllowSideEffects, (), bool, true)                         \
+  Macro(RecordReplayPointerId, (const void* ptr), int, 0)                     \
+  Macro(RecordReplayIdPointer, (int id), void*, nullptr)                      \
+  Macro(RecordReplayGetRecordingId, (), char*, nullptr)                       \
+  Macro(RecordReplayGetUnusableRecordingReason, (), char*, nullptr)           \
+  Macro(RecordReplayNewBookmark, (), uint64_t, 0)                             \
+  Macro(RecordReplayPaintStart, (), size_t, 0)                                \
+  Macro(RecordReplayJSONCreateString, (const char*), void*, nullptr)          \
+  Macro(RecordReplayJSONCreateObject,                                         \
+        (size_t, const char**, void**), void*, nullptr)                       \
+  Macro(RecordReplayJSONToString, (void*), char*, nullptr)                    \
+  Macro(RecordReplayProgressCounter, (), uint64_t*, nullptr)                  \
+  Macro(RecordReplayGetStack, (char* aStack, size_t aSize), bool, false)      \
+  Macro(RecordReplayReadAssetFileContents,                                    \
+        (const char* aPath, size_t *aLength),                                 \
+        char*, nullptr)                                                       \
+  Macro(RecordReplayReplaceSourceContents,                                    \
+        (const char* contents), const char*, nullptr)
+
+#define ForEachRecordReplaySymbolVoidShared(Macro)                            \
+  Macro(RecordReplayDisableFeatures, (const char* json))                      \
+  Macro(RecordReplayRememberRecording, ())                                    \
+  Macro(RecordReplayOnNewSource,                                              \
+        (const char* id, const char* kind, const char* url))                  \
+  Macro(RecordReplayOnConsoleMessage, (size_t bookmark))                      \
+  Macro(RecordReplayOnExceptionUnwind, ())                                    \
+  Macro(RecordReplaySetCommandCallback,                                       \
+        (const char* method, CommandCallbackRaw callback))                    \
+  Macro(RecordReplayPrint, (const char* format, va_list args))                \
+  Macro(RecordReplayDiagnostic, (const char* format, va_list args))           \
+  Macro(RecordReplayWarning, (const char* format, va_list args))              \
+  Macro(RecordReplayTrace, (const char* format, va_list args))                \
+  Macro(RecordReplayOnInstrument,                                             \
+        (const char* kind, const char* function, int offset))                 \
+  Macro(RecordReplayAssert, (const char*, va_list))                           \
+  Macro(RecordReplayAssertBytes,                                              \
+        (const char* why, const void* ptr, size_t nbytes))                    \
+  Macro(RecordReplayDescribeAssertData, (const char* text))                   \
+  Macro(RecordReplayBytes, (const char* why, void* buf, size_t size))         \
+  Macro(RecordReplayProgressReached, ())                                      \
+  Macro(RecordReplayTriggerProgressInterrupt, ())                             \
+  Macro(RecordReplayBeginPassThroughEvents, ())                               \
+  Macro(RecordReplayEndPassThroughEvents, ())                                 \
+  Macro(RecordReplayBeginDisallowEvents, ())                                  \
+  Macro(RecordReplayBeginDisallowEventsWithLabel, (const char* label))        \
+  Macro(RecordReplayEndDisallowEvents, ())                                    \
+  Macro(RecordReplayOrderedLock, (int lock))                                  \
+  Macro(RecordReplayOrderedUnlock, (int lock))                                \
+  Macro(RecordReplayInvalidateRecording, (const char* format, ...))           \
+  Macro(RecordReplayNewCheckpoint, ())                                        \
+  Macro(RecordReplayRegisterPointerWithName,                                  \
+        (const char* name, const void* ptr))                                  \
+  Macro(RecordReplayUnregisterPointer, (const void* ptr))                     \
+  Macro(RecordReplayFinishRecording, ())                                      \
+  Macro(RecordReplayOnNetworkRequest,                                         \
+        (const char* id, const char* kind, uint64_t bookmark))                \
+  Macro(RecordReplayOnNetworkRequestEvent, (const char* id))                  \
+  Macro(RecordReplayOnNetworkStreamStart,                                     \
+        (const char* id, const char* kind, const char* parentId))             \
+  Macro(RecordReplayOnNetworkStreamData,                                      \
+        (const char* id, size_t offset, size_t length, uint64_t bookmark))    \
+  Macro(RecordReplayOnNetworkStreamEnd, (const char* id, size_t length))      \
+  Macro(RecordReplayPaintFinished, (size_t bookmark))                         \
+  Macro(RecordReplaySetPaintCallback, (char* (*callback)(const char*, int)))  \
+  Macro(RecordReplayOnDebuggerStatement, ())                                  \
+  Macro(RecordReplayNotifyActivity, ())                                       \
+  Macro(RecordReplayAddMetadata, (const char* metadata))                      \
+  Macro(RecordReplayJSONFree, (void*))                                        \
+  Macro(RecordReplayOnAnnotation, (const char* kind, const char* contents))   \
+  Macro(RecordReplayAddPossibleBreakpoint,                                    \
+        (int line, int column, const char* function_id, int function_index))  \
+  Macro(RecordReplayOnEvent, (const char* aEvent, bool aBefore))              \
+  Macro(RecordReplayOnMouseEvent,                                             \
+        (const char* aKind, size_t aClientX, size_t aClientY,                 \
+         bool synthetic))                                                     \
+  Macro(RecordReplayOnKeyEvent, (const char* aKind, const char* aKey,         \
+         bool synthetic))                                                     \
+  Macro(RecordReplayOnNavigationEvent, (const char* aKind, const char* aUrl)) \
+  Macro(RecordReplayAddDependencyGraphEdge,                                   \
+        (int source, int target, const char* json))                           \
+  Macro(RecordReplayBeginDependencyExecution, (int node))                     \
+  Macro(RecordReplayEndDependencyExecution, ())                               \
+  Macro(RecordReplaySetDefaultCommandCallback,                                \
+        (char* (*callback)(const char* command, const char* params)))         \
+  Macro(RecordReplaySetClearPauseDataCallback, (void (*callback)()))          \
+  Macro(RecordReplaySetCrashReasonCallback, (const char* (*aCallback)()))     \
+  Macro(RecordReplaySetChangeInstrumentCallback,                              \
+        (void (*callback)(bool wantInstrumentation)))                         \
+  Macro(RecordReplaySetProgressCallback, (void (*aCallback)(uint64_t)))       \
+  Macro(RecordReplaySetProgressInterruptCallback, (void (*aCallback)()))      \
+  Macro(RecordReplayEnableProgressCheckpoints, ())                            \
+  Macro(RecordReplaySetTrackObjectsCallback,                                  \
+        (void (*aCallback)(bool aTrackObjects)))                              \
+  Macro(RecordReplaySetPossibleBreakpointsCallback,                           \
+        (void (*aCallback)(const char*)))                                     \
+  Macro(RecordReplaySetAssertDataCallbacks,                                   \
+        (void (*aGetData)(void**, size_t*),                                   \
+         char* (*aOnMismatch)(void*, size_t, void*, size_t),                  \
+         void (*aDescribeData)(void*, size_t)))
+
+#if !V8_OS_WIN
+#define ForEachRecordReplaySymbolVoid(Macro)                                  \
+  ForEachRecordReplaySymbolVoidShared(Macro)                                  \
+  Macro(RecordReplayAddOrderedPthreadMutex,                                   \
+        (const char* name, pthread_mutex_t* mutex))
+#else
+#define ForEachRecordReplaySymbolVoid(Macro)                                  \
+  ForEachRecordReplaySymbolVoidShared(Macro)                                  \
+  Macro(RecordReplayAddOrderedSRWLock, (const char* name, void* lock))        \
+  Macro(RecordReplayRemoveOrderedSRWLock, (void* lock))
+#endif
+
+#define DeclareRecordReplaySymbol(Name, Params, ReturnType, ReturnDefault)    \
+  static ReturnType (*g##Name) Params;
+ForEachRecordReplaySymbol(DeclareRecordReplaySymbol)
+#undef DeclareRecordReplaySymbol
+
+#define DeclareRecordReplaySymbolVoid(Name, Params)                           \
+  static void (*g##Name) Params;
+ForEachRecordReplaySymbolVoid(DeclareRecordReplaySymbolVoid)
+#undef DeclareRecordReplaySymbolVoid
+
+namespace internal {
+
+bool gRecordReplayHasCheckpoint;
+
+void RecordReplayOnNewSource(Isolate* isolate, const char* id,
+                             const char* kind, const char* url) {
+  if (gRecordReplayHasCheckpoint) {
+    gRecordReplayOnNewSource(id, kind, url);
+  }
+}
+
+void RecordReplayOnConsoleMessage(size_t bookmark) {
+  if (gRecordReplayHasCheckpoint) {
+    gRecordReplayOnConsoleMessage(bookmark);
+  }
+}
+
+extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark) {
+  RecordReplayOnConsoleMessage(bookmark);
+}
+
+Handle<Object>* gCurrentException;
+
+extern "C" void V8RecordReplayGetCurrentException(MaybeLocal<Value>* exception) {
+  CHECK(IsMainThread());
+  if (gCurrentException) {
+    *exception = Utils::ToLocal(*gCurrentException);
+  }
+}
+
+
+extern bool RecordReplayHasRegisteredScript(Script script);
+
+void RecordReplayOnExceptionUnwind(Isolate* isolate) {
+  CHECK(gRecordingOrReplaying);
+  CHECK(IsMainThread());
+  CHECK(!gCurrentException);
+
+  if (!gRecordReplayHasCheckpoint)
+    return;
+
+  HandleScope scope(isolate);
+
+  if (!isolate->has_pending_exception())
+    return;
+
+  Handle<Object> exception(isolate->pending_exception(), isolate);
+  if (!isolate->is_catchable_by_javascript(*exception))
+    return;
+
+  {
+    // Note: Most of this is copied from |ComputeLocation| in messages.cc.
+    JavaScriptFrameIterator it(isolate);
+    if (!it.done()) {
+      // Compute the location from the function and the relocation info of the
+      // baseline code. For optimized code this will use the deoptimization
+      // information to get canonical location information.
+      std::vector<FrameSummary> frames;
+      it.frame()->Summarize(&frames);
+      if (!frames.empty()) { // There might not always be a frame due to RUN-1920.
+        auto& summary = frames.back().AsJavaScript();
+        Handle<SharedFunctionInfo> shared(summary.function()->shared(), isolate);
+        Handle<Object> script(shared->script(), isolate);
+        if (script->IsScript()) {
+          Handle<Script> casted_script = Handle<Script>::cast(script);
+          if (!RecordReplayHasRegisteredScript(*casted_script)) {
+            // Don't repor errors from unregistered.
+            return;
+          }
+        }
+      }
+    }
+  }
+
+  isolate->clear_pending_exception();
+  Handle<Object> message(isolate->pending_message(), isolate);
+  isolate->clear_pending_message();
+  Handle<Object> scheduledException;
+  if (isolate->has_scheduled_exception()) {
+    scheduledException = Handle<Object>(isolate->scheduled_exception(), isolate);
+    isolate->clear_scheduled_exception();
+  }
+  gCurrentException = &exception;
+
+  gRecordReplayOnExceptionUnwind();
+
+  gCurrentException = nullptr;
+  CHECK(!isolate->has_pending_exception());
+  isolate->set_pending_exception(*exception);
+  isolate->set_pending_message(*message);
+  if (!scheduledException.is_null()) {
+    isolate->set_scheduled_exception(*scheduledException);
+  }
+}
+
+uint64_t* gProgressCounter;
+
+extern "C" uint64_t* V8RecordReplayGetProgressCounter() {
+  return gProgressCounter;
+}
+
+bool gRecordReplayInstrumentationEnabled;
+
+void RecordReplayChangeInstrument(bool enabled) {
+  CHECK(!enabled || recordreplay::IsReplaying());
+  gRecordReplayInstrumentationEnabled = enabled;
+
+  // All optimized code needs to be recompiled when instrumentation changes,
+  // as instrumentation calls will be optimized out when instrumentation is
+  // disabled.
+  Isolate* isolate = Isolate::Current();
+  Deoptimizer::DeoptimizeAll(isolate);
+}
+
+uint64_t gTargetProgress;
+
+void RecordReplaySetTargetProgress(uint64_t progress) {
+  CHECK(IsMainThread());
+  gTargetProgress = progress;
+}
+
+void RecordReplayTriggerProgressInterrupt() {
+  CHECK(recordreplay::IsRecording() && IsMainThread());
+  gRecordReplayTriggerProgressInterrupt();
+}
+
+extern std::string GetScriptLocationString(int script_id, int start_position);
+
+void RecordReplayOnTargetProgressReached() {
+  CHECK(IsMainThread());
+  if (recordreplay::AreEventsDisallowed()) {
+    // We should not have progress updates when events disallowed.
+    if (!recordreplay::HasDivergedFromRecording()) {
+      // TODO: [RUN-2235] Replace with GetCurrentLocationStringExtended.
+      std::ostringstream os;
+      os << "PC=" << *gProgressCounter;
+      Isolate* isolate = Isolate::Current();
+      HandleScope scope(isolate);
+      os << " stack=";
+      isolate->PrintCurrentStackTrace(os);
+
+      recordreplay::Warning("OnProgressReached %s", os.str().c_str());
+    }
+    return;
+  }
+  gRecordReplayProgressReached();
+}
+
+static void RecordReplayProgressInterruptCallback() {
+  CHECK(IsMainThread());
+  Isolate* isolate = Isolate::Current();
+  isolate->RecordReplayInvokeApiInterruptCallbacksAtProgress();
+}
+
+void RecordReplayInstrument(const char* kind, const char* function, int function_index) {
+  gRecordReplayOnInstrument(kind, function, function_index);
+}
+
+extern void TrackObjectsCallback(bool track_objects);
+extern void RecordReplayGetPossibleBreakpointsCallback(const char* source_id);
+
+extern void RecordReplayCallbackAssertGetData(void** pbuf, size_t* psize);
+extern char* RecordReplayCallbackAssertOnDataMismatch(void* recorded, size_t recorded_size,
+                                                      void* replayed, size_t replayed_size);
+extern void RecordReplayCallbackAssertDescribeData(void* buf, size_t size);
+
+extern char* CommandCallback(const char* command, const char* params);
+extern void ClearPauseDataCallback();
+
+bool gRecordReplayAssertValues;
+const char* gRecordReplayAssertValuesPattern;
+
+bool gRecordReplayAssertProgress;
+bool gRecordReplayAssertTrackedObjects;
+
+// Enable reporting the dependency graph while replaying.
+// This is on by default.
+bool gRecordReplayEnableDependencyGraph;
+
+// Assert that dependency graph nodes / edges are created consistently.
+// This adds recording overhead and is off by default.
+bool gRecordReplayAssertDependencyGraph;
+
+// Enable various checks when advancing the progress counter. Set via the
+// environment, or when events are disallowed on the main thread.
+int gRecordReplayCheckProgress;
+
+// Only finish recordings if there were interesting sources loaded
+// into the process.
+static char* gRecordReplayInterestingSource;
+
+// Processes which didn't paint anything will optionally be ignored,
+// even if they have interesting sources.
+static bool gRecordReplayHasPaint;
+
+// Whether we've determined this is an interesting recording.
+static bool gRecordReplayInterestingRecording;
+
+// This should be called whenever any of the state it tests is updated.
+static void MaybeMarkInterestingRecording() {
+  CHECK(IsMainThread());
+
+  if (gRecordReplayInterestingRecording) {
+    return;
+  }
+
+  if (!gRecordReplayInterestingSource) {
+    return;
+  }
+
+  if (getenv("RECORD_REPLAY_IGNORE_NON_PAINTING_CONTENT") && !gRecordReplayHasPaint) {
+    return;
+  }
+
+  gRecordReplayInterestingRecording = true;
+
+  gRecordReplayRememberRecording();
+
+  // Add the recording to a recording ID file if specified.
+  char* env = getenv("RECORD_REPLAY_RECORDING_ID_FILE");
+  if (env) {
+    FILE* file = fopen(env, "a");
+    if (file) {
+      const char* recordingId = recordreplay::GetRecordingId();
+      // Include the first interesting source found when writing the
+      // recording ID out, to help distinguish between different content
+      // processes which Chromium will create for content from different
+      // origins.
+      fprintf(file, "%s %s\n", recordingId, gRecordReplayInterestingSource);
+      fclose(file);
+      recordreplay::Print("Found content, saved recording %s to %s", recordingId, env);
+    } else {
+      recordreplay::Print("Error: Could not open %s for adding recording ID", env);
+    }
+  }
+}
+
+void RecordReplayAddInterestingSource(const char* url) {
+  if (!*url) {
+    // Always ignore sources with missing URLs.
+    return;
+  }
+
+  static bool gDumpSources = getenv("RECORD_REPLAY_PRINT_SOURCES");
+  if (gDumpSources) {
+    recordreplay::Print("NewSource %s", url);
+  }
+
+  if (!gRecordReplayInterestingSource) {
+    gRecordReplayInterestingSource = strdup(url);
+    MaybeMarkInterestingRecording();
+  }
+}
+
+// Add metadata for the recording the first time an HTML page is parsed.
+void RecordReplayAddHTMLParse(const char* url) {
+  // Ignore uninteresting URLs.
+  if (!url || !*url || !strncmp(url, "about:", 6) ||
+    // Ignore most Chrome URLs, but allow extensions!
+    (!strncmp(url, "chrome", 6) && strncmp(url, "chrome-extension", 16))) {
+    return;
+  }
+
+  static bool gHasHTMLParse = false;
+  if (gHasHTMLParse) {
+    return;
+  }
+  gHasHTMLParse = true;
+
+  void* str = gRecordReplayJSONCreateString(url);
+
+  const char* property = "uri";
+  void* object = gRecordReplayJSONCreateObject(1, &property, &str);
+
+  char* objectStr = gRecordReplayJSONToString(object);
+  gRecordReplayAddMetadata(objectStr);
+
+  free(objectStr);
+  gRecordReplayJSONFree(str);
+  gRecordReplayJSONFree(object);
+}
+
+// For posting tasks to the main thread.
+static Isolate* gMainThreadIsolate;
+
+void RecordReplayOnMainThreadIsolateCreated(Isolate* isolate) {
+  CHECK(!gMainThreadIsolate);
+  gMainThreadIsolate = isolate;
+}
+
+static Eternal<v8::Context>* gDefaultContext;
+
+extern "C" void V8RecordReplaySetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context> cx) {
+  if (IsMainThread()) {
+    gDefaultContext = new Eternal<v8::Context>(isolate, cx);
+  }
+}
+
+extern "C" void V8RecordReplayGetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context>* cx) {
+  CHECK(IsMainThread() && gDefaultContext);
+  *cx = gDefaultContext->Get(isolate);
+}
+
+bool RecordReplayHasDefaultContext() {
+  return !!gDefaultContext;
+}
+
+extern void RecordReplayInitInstrumentationState();
+
+void RecordReplayDescribeAssertData(const char* text) {
+  gRecordReplayDescribeAssertData(text);
+}
+
+bool RecordReplayAssertValues(const std::string& url) {
+  if (!gRecordReplayAssertValues) {
+    return false;
+  }
+  if (!gRecordReplayAssertValuesPattern) {
+    return true;
+  }
+  return url.length() && strstr(url.c_str(), gRecordReplayAssertValuesPattern);
+}
+
+} // namespace internal
+
+bool recordreplay::FeatureEnabled(const char* feature, const char* subfeature) {
+  if (!gHasDisabledFeatures) {
+    return true;
+  }
+  return gRecordReplayFeatureEnabled(feature, subfeature);
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayFeatureEnabled(const char* feature, const char* subfeature) {
+  return recordreplay::FeatureEnabled(feature, subfeature);
+}
+
+bool recordreplay::HasDisabledFeatures() {
+  return gHasDisabledFeatures;
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayHasDisabledFeatures() {
+  return recordreplay::HasDisabledFeatures();
+}
+
+// Return whether this is a test environment where experimental features
+// can be used.
+static bool GetTestEnvironmentFlag() {
+  auto* sTestEnvironment = getenv("RECORD_REPLAY_TEST_ENVIRONMENT");
+  return sTestEnvironment && sTestEnvironment[0] && sTestEnvironment[0] != '0';
+}
+
+// JSON for features we are currently developing and only want to use in
+// test environments. Because all features are enabled by default and
+// disabled via this JSON, the feature names need to be negatives like
+// no-experimental-whatzit.
+static const char* gExperimentalFeaturesJSON = nullptr;
+
+static void RecordReplayInitializeDisabledFeatures() {
+  if (!gExperimentalFeaturesJSON) {
+    return;
+  }
+  if (GetTestEnvironmentFlag()) {
+    gRecordReplayDisableFeatures(gExperimentalFeaturesJSON);
+  }
+}
+
+bool recordreplay::IsRecordingOrReplaying(const char* feature, const char* subfeature) {
+  return gRecordingOrReplaying && (!feature || FeatureEnabled(feature, subfeature));
+}
+
+extern "C" DLLEXPORT bool V8IsRecordingOrReplaying(const char* feature, const char* subfeature) {
+  return recordreplay::IsRecordingOrReplaying(feature, subfeature);
+}
+
+char* recordreplay::ReadAssetFileContents(const char* aPath, size_t* aLength) {
+  if (IsReplaying()) {
+    return gRecordReplayReadAssetFileContents(aPath, aLength);
+  } else {
+    return nullptr;
+  }
+}
+
+extern "C" DLLEXPORT char* V8RecordReplayReadAssetFileContents(const char* aPath, size_t* aLength) {
+  return recordreplay::ReadAssetFileContents(aPath, aLength);
+}
+
+static const char* RecordReplayReplaceSourceContents(const char* contents) {
+  if (recordreplay::IsReplaying()) {
+    return gRecordReplayReplaceSourceContents(contents);
+  }
+  return nullptr;
+}
+
+void recordreplay::Print(const char* format, ...) {
+  if (IsRecordingOrReplaying()) {
+    va_list args;
+    va_start(args, format);
+    gRecordReplayPrint(format, args);
+    va_end(args);
+  }
+}
+
+extern "C" void V8RecordReplayPrint(const char* format, ...) {
+  if (recordreplay::IsRecordingOrReplaying()) {
+    va_list args;
+    va_start(args, format);
+    gRecordReplayPrint(format, args);
+    va_end(args);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayPrintVA(const char* format, va_list args) {
+  if (recordreplay::IsRecordingOrReplaying()) {
+    gRecordReplayPrint(format, args);
+  }
+}
+
+void recordreplay::Diagnostic(const char* format, ...) {
+  if (IsRecordingOrReplaying()) {
+    va_list args;
+    va_start(args, format);
+    gRecordReplayDiagnostic(format, args);
+    va_end(args);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayDiagnosticVA(const char* format, va_list args) {
+  if (recordreplay::IsRecordingOrReplaying()) {
+    gRecordReplayDiagnostic(format, args);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayCommandDiagnosticVA(const char* format,
+                                                            va_list args) {
+  if (recordreplay::IsReplaying()) {
+    // TODO: RUN-2499
+    std::string finalFormat = "[CommandDiagnostic]" + std::string(format);
+    gRecordReplayPrint(finalFormat.c_str(), args);
+  }
+}
+
+void recordreplay::CommandDiagnostic(const char* format, ...) {
+  if (IsReplaying()) {
+    va_list args;
+    va_start(args, format);
+    V8RecordReplayCommandDiagnosticVA(format, args);
+    va_end(args);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayCommandDiagnosticTraceVA(
+    const char* format, va_list args) {
+  if (recordreplay::IsReplaying()) {
+    // TODO: RUN-2499
+    std::string finalFormat = "[CommandDiagnostic]" + std::string(format);
+    gRecordReplayTrace(finalFormat.c_str(), args);
+  }
+}
+
+void recordreplay::CommandDiagnosticTrace(const char* format, ...) {
+  if (IsReplaying()) {
+    va_list args;
+    va_start(args, format);
+    V8RecordReplayCommandDiagnosticTraceVA(format, args);
+    va_end(args);
+  }
+}
+
+void recordreplay::Warning(const char* format, ...) {
+  if (IsRecordingOrReplaying()) {
+    va_list args;
+    va_start(args, format);
+    gRecordReplayWarning(format, args);
+    va_end(args);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayWarning(const char* format,
+                                                va_list args) {
+  if (recordreplay::IsRecordingOrReplaying()) {
+    gRecordReplayWarning(format, args);
+  }
+}
+
+void recordreplay::Trace(const char* format, ...) {
+  if (IsRecordingOrReplaying()) {
+    va_list args;
+    va_start(args, format);
+    gRecordReplayTrace(format, args);
+    va_end(args);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayTrace(const char* format,
+                                              va_list args) {
+  if (recordreplay::IsRecordingOrReplaying()) {
+    gRecordReplayTrace(format, args);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayCrash(const char* format, va_list args) {
+  char str[4096];
+  vsnprintf(str, sizeof(str), format, args);
+  str[sizeof(str) - 1] = 0;
+
+  V8_Fatal("%s", str);
+}
+
+void recordreplay::Crash(const char* format, ...) {
+  if (IsRecordingOrReplaying()) {
+    va_list args;
+    va_start(args, format);
+    V8RecordReplayCrash(format, args);
+    va_end(args);
+  }
+}
+
+
+bool recordreplay::HadMismatch() {
+  if (IsRecordingOrReplaying()) {
+    // It is an error to call this during record time.
+    CHECK(!recordreplay::IsRecording());
+    return gRecordReplayHadMismatch();
+  }
+  return false;
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayHadMismatch() {
+  if (recordreplay::IsRecordingOrReplaying()) {
+    // It is an error to call this during record time.
+    CHECK(!recordreplay::IsRecording());
+    return gRecordReplayHadMismatch();
+  }
+  return false;
+}
+
+bool recordreplay::HasAsserts() {
+  return !gAssertsDisabled && IsRecordingOrReplaying();
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayHasAsserts() {
+  return recordreplay::HasAsserts();
+}
+
+void recordreplay::AssertRaw(const char* format, ...) {
+  va_list ap;
+  va_start(ap, format);
+  gRecordReplayAssert(format, ap);
+  va_end(ap);
+}
+
+void recordreplay::Assert(const char* format, ...) {
+  if (HasAsserts()) {
+    va_list ap;
+    va_start(ap, format);
+    gRecordReplayAssert(format, ap);
+    va_end(ap);
+  }
+}
+
+extern "C" void V8RecordReplayAssert(const char* format, ...) {
+  if (recordreplay::HasAsserts()) {
+    va_list ap;
+    va_start(ap, format);
+    gRecordReplayAssert(format, ap);
+    va_end(ap);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayAssertVA(const char* format, va_list args) {
+  if (recordreplay::HasAsserts()) {
+    gRecordReplayAssert(format, args);
+  }
+}
+
+void recordreplay::AssertMaybeEventsDisallowed(const char* format, ...) {
+  if (HasAsserts() &&
+      !AreEventsDisallowed("AssertMaybeEventsDisallowed")) {
+    va_list ap;
+    va_start(ap, format);
+    gRecordReplayAssert(format, ap);
+    va_end(ap);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayAssertMaybeEventsDisallowedVA(const char* format, va_list args) {
+  if (recordreplay::HasAsserts() &&
+      !recordreplay::AreEventsDisallowed("AssertMaybeEventsDisallowed")) {
+    gRecordReplayAssert(format, args);
+  }
+}
+
+void recordreplay::AssertBytes(const char* why, const void* buf, size_t size) {
+  if (HasAsserts()) {
+    gRecordReplayAssertBytes(why, buf, size);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayAssertBytes(const char* why, const void* buf, size_t size) {
+  recordreplay::AssertBytes(why, buf, size);
+}
+
+bool recordreplay::AreAssertsDisabled() {
+  return gAssertsDisabled;
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayAreAssertsDisabled() {
+  return recordreplay::AreAssertsDisabled();
+}
+
+uintptr_t recordreplay::RecordReplayValue(const char* why, uintptr_t v) {
+  if (IsRecordingOrReplaying("values", why)) {
+    return gRecordReplayValue(why, v);
+  }
+  return v;
+}
+
+extern "C" DLLEXPORT uintptr_t V8RecordReplayValue(const char* why, uintptr_t value) {
+  return recordreplay::RecordReplayValue(why, value);
+}
+
+void recordreplay::RecordReplayBytes(const char* why, void* buf, size_t size) {
+  if (IsRecordingOrReplaying("values", why)) {
+    gRecordReplayBytes(why, buf, size);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayBytes(const char* why, void* buf, size_t size) {
+  recordreplay::RecordReplayBytes(why, buf, size);
+}
+
+void recordreplay::RecordReplayString(const char* why, std::string& str) {
+  size_t length = RecordReplayValue(why, str.length());
+  str.resize(length);
+  if (length) {
+    RecordReplayBytes(why, &str[0], length);
+  }
+}
+
+bool recordreplay::AreEventsDisallowed(const char* why) {
+  if (IsRecordingOrReplaying("disallow-events", why)) {
+    return gRecordReplayAreEventsDisallowed();
+  }
+  return false;
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayAreEventsDisallowed(const char* why) {
+  return recordreplay::AreEventsDisallowed(why);
+}
+
+bool recordreplay::AreEventsPassedThrough(const char* why) {
+  if (IsRecordingOrReplaying("pass-through-events", why)) {
+    return gRecordReplayAreEventsPassedThrough();
+  }
+  return false;
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayAreEventsPassedThrough(const char* why) {
+  return recordreplay::AreEventsPassedThrough(why);
+}
+
+void recordreplay::BeginPassThroughEvents() {
+  if (IsRecordingOrReplaying()) {
+    gRecordReplayBeginPassThroughEvents();
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayBeginPassThroughEvents() {
+  recordreplay::BeginPassThroughEvents();
+}
+
+void recordreplay::EndPassThroughEvents() {
+  if (IsRecordingOrReplaying()) {
+    gRecordReplayEndPassThroughEvents();
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayEndPassThroughEvents() {
+  recordreplay::EndPassThroughEvents();
+}
+
+void recordreplay::BeginDisallowEvents() {
+  if (IsRecordingOrReplaying()) {
+    gRecordReplayBeginDisallowEvents();
+    if (IsMainThread())
+      ++internal::gRecordReplayCheckProgress;
+  }
+}
+
+void recordreplay::BeginDisallowEventsWithLabel(const char* label) {
+  if (IsRecordingOrReplaying()) {
+    gRecordReplayBeginDisallowEventsWithLabel(label);
+    if (IsMainThread())
+      ++internal::gRecordReplayCheckProgress;
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayBeginDisallowEvents() {
+  recordreplay::BeginDisallowEvents();
+}
+
+extern "C" DLLEXPORT void V8RecordReplayBeginDisallowEventsWithLabel(const char* label) {
+  recordreplay::BeginDisallowEventsWithLabel(label);
+}
+
+void recordreplay::EndDisallowEvents() {
+  if (IsRecordingOrReplaying()) {
+    if (IsMainThread())
+      --internal::gRecordReplayCheckProgress;
+    gRecordReplayEndDisallowEvents();
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayEndDisallowEvents() {
+  recordreplay::EndDisallowEvents();
+}
+
+void recordreplay::InvalidateRecording(const char* why) {
+  if (IsRecordingOrReplaying()) {
+    gRecordReplayInvalidateRecording("%s", why);
+  }
+}
+
+void recordreplay::NewCheckpoint() {
+  // We can only create checkpoints if a context has been created. A context is
+  // needed to process commands which we might get from the driver.
+  if (IsRecordingOrReplaying() && IsMainThread() && internal::gDefaultContext) {
+    internal::gRecordReplayHasCheckpoint = true;
+    gRecordReplayNewCheckpoint();
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayNewCheckpoint() {
+  recordreplay::NewCheckpoint();
+}
+
+// The BrowserEvent callback junction is a support for communicating
+// events that occur in the browser outside of the v8 codebase.
+// This is necessary because chrome's architecture takes pains to
+// isolate components that are even running on the same process.
+// The initial user for this API is the network inspector agent,
+// which communicates network events to the backend.
+
+// `payload` should be the serialized json data for the event.
+typedef void (*RecordReplayBrowserEventCallback)(const char* name, const char* payload);
+static RecordReplayBrowserEventCallback gBrowserEventCallback = nullptr;
+
+// Browser events added before the callback was registered, which happens when
+// the first checkpoint is reached.
+typedef std::vector<std::pair<std::string, std::string>> BrowserEventsVector;
+static BrowserEventsVector* gPendingBrowserEvents;
+
+extern "C" DLLEXPORT void V8RecordReplayBrowserEvent(const char* name, const char* payload) {
+  CHECK(recordreplay::IsRecordingOrReplaying());
+  CHECK(IsMainThread());
+  if (gBrowserEventCallback) {
+    gBrowserEventCallback(name, payload);
+  } else {
+    if (!gPendingBrowserEvents) {
+      gPendingBrowserEvents = new BrowserEventsVector();
+    }
+    gPendingBrowserEvents->emplace_back(name, payload);
+  }
+}
+
+extern "C" void V8RecordReplayRegisterBrowserEventCallback(
+    RecordReplayBrowserEventCallback callback) {
+  CHECK(recordreplay::IsRecordingOrReplaying());
+  CHECK(IsMainThread());
+  CHECK(!gBrowserEventCallback);
+  gBrowserEventCallback = callback;
+
+  if (gPendingBrowserEvents) {
+    for (const auto& item : *gPendingBrowserEvents) {
+      gBrowserEventCallback(item.first.c_str(), item.second.c_str());
+    }
+    delete gPendingBrowserEvents;
+    gPendingBrowserEvents = nullptr;
+  }
+}
+
+size_t recordreplay::CreateOrderedLock(const char* name) {
+  if (IsRecordingOrReplaying()) {
+    return gRecordReplayCreateOrderedLock(name);
+  }
+  return 0;
+}
+
+extern "C" DLLEXPORT size_t V8RecordReplayCreateOrderedLock(const char* name) {
+  return recordreplay::CreateOrderedLock(name);
+}
+
+void recordreplay::OrderedLock(int lock) {
+  if (IsRecordingOrReplaying()) {
+    gRecordReplayOrderedLock(lock);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayOrderedLock(int lock) {
+  recordreplay::OrderedLock(lock);
+}
+
+void recordreplay::OrderedUnlock(int lock) {
+  if (IsRecordingOrReplaying()) {
+    gRecordReplayOrderedUnlock(lock);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayOrderedUnlock(int lock) {
+  recordreplay::OrderedUnlock(lock);
+}
+
+#if !V8_OS_WIN
+
+extern "C" void V8RecordReplayAddOrderedPthreadMutex(const char* name,
+                                                     pthread_mutex_t* mutex) {
+  if (recordreplay::IsRecordingOrReplaying()) {
+    gRecordReplayAddOrderedPthreadMutex(name, mutex);
+  }
+}
+
+#else // V8_OS_WIN
+
+extern "C" DLLEXPORT void V8RecordReplayAddOrderedSRWLock(const char* name, void* lock) {
+  if (recordreplay::IsRecordingOrReplaying()) {
+    gRecordReplayAddOrderedSRWLock(name, lock);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayRemoveOrderedSRWLock(void* lock) {
+  if (recordreplay::IsRecordingOrReplaying()) {
+    gRecordReplayRemoveOrderedSRWLock(lock);
+  }
+}
+
+#endif // V8_OS_WIN
+
+bool recordreplay::IsReplaying() {
+  if (IsRecordingOrReplaying()) {
+    return gRecordReplayIsReplaying();
+  }
+  return false;
+}
+
+extern "C" DLLEXPORT bool V8IsReplaying() {
+  return recordreplay::IsReplaying();
+}
+
+bool recordreplay::IsRecording() {
+  return !IsReplaying();
+}
+
+extern "C" DLLEXPORT bool V8IsRecording() {
+  return recordreplay::IsRecording();
+}
+
+bool recordreplay::IsARMRecording() {
+  return IsRecordingOrReplaying() && gARMRecording;
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayIsARM() {
+  return recordreplay::IsARMRecording();
+}
+
+bool recordreplay::HasDivergedFromRecording() {
+  if (recordreplay::IsRecordingOrReplaying()) {
+    return gRecordReplayHasDivergedFromRecording();
+  }
+  return false;
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayHasDivergedFromRecording() {
+  return recordreplay::HasDivergedFromRecording();
+}
+
+bool recordreplay::AllowSideEffects() {
+  if (recordreplay::IsRecordingOrReplaying()) {
+    return gRecordReplayAllowSideEffects();
+  }
+  return true;
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayAllowSideEffects() {
+  return recordreplay::AllowSideEffects();
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayUpdateDependencyGraph() {
+  return i::gRecordReplayEnableDependencyGraph
+      && (recordreplay::IsReplaying() || i::gRecordReplayAssertDependencyGraph)
+      && IsMainThread();
+}
+
+extern "C" DLLEXPORT int V8RecordReplayNewDependencyGraphNode(const char* json) {
+  if (V8RecordReplayUpdateDependencyGraph()) {
+    int id = gRecordReplayNewDependencyGraphNode(json);
+    if (i::gRecordReplayAssertDependencyGraph) {
+      recordreplay::Assert("NewDependencyGraphNode id=%d %s",
+                           id, json ? json : "");
+    }
+    return id;
+  }
+  return 0;
+}
+
+int recordreplay::NewDependencyGraphNode(const char* json) {
+  return V8RecordReplayNewDependencyGraphNode(json);
+}
+
+extern "C" DLLEXPORT void V8RecordReplayAddDependencyGraphEdge(int source, int target, const char* json) {
+  if (V8RecordReplayUpdateDependencyGraph()) {
+    gRecordReplayAddDependencyGraphEdge(source, target, json);
+    if (i::gRecordReplayAssertDependencyGraph) {
+      recordreplay::Assert("NewDependencyGraphEdge source=%d target=%d %s",
+                           source, target, json ? json : "");
+    }
+  }
+}
+
+void recordreplay::AddDependencyGraphEdge(int source, int target, const char* json) {
+  V8RecordReplayAddDependencyGraphEdge(source, target, json);
+}
+
+static std::vector<int>* gDependencyGraphExecutionStack;
+
+extern "C" int V8RecordReplayDependencyGraphExecutionNode() {
+  if (!IsMainThread() ||
+      !gDependencyGraphExecutionStack ||
+      !gDependencyGraphExecutionStack->size()) {
+    return 0;
+  }
+  return gDependencyGraphExecutionStack->back();
+}
+
+extern "C" DLLEXPORT void V8RecordReplayBeginDependencyExecution(int node) {
+  if (V8RecordReplayUpdateDependencyGraph()) {
+    if (!gDependencyGraphExecutionStack) {
+      gDependencyGraphExecutionStack = new std::vector<int>();
+    }
+    gDependencyGraphExecutionStack->push_back(node);
+    gRecordReplayBeginDependencyExecution(node);
+    if (i::gRecordReplayAssertDependencyGraph) {
+      recordreplay::Assert("BeginDependencyExecution id=%d", node);
+    }
+  }
+}
+
+void recordreplay::BeginDependencyExecution(int node) {
+  V8RecordReplayBeginDependencyExecution(node);
+}
+
+extern "C" DLLEXPORT void V8RecordReplayEndDependencyExecution() {
+  if (V8RecordReplayUpdateDependencyGraph()) {
+    gDependencyGraphExecutionStack->pop_back();
+    gRecordReplayEndDependencyExecution();
+    if (i::gRecordReplayAssertDependencyGraph) {
+      recordreplay::Assert("EndDependencyExecution");
+    }
+  }
+}
+
+void recordreplay::EndDependencyExecution() {
+  V8RecordReplayEndDependencyExecution();
+}
+
+void recordreplay::RegisterPointer(const char* name, const void* ptr) {
+  if (IsRecordingOrReplaying("pointer-ids")) {
+    gRecordReplayRegisterPointerWithName(name, ptr);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayRegisterPointer(const char* name, const void* ptr) {
+  recordreplay::RegisterPointer(name, ptr);
+}
+
+void recordreplay::UnregisterPointer(const void* ptr) {
+  if (IsRecordingOrReplaying("pointer-ids")) {
+    gRecordReplayUnregisterPointer(ptr);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayUnregisterPointer(const void* ptr) {
+  recordreplay::UnregisterPointer(ptr);
+}
+
+int recordreplay::PointerId(const void* ptr) {
+  if (IsRecordingOrReplaying("pointer-ids")) {
+    return gRecordReplayPointerId(ptr);
+  }
+  return 0;
+}
+
+extern "C" DLLEXPORT int V8RecordReplayPointerId(const void* ptr) {
+  return recordreplay::PointerId(ptr);
+}
+
+void* recordreplay::IdPointer(int id) {
+  CHECK(IsRecordingOrReplaying("pointer-ids"));
+  return gRecordReplayIdPointer(id);
+}
+
+extern "C" DLLEXPORT void* V8RecordReplayIdPointer(int id) {
+  return recordreplay::IdPointer(id);
+}
+
+extern "C" DLLEXPORT uint64_t V8RecordReplayNewBookmark() {
+  internal::Isolate* isolate = internal::Isolate::Current();
+  if (internal::gRecordReplayHasCheckpoint &&
+      isolate && internal::AllowJavascriptExecution::IsAllowed(isolate)) {
+    // Our bookmark code invokes JS. Make sure that that is possible and allowed.
+    // https://linear.app/replay/issue/RUN-1908/fix-devtools-crashes
+    return gRecordReplayNewBookmark();
+  }
+  return 0;
+}
+
+extern "C" DLLEXPORT void V8RecordReplayOnNetworkRequest(const char* id, const char* kind, uint64_t bookmark) {
+  CHECK(recordreplay::IsRecordingOrReplaying());
+  if (internal::gRecordReplayHasCheckpoint) {
+    gRecordReplayOnNetworkRequest(id, kind, bookmark);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayOnNetworkRequestEvent(const char* id) {
+  CHECK(recordreplay::IsRecordingOrReplaying());
+  if (internal::gRecordReplayHasCheckpoint) {
+    gRecordReplayOnNetworkRequestEvent(id);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayOnNetworkStreamStart(const char* id, const char* kind, const char* parentId) {
+  CHECK(recordreplay::IsRecordingOrReplaying());
+  if (internal::gRecordReplayHasCheckpoint) {
+    gRecordReplayOnNetworkStreamStart(id, kind, parentId);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayOnNetworkStreamData(const char* id, size_t offset, size_t length, uint64_t bookmark) {
+  CHECK(recordreplay::IsRecordingOrReplaying());
+  if (internal::gRecordReplayHasCheckpoint) {
+    gRecordReplayOnNetworkStreamData(id, offset, length, bookmark);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayOnNetworkStreamEnd(const char* id, size_t length) {
+  CHECK(recordreplay::IsRecordingOrReplaying());
+  if (internal::gRecordReplayHasCheckpoint) {
+    gRecordReplayOnNetworkStreamEnd(id, length);
+  }
+}
+
+extern "C" size_t V8RecordReplayPaintStart() {
+  DCHECK(recordreplay::IsRecordingOrReplaying());
+  if (!internal::gRecordReplayHasCheckpoint) {
+    return 0;
+  }
+  internal::gRecordReplayHasPaint = true;
+  internal::MaybeMarkInterestingRecording();
+  return gRecordReplayPaintStart();
+}
+
+extern "C" void V8RecordReplayPaintFinished(size_t bookmark) {
+  DCHECK(recordreplay::IsRecordingOrReplaying());
+  if (bookmark) {
+    gRecordReplayPaintFinished(bookmark);
+  }
+}
+
+extern "C" void V8RecordReplaySetPaintCallback(char* (*callback)(const char*, int)) {
+  DCHECK(recordreplay::IsRecordingOrReplaying());
+  gRecordReplaySetPaintCallback(callback);
+}
+
+extern "C" void V8RecordReplayOnDebuggerStatement() {
+  DCHECK(recordreplay::IsRecordingOrReplaying());
+  if (internal::gRecordReplayHasCheckpoint) {
+    gRecordReplayOnDebuggerStatement();
+  }
+}
+
+extern "C" void V8RecordReplayNotifyActivity() {
+  gRecordReplayNotifyActivity();
+}
+
+extern "C" void V8RecordReplayAddMetadata(const char* jsonString) {
+  gRecordReplayAddMetadata(jsonString);
+}
+
+extern "C" DLLEXPORT void V8RecordReplayOnAnnotation(const char* kind, const char* contents) {
+  DCHECK(recordreplay::IsRecordingOrReplaying());
+  if (internal::gRecordReplayHasCheckpoint) {
+    gRecordReplayOnAnnotation(kind, contents);
+  }
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayGetStack(char* aStack, size_t aSize) {
+  DCHECK(recordreplay::IsRecordingOrReplaying());
+  return gRecordReplayGetStack(aStack, aSize);
+}
+
+namespace internal {
+
+void RecordReplayAddPossibleBreakpoint(int line, int column, const char* function_id, int function_index) {
+  gRecordReplayAddPossibleBreakpoint(line, column, function_id, function_index);
+}
+
+} // namespace internal
+
+extern "C" DLLEXPORT void V8RecordReplayOnEvent(const char* aEvent, bool aBefore) {
+  DCHECK(recordreplay::IsRecordingOrReplaying());
+  if (!internal::gRecordReplayHasCheckpoint) {
+    return;
+  }
+  
+  gRecordReplayOnEvent(aEvent, aBefore);
+}
+
+extern "C" DLLEXPORT void V8RecordReplayOnMouseEvent(const char* kind, size_t clientX,
+                                                     size_t clientY, bool synthetic) {
+  DCHECK(recordreplay::IsRecordingOrReplaying());
+  if (!internal::gRecordReplayHasCheckpoint) {
+    return;
+  }
+  gRecordReplayOnMouseEvent(kind, clientX, clientY, synthetic);
+}
+
+extern "C" DLLEXPORT void V8RecordReplayOnKeyEvent(const char* kind, const char* key, bool synthetic) {
+  DCHECK(recordreplay::IsRecordingOrReplaying());
+  if (!internal::gRecordReplayHasCheckpoint) {
+    return;
+  }
+  gRecordReplayOnKeyEvent(kind, key, synthetic);
+}
+
+extern "C" DLLEXPORT void V8RecordReplayOnNavigationEvent(const char* kind, const char* url) {
+  DCHECK(recordreplay::IsRecordingOrReplaying());
+  if (!internal::gRecordReplayHasCheckpoint) {
+    return;
+  }
+  gRecordReplayOnNavigationEvent(kind, url);
+}
+
+extern "C" DLLEXPORT void V8RecordReplayGetCurrentJSStack(std::string* stackTrace) {
+  CHECK(recordreplay::IsRecordingOrReplaying());
+  CHECK(stackTrace);
+
+  std::stringstream stack;
+
+  i::Isolate* isolate = internal::Isolate::TryGetCurrent();
+  i::HandleScope scope(isolate);
+  if (isolate) {
+    isolate->PrintCurrentStackTrace(stack);
+  }
+
+  *stackTrace = stack.str();
+}
+
+template <typename Src, typename Dst>
+static inline void CastPointer(const Src src, Dst* dst) {
+  static_assert(sizeof(Src) == sizeof(uintptr_t), "bad size");
+  static_assert(sizeof(Dst) == sizeof(uintptr_t), "bad size");
+  memcpy((void*)dst, (const void*)&src, sizeof(uintptr_t));
+}
+
+template <typename T>
+static void RecordReplayLoadSymbol(void* handle, const char* name, T& function) {
+#if V8_OS_WIN
+  void* sym = (void*)(GetProcAddress((HMODULE)handle, name));
+#else
+  void* sym = dlsym(handle, name);
+#endif
+  if (!sym) {
+    fprintf(stderr, "Could not find %s in Record Replay driver, crashing.\n", name);
+#if V8_OS_WIN
+    // Additionally write the message to a new file. Capturing the output written to
+    // stderr by browser subprocesses on windows is surprisingly difficult.
+    FILE* f = fopen("record_replay_load_symbol_error.txt", "w");
+    if (f) {
+      fprintf(f, "Could not find %s in Record Replay driver, crashing.\n", name);
+      fclose(f);
+    }
+#endif
+    IMMEDIATE_CRASH();
+  }
+
+  CastPointer(sym, &function);
+}
+
+static bool IsRecordingUnusable() {
+  if (recordreplay::IsRecording()) {
+    char* reason = gRecordReplayGetUnusableRecordingReason();
+    if (reason) {
+      free(reason);
+      return true;
+    }
+  }
+  return false;
+}
+
+// Recording IDs are UUIDs, and have a fixed length.
+static char gRecordingId[40];
+
+const char* recordreplay::GetRecordingId() {
+  if (IsRecordingUnusable()) {
+    return nullptr;
+  }
+  if (!gRecordingId[0]) {
+    // RecordReplayGetRecordingId() is not currently supported while replaying,
+    // so we embed the recording ID in the recording itself.
+    if (recordreplay::IsRecording()) {
+      char* recordingId = gRecordReplayGetRecordingId();
+      if (!recordingId) {
+        CHECK(IsRecordingUnusable());
+        return nullptr;
+      }
+      CHECK(*recordingId != 0);
+      CHECK(strlen(recordingId) + 1 <= sizeof(gRecordingId));
+      strcpy(gRecordingId, recordingId);
+    }
+    recordreplay::RecordReplayBytes("RecordingId", gRecordingId, sizeof(gRecordingId));
+  }
+  return gRecordingId;
+}
+
+extern "C" DLLEXPORT const char* V8GetRecordingId() {
+  return recordreplay::GetRecordingId();
+}
+
+extern "C" const char* V8RecordReplayCrashReasonCallback();
+
+static void DoFinishRecording() {
+  recordreplay::Print("DoFinishRecording");
+
+  gRecordReplayFinishRecording();
+
+  recordreplay::Print("RecordingFinished");
+  _exit(0);
+}
+
+class FinishRecordingTask final : public Task {
+ public:
+  void Run() final { DoFinishRecording(); }
+};
+
+// Data for making sure we finish the recording if the main thread is stuck
+// doing a synchronous operation.
+static std::atomic<bool> gNeedFinishRecording;
+static std::atomic<void (*)(void*)> gUnblockMainThreadCallback;
+static std::atomic<void*> gUnblockMainThreadCallbackData;
+static int gFinishRecordingOrderedLockId;
+base::Thread::LocalStorageKey gAssertBufferAllocationStateLSKey;
+
+extern "C" DLLEXPORT void V8RecordReplayMaybeTerminate(void (*callback)(void*), void* data) {
+  recordreplay::Assert("V8RecordReplayMaybeTerminate");
+  if (IsMainThread()) {
+    recordreplay::OrderedLock(gFinishRecordingOrderedLockId);
+    gUnblockMainThreadCallback = callback;
+    gUnblockMainThreadCallbackData = data;
+    if (gNeedFinishRecording) {
+      DoFinishRecording();
+    }
+    recordreplay::OrderedUnlock(gFinishRecordingOrderedLockId);
+  }
+}
+
+extern "C" DLLEXPORT void V8RecordReplayFinishRecording() {
+  recordreplay::Assert("V8RecordReplayFinishRecording");
+  if (recordreplay::IsRecordingOrReplaying()) {
+    if (internal::gRecordReplayInterestingRecording) {
+      if (IsMainThread()) {
+        DoFinishRecording();
+      } else {
+        recordreplay::Print("PendingFinishRecording");
+        recordreplay::OrderedLock(gFinishRecordingOrderedLockId);
+        gNeedFinishRecording = true;
+        if (gUnblockMainThreadCallback) {
+          gUnblockMainThreadCallback.load()(gUnblockMainThreadCallbackData);
+        }
+        recordreplay::OrderedUnlock(gFinishRecordingOrderedLockId);
+        CHECK(internal::gMainThreadIsolate);
+        auto runner = internal::V8::GetCurrentPlatform()->GetForegroundTaskRunner((Isolate*)internal::gMainThreadIsolate);
+        runner->PostTask(std::make_unique<FinishRecordingTask>());
+#if V8_OS_WIN
+        Sleep(UINT32_MAX);
+#else
+        sleep(UINT32_MAX);
+#endif
+      }
+    } else {
+      recordreplay::InvalidateRecording("No interesting content");
+    }
+  }
+}
+
+#if V8_OS_WIN
+static DWORD gMainThread;
+static void InitMainThread() {
+  gMainThread = GetCurrentThreadId();
+}
+bool IsMainThread() {
+  return gMainThread == GetCurrentThreadId();
+}
+#else
+static pthread_t gMainThread;
+static void InitMainThread() {
+  gMainThread = pthread_self();
+}
+bool IsMainThread() {
+  return gMainThread == pthread_self();
+}
+#endif
+
+// Set this process as recording or replaying.
+// Also serves to initializes Replay state.
+void recordreplay::SetRecordingOrReplaying(void* handle) {
+#define LoadRecordReplaySymbol(Name, Params, ReturnType, ReturnDefault)    \
+  RecordReplayLoadSymbol(handle, #Name, g##Name);
+ForEachRecordReplaySymbol(LoadRecordReplaySymbol)
+#undef LoadRecordReplaySymbol
+
+#define LoadRecordReplaySymbolVoid(Name, Params)                           \
+  RecordReplayLoadSymbol(handle, #Name, g##Name);
+ForEachRecordReplaySymbolVoid(LoadRecordReplaySymbolVoid)
+#undef LoadRecordReplaySymbolVoid
+
+  RecordReplayInitializeDisabledFeatures();
+  gHasDisabledFeatures = gRecordReplayHasDisabledFeatures();
+
+  gRecordingOrReplaying = V8RecordReplayFeatureEnabled("record-replay", nullptr);
+  InitMainThread();
+
+  gAssertsDisabled = gRecordReplayAreAssertsDisabled();
+
+  gRecordReplaySetDefaultCommandCallback(i::CommandCallback);
+  gRecordReplaySetClearPauseDataCallback(i::ClearPauseDataCallback);
+  gRecordReplaySetCrashReasonCallback(V8RecordReplayCrashReasonCallback);
+
+  gFinishRecordingOrderedLockId = (int)CreateOrderedLock("FinishRecording");
+  gAssertBufferAllocationStateLSKey = base::Thread::CreateThreadLocalKey();
+
+  i::gProgressCounter = gRecordReplayProgressCounter();
+
+  gRecordReplaySetChangeInstrumentCallback(i::RecordReplayChangeInstrument);
+  gRecordReplaySetProgressCallback(i::RecordReplaySetTargetProgress);
+  gRecordReplaySetProgressInterruptCallback(i::RecordReplayProgressInterruptCallback);
+  gRecordReplayEnableProgressCheckpoints();
+  gRecordReplaySetTrackObjectsCallback(i::TrackObjectsCallback);
+  gRecordReplaySetPossibleBreakpointsCallback(i::RecordReplayGetPossibleBreakpointsCallback);
+
+  // Remember whether this recording was made on ARM.
+#if V8_TARGET_ARCH_ARM64
+  gARMRecording = true;
+#endif
+  gARMRecording = RecordReplayValue("ARMRecording", gARMRecording);
+
+  i::gRecordReplayAssertValues = !!getenv("RECORD_REPLAY_JS_ASSERTS");
+  i::gRecordReplayAssertValuesPattern = getenv("RECORD_REPLAY_JS_ASSERTS_PATTERN");
+
+  i::gRecordReplayCheckProgress =
+      i::gRecordReplayAssertValues || !!getenv("RECORD_REPLAY_JS_PROGRESS_CHECKS");
+  i::gRecordReplayAssertProgress =
+      i::gRecordReplayAssertValues || !!getenv("RECORD_REPLAY_JS_PROGRESS_ASSERTS");
+  i::gRecordReplayAssertTrackedObjects =
+      i::gRecordReplayAssertValues || !!getenv("RECORD_REPLAY_JS_OBJECT_ASSERTS");
+
+  if (i::gRecordReplayAssertProgress) {
+    gRecordReplaySetAssertDataCallbacks(i::RecordReplayCallbackAssertGetData,
+                                        i::RecordReplayCallbackAssertOnDataMismatch,
+                                        i::RecordReplayCallbackAssertDescribeData);
+  }
+
+  // Currently the dependency graph is enabled by default.
+  i::gRecordReplayEnableDependencyGraph =
+    V8RecordReplayFeatureEnabled("dependency-graph", nullptr);
+
+  i::gRecordReplayAssertDependencyGraph = !!getenv("RECORD_REPLAY_DEPENDENCY_GRAPH_ASSERTS");
+
+  // Disable wasm background compilation.
+  if (V8RecordReplayFeatureEnabled("disable-v8-flags-wasm-compilation-tasks", nullptr)) {
+    i::FLAG_wasm_num_compilation_tasks = 0;
+    i::FLAG_wasm_async_compilation = false;
+  }
+
+  // The baseline JIT's handling of some record/replay opcodes is buggy.
+  if (V8RecordReplayFeatureEnabled("disable-v8-flags-baseline-jit", nullptr)) {
+    i::v8_flags.sparkplug = false;
+  }
+
+  // The optimizing JIT is used by default but can be disabled via a feature.
+  if (!V8RecordReplayFeatureEnabled("v8-flags-optimizing-jit", nullptr)) {
+    i::v8_flags.turbofan = false;
+  }
+
+  // Disable some GC settings while replaying for causing mysterious crashes.
+  if (IsReplaying() || !V8RecordReplayFeatureEnabled("v8-flags-gc", nullptr)) {
+    i::FLAG_concurrent_marking = false;
+    i::FLAG_concurrent_sweeping = false;
+    i::FLAG_incremental_marking_task = false;
+    i::FLAG_parallel_compaction = false;
+    i::FLAG_parallel_marking = false;
+    i::FLAG_parallel_pointer_update = false;
+    i::FLAG_parallel_scavenge = false;
+    i::FLAG_scavenge_task = false;
+    i::FLAG_incremental_marking = false;
+  }
+
+  // For now the compilation cache is only used when recording.
+  if (IsReplaying() || !V8RecordReplayFeatureEnabled("v8-flags-compilation-cache", nullptr)) {
+    i::FLAG_compilation_cache = false;
+  }
+
+  // Write out our pid to a file if specified.
+  char* env = getenv("RECORD_REPLAY_PID_FILE");
+  if (env) {
+    FILE* file = fopen(env, "a");
+    if (file) {
+      fprintf(file, "%d\n", getpid());
+      fclose(file);
+    }
+  }
+
+  i::RecordReplayInitInstrumentationState();
+}
+
+extern "C" void V8SetRecordingOrReplaying(void* handle) {
+  recordreplay::SetRecordingOrReplaying(handle);
+}
+
+extern "C" void V8InitializeNotRecordingOrReplaying() {
+  // These flags are necessary to avoid hangs in some situations, for unknown
+  // reasons. See https://linear.app/replay/issue/RUN-1071
+  internal::v8_flags.sparkplug = false;
+  internal::FLAG_incremental_marking_task = false;
+}
+
+extern "C" DLLEXPORT bool V8IsMainThread() {
+  return IsMainThread();
+}
+
+static size_t gInReplayCode;
+
+bool recordreplay::IsInReplayCode(const char* why) {
+  return V8IsRecordingOrReplaying("replay-code", why) &&
+        IsMainThread() &&
+        gInReplayCode;
+}
+
+extern "C" DLLEXPORT bool V8RecordReplayIsInReplayCode(const char* why) {
+  return recordreplay::IsInReplayCode(why);
+}
+
+extern "C" DLLEXPORT void V8RecordReplayEnterReplayCode() {
+  CHECK(IsMainThread());
+  gInReplayCode++;
+}
+
+extern "C" DLLEXPORT void V8RecordReplayExitReplayCode() {
+  gInReplayCode--;
+}
+
+
+extern "C" DLLEXPORT void V8RecordReplayBeginAssertBufferAllocations(const char* issueLabel) {
+  if (!recordreplay::IsRecordingOrReplaying() || recordreplay::AreAssertsDisabled()) {
+    return;
+  }
+  recordreplay::AssertBufferAllocationState* state =
+    recordreplay::AutoAssertBufferAllocations::GetState();
+  
+  if (!state) {
+    state = new recordreplay::AssertBufferAllocationState;
+    state->issueLabel = issueLabel;
+    base::Thread::SetThreadLocal(gAssertBufferAllocationStateLSKey,
+      reinterpret_cast<void*>(state)
+    );
+  }
+  ++state->enabled;
+}
+
+extern "C" DLLEXPORT void V8RecordReplayEndAssertBufferAllocations() {
+  if (!recordreplay::IsRecordingOrReplaying() || recordreplay::AreAssertsDisabled()) {
+    return;
+  }
+  
+  recordreplay::AssertBufferAllocationState* state =
+    recordreplay::AutoAssertBufferAllocations::GetState();
+  --state->enabled;
+  if (!state->enabled) {
+    delete state;
+    base::Thread::SetThreadLocal(gAssertBufferAllocationStateLSKey, nullptr);
+  }
+}
+
+
+recordreplay::AutoAssertMaybeEventsDisallowed::AutoAssertMaybeEventsDisallowed(
+    const char* format, ...) {
+  base::EmbeddedVector<char, 1024> buf;
+  va_list arguments;
+  va_start(arguments, format);
+  base::VSNPrintF(buf, format, arguments);
+  va_end(arguments);
+  msg_ = std::string(buf.begin());
+
+  if (!gAssertsDisabled &&
+      IsRecordingOrReplaying() &&
+      (
+        !AreEventsDisallowed("AutoAssertMaybeEventsDisallowed")
+      )
+  ) {
+    recordreplay::Assert("%s", msg_.c_str());
+  }
+}
+
+recordreplay::AutoAssertMaybeEventsDisallowed::~AutoAssertMaybeEventsDisallowed() {
+  if (!gAssertsDisabled &&
+      IsRecordingOrReplaying() &&
+      (
+        !AreEventsDisallowed("AutoAssertMaybeEventsDisallowed")
+      )
+  ) {
+    recordreplay::Assert("%s", msg_.c_str());
+  }
+}
+
+// static
+recordreplay::AssertBufferAllocationState* recordreplay::AutoAssertBufferAllocations::GetState() {
+  return reinterpret_cast<recordreplay::AssertBufferAllocationState*>(
+    base::Thread::GetThreadLocal(gAssertBufferAllocationStateLSKey)
+  );
+}
+
+recordreplay::AutoAssertBufferAllocations::AutoAssertBufferAllocations(const char* issueLabel) {
+  V8RecordReplayBeginAssertBufferAllocations(issueLabel);
+}
+
+recordreplay::AutoAssertBufferAllocations::~AutoAssertBufferAllocations() {
+  V8RecordReplayEndAssertBufferAllocations();
+}
+
 
 namespace internal {
 

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -12968,7 +12968,7 @@ void recordreplay::Assert(const char* format, ...) {
   }
 }
 
-extern "C" void V8RecordReplayAssert(const char* format, ...) {
+extern "C" DLLEXPORT void V8RecordReplayAssert(const char* format, ...) {
   if (recordreplay::HasAsserts()) {
     va_list ap;
     va_start(ap, format);

--- a/src/ast/ast-value-factory.h
+++ b/src/ast/ast-value-factory.h
@@ -92,6 +92,14 @@ class AstRawString final : public ZoneObject {
     return string_;
   }
 
+  std::string to_string() const {
+    std::string rv;
+    for (int i = 0; i < length(); i++) {
+      rv += *(char*)(raw_data() + i * (is_one_byte() ? 1 : 2));
+    }
+    return rv;
+  }
+
 #ifdef OBJECT_PRINT
   void Print() const;
 #endif  // OBJECT_PRINT

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1787,12 +1787,16 @@ class CallBase : public Expression {
     return SpreadPositionField::decode(bit_field_);
   }
 
+  int call_head_token_position() const { return call_head_token_position_; }
+
  protected:
   CallBase(Zone* zone, NodeType type, Expression* expression,
-           const ScopedPtrList<Expression>& arguments, int pos, bool has_spread)
+           const ScopedPtrList<Expression>& arguments, int pos, bool has_spread,
+           int call_head_token_position)
       : Expression(pos, type),
         expression_(expression),
-        arguments_(arguments.ToConstVector(), zone) {
+        arguments_(arguments.ToConstVector(), zone),
+        call_head_token_position_(call_head_token_position) {
     DCHECK(type == kCall || type == kCallNew);
     if (has_spread) {
       ComputeSpreadPosition();
@@ -1811,6 +1815,7 @@ class CallBase : public Expression {
 
   Expression* expression_;
   ZonePtrList<Expression> arguments_;
+  int call_head_token_position_;
 };
 
 class Call final : public CallBase {
@@ -1872,8 +1877,8 @@ class Call final : public CallBase {
 
   Call(Zone* zone, Expression* expression,
        const ScopedPtrList<Expression>& arguments, int pos,
-       TaggedTemplateTag tag)
-      : CallBase(zone, kCall, expression, arguments, pos, false) {
+       TaggedTemplateTag tag, int call_head_token_position)
+      : CallBase(zone, kCall, expression, arguments, pos, false, call_head_token_position) {
     bit_field_ |= IsTaggedTemplateField::encode(true) |
                   IsOptionalChainLinkField::encode(false) |
                   EvalScopeInfoIndexField::encode(0);
@@ -1892,8 +1897,10 @@ class CallNew final : public CallBase {
   friend Zone;
 
   CallNew(Zone* zone, Expression* expression,
-          const ScopedPtrList<Expression>& arguments, int pos, bool has_spread)
-      : CallBase(zone, kCallNew, expression, arguments, pos, has_spread) {}
+          const ScopedPtrList<Expression>& arguments, int pos, bool has_spread,
+          int call_head_token_position)
+      : CallBase(zone, kCallNew, expression, arguments, pos, has_spread,
+                 call_head_token_position) {}
 };
 
 // SuperCallForwardArgs is not utterable in JavaScript. It is used to

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1867,8 +1867,10 @@ class Call final : public CallBase {
 
   Call(Zone* zone, Expression* expression,
        const ScopedPtrList<Expression>& arguments, int pos, bool has_spread,
-       int eval_scope_info_index, bool optional_chain)
-      : CallBase(zone, kCall, expression, arguments, pos, has_spread) {
+       int call_head_token_position, int eval_scope_info_index,
+       bool optional_chain)
+      : CallBase(zone, kCall, expression, arguments, pos, has_spread,
+                 call_head_token_position) {
     bit_field_ |= IsTaggedTemplateField::encode(false) |
                   IsOptionalChainLinkField::encode(optional_chain) |
                   EvalScopeInfoIndexField::encode(eval_scope_info_index);
@@ -3394,11 +3396,12 @@ class AstNodeFactory final {
 
   Call* NewCall(Expression* expression,
                 const ScopedPtrList<Expression>& arguments, int pos,
-                bool has_spread, int eval_scope_info_index = 0,
-                bool optional_chain = false) {
+                bool has_spread, int call_head_token_position,
+                int eval_scope_info_index = 0, bool optional_chain = false) {
     DCHECK_IMPLIES(eval_scope_info_index > 0, !optional_chain);
     return zone_->New<Call>(zone_, expression, arguments, pos, has_spread,
-                            eval_scope_info_index, optional_chain);
+                            call_head_token_position, eval_scope_info_index,
+                            optional_chain);
   }
 
   SuperCallForwardArgs* NewSuperCallForwardArgs(SuperCallReference* expression,
@@ -3407,15 +3410,18 @@ class AstNodeFactory final {
   }
 
   Call* NewTaggedTemplate(Expression* expression,
-                          const ScopedPtrList<Expression>& arguments, int pos) {
+                          const ScopedPtrList<Expression>& arguments, int pos,
+                          int call_head_token_position = 0) {
     return zone_->New<Call>(zone_, expression, arguments, pos,
-                            Call::TaggedTemplateTag::kTrue);
+                            Call::TaggedTemplateTag::kTrue,
+                            call_head_token_position);
   }
 
   CallNew* NewCallNew(Expression* expression,
                       const ScopedPtrList<Expression>& arguments, int pos,
-                      bool has_spread) {
-    return zone_->New<CallNew>(zone_, expression, arguments, pos, has_spread);
+                      bool has_spread, int call_head_token_position) {
+    return zone_->New<CallNew>(zone_, expression, arguments, pos, has_spread,
+                               call_head_token_position);
   }
 
   CallRuntime* NewCallRuntime(Runtime::FunctionId id,

--- a/src/ast/scopes.cc
+++ b/src/ast/scopes.cc
@@ -1270,6 +1270,14 @@ Variable* Scope::DeclareVariable(
       var = NonLocal(name, VariableMode::kDynamic);
       // Mark the var as used in case anyone outside the eval wants to use it.
       var->set_is_used();
+  // While replaying, force all variables to be context-allocated.
+  // Ideally we'd only do this for non-leaf functions, but it's not
+  // immediately obvious how to do that at this level.
+  // (RUN-2604)
+  if (recordreplay::IsReplaying() &&
+      recordreplay::FeatureEnabled("force-variable-context-allocation")) {
+    var->ForceContextAllocation();
+  }
     } else {
       // Declare the name.
       var = DeclareLocal(name, mode, kind, was_added, init);
@@ -1315,6 +1323,16 @@ Variable* Scope::DeclareVariable(
   // lead to repeated DeclareEvalVar or DeclareEvalFunction calls.
   decls_.Add(declaration);
   declaration->set_var(var);
+
+  // While replaying, force all variables to be context-allocated.
+  // Ideally we'd only do this for non-leaf functions, but it's not
+  // immediately obvious how to do that at this level.
+  // (RUN-2604)
+  if (recordreplay::IsReplaying() &&
+      recordreplay::FeatureEnabled("force-variable-context-allocation") &&
+      kind == VariableKind::NORMAL_VARIABLE) {
+        var->ForceContextAllocation();
+  }
   return var;
 }
 

--- a/src/base/build_config.h
+++ b/src/base/build_config.h
@@ -34,7 +34,10 @@
 #else
 #define V8_HAS_PKU_SUPPORT 0
 #endif
-#define V8_HAS_PKU_JIT_WRITE_PROTECT V8_HAS_PKU_SUPPORT
+// [replay] disable this to avoid dealing w/ dlsym
+// see https://linear.app/replay/issue/RUN-1085/chromium-108-crash-getkeypermission
+// #define V8_HAS_PKU_JIT_WRITE_PROTECT V8_HAS_PKU_SUPPORT
+#define V8_HAS_PKU_JIT_WRITE_PROTECT 0
 
 // pthread_jit_write_protect is only available on arm64 Mac.
 #if defined(V8_HOST_ARCH_ARM64) && defined(V8_OS_MACOS)

--- a/src/base/logging.cc
+++ b/src/base/logging.cc
@@ -184,6 +184,18 @@ class FailureMessage {
 
 }  // namespace
 
+const char* gCrashReason;
+
+extern "C" const char* V8RecordReplayCrashReasonCallback() {
+  return gCrashReason;
+}
+
+static __attribute__((noinline)) void BusyWait() {
+  fprintf(stderr, "Busy-waiting... (pid %d)", getpid());
+  volatile int x = 1;
+  while (x) {}
+}
+
 #if V8_LOGGING_LEVEL == 2
 void V8_Fatal(const char* file, int line, const char* format, ...) {
 #else
@@ -191,6 +203,18 @@ void V8_Fatal(const char* format, ...) {
   const char* file = "";
   int line = 0;
 #endif
+
+  {
+    char str[4096];
+    va_list arguments;
+    va_start(arguments, format);
+    vsnprintf(str, sizeof(str), format, arguments);
+    str[sizeof(str) - 1] = 0;
+    va_end(arguments);
+
+    gCrashReason = strdup(str);
+  }
+
   va_list arguments;
   va_start(arguments, format);
   // Format the error message into a stack object for later retrieveal by the
@@ -240,6 +264,12 @@ void V8_Fatal(const char* format, ...) {
   v8::base::PrintStackTraceIfAvailable();
 
   fflush(stderr);
+
+  if (getenv("RECORD_REPLAY_WAIT_AT_CRASH") ||
+      getenv("RECORD_REPLAY_WAIT_AT_FATAL_ERROR")) {
+    BusyWait();
+  }
+
   v8::base::OS::Abort();
 }
 

--- a/src/base/platform/condition-variable.cc
+++ b/src/base/platform/condition-variable.cc
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <time.h>
 
+#include "v8.h"
 #include "absl/time/time.h"
 #include "src/base/platform/time.h"
 

--- a/src/base/platform/elapsed-timer.h
+++ b/src/base/platform/elapsed-timer.h
@@ -8,6 +8,8 @@
 #include "src/base/logging.h"
 #include "src/base/platform/time.h"
 
+#include "replayio.h"
+
 namespace v8 {
 namespace base {
 
@@ -116,6 +118,7 @@ class ElapsedTimer final {
 
  private:
   static V8_INLINE TimeTicks Now() {
+    replayio::AutoPassThroughEvents pt;
     TimeTicks now = TimeTicks::Now();
     DCHECK(!now.IsNull());
     return now;

--- a/src/base/platform/mutex.cc
+++ b/src/base/platform/mutex.cc
@@ -51,7 +51,18 @@ bool RecursiveMutex::TryLock() {
   return false;
 }
 
-Mutex::Mutex() {
+Mutex::Mutex(const char* ordered_name) {
+  // record/replay: The original hook registered the underlying pthread mutex
+  // with the replay backend via V8RecordReplayAddOrderedPthreadMutex() so that
+  // lock/unlock ordering could be made deterministic. In this V8 the platform
+  // mutex is backed by absl::Mutex (native_handle_), which does not expose a
+  // pthread_mutex_t and is not implemented in terms of one, so there is no
+  // valid pthread_mutex_t* to register. Reinterpreting &native_handle_ as a
+  // pthread_mutex_t* would feed the backend a non-pthread object and cause
+  // divergence/crashes, so the registration is intentionally skipped here.
+  // The constructor still accepts |ordered_name| to stay ABI/source compatible
+  // with the ported header and call sites that pass a name.
+  USE(ordered_name);
 #ifdef DEBUG
   level_ = 0;
 #endif

--- a/src/base/platform/mutex.h
+++ b/src/base/platform/mutex.h
@@ -35,7 +35,7 @@ class ConditionVariable;
 
 class V8_BASE_EXPORT Mutex final {
  public:
-  Mutex();
+  Mutex(const char* ordered_name = nullptr);
   Mutex(const Mutex&) = delete;
   Mutex& operator=(const Mutex&) = delete;
   ~Mutex();

--- a/src/base/platform/platform-darwin.cc
+++ b/src/base/platform/platform-darwin.cc
@@ -50,9 +50,11 @@
 namespace v8 {
 namespace base {
 
-// Defined in v8_base (api.cc); declared weak so libbase-only build tools
-// (torque/mksnapshot) link with it resolving to null (they never record).
-extern "C" V8_WEAK bool V8RecordReplayIsARM();
+// Weak DEFINITION (not just a declaration): a weak undefined reference links on
+// ELF but not on macOS Mach-O ('symbol not found'). The strong DLLEXPORT
+// definition in v8_base (api.cc) overrides this for libv8; the libbase-only build
+// tools (torque/mksnapshot) get this false stub (they never record).
+extern "C" V8_WEAK bool V8RecordReplayIsARM() { return false; }
 
 namespace {
 
@@ -121,7 +123,7 @@ void OS::AdjustSchedulingParams() {
   // recordreplay::IsARMRecording() lives in v8_base (api.cc), which the
   // libbase-only build tools (torque/mksnapshot) don't link; reference the C ABI
   // weakly so those tools resolve it to null (a build tool never records).
-  if (V8RecordReplayIsARM && V8RecordReplayIsARM())
+  if (V8RecordReplayIsARM())
     return;
 
   {

--- a/src/base/platform/platform-darwin.cc
+++ b/src/base/platform/platform-darwin.cc
@@ -39,6 +39,8 @@
 #include "src/base/platform/platform-posix.h"
 #include "src/base/platform/platform.h"
 
+#include "v8.h"
+
 #if defined(V8_TARGET_OS_IOS)
 #include "src/base/ios-headers.h"
 #else
@@ -111,6 +113,10 @@ TimezoneCache* OS::CreateTimezoneCache() {
 
 void OS::AdjustSchedulingParams() {
 #if V8_TARGET_ARCH_X64 || V8_TARGET_ARCH_IA32
+  // Avoid making system calls that didn't originally happen if we recorded on ARM.
+  if (recordreplay::IsARMRecording())
+    return;
+
   {
     // Check availability of scheduling params.
     uint32_t val = 0;

--- a/src/base/platform/platform-darwin.cc
+++ b/src/base/platform/platform-darwin.cc
@@ -114,7 +114,11 @@ TimezoneCache* OS::CreateTimezoneCache() {
 void OS::AdjustSchedulingParams() {
 #if V8_TARGET_ARCH_X64 || V8_TARGET_ARCH_IA32
   // Avoid making system calls that didn't originally happen if we recorded on ARM.
-  if (recordreplay::IsARMRecording())
+  // recordreplay::IsARMRecording() lives in v8_base (api.cc), which the
+  // libbase-only build tools (torque/mksnapshot) don't link; reference the C ABI
+  // weakly so those tools resolve it to null (a build tool never records).
+  extern "C" V8_WEAK bool V8RecordReplayIsARM();
+  if (V8RecordReplayIsARM && V8RecordReplayIsARM())
     return;
 
   {

--- a/src/base/platform/platform-darwin.cc
+++ b/src/base/platform/platform-darwin.cc
@@ -50,6 +50,10 @@
 namespace v8 {
 namespace base {
 
+// Defined in v8_base (api.cc); declared weak so libbase-only build tools
+// (torque/mksnapshot) link with it resolving to null (they never record).
+extern "C" V8_WEAK bool V8RecordReplayIsARM();
+
 namespace {
 
 vm_prot_t GetVMProtFromMemoryPermission(OS::MemoryPermission access) {
@@ -117,7 +121,6 @@ void OS::AdjustSchedulingParams() {
   // recordreplay::IsARMRecording() lives in v8_base (api.cc), which the
   // libbase-only build tools (torque/mksnapshot) don't link; reference the C ABI
   // weakly so those tools resolve it to null (a build tool never records).
-  extern "C" V8_WEAK bool V8RecordReplayIsARM();
   if (V8RecordReplayIsARM && V8RecordReplayIsARM())
     return;
 

--- a/src/base/platform/platform-linux.cc
+++ b/src/base/platform/platform-linux.cc
@@ -45,6 +45,8 @@
 #include "src/base/platform/platform-posix.h"
 #include "src/base/platform/platform.h"
 
+#include "v8.h"
+
 namespace v8 {
 namespace base {
 
@@ -90,6 +92,9 @@ void* OS::RemapShared(void* old_address, void* new_address, size_t size) {
 std::optional<OS::MemoryRange> OS::GetFirstFreeMemoryRangeWithin(
     OS::Address boundary_start, OS::Address boundary_end, size_t minimum_size,
     size_t alignment) {
+  // Reading from /proc/self/maps isn't supported when recording/replaying.
+  if (recordreplay::IsRecordingOrReplaying()) return {};
+
   std::optional<OS::MemoryRange> result;
   SignalSafeMapsParser parser;
   if (!parser.IsValid()) return {};
@@ -131,6 +136,9 @@ namespace {
 std::unique_ptr<std::vector<MemoryRegion>> ParseProcSelfMaps(
     FILE* fp, std::function<bool(const MemoryRegion&)> predicate,
     bool early_stopping) {
+  // Reading from /proc/self/maps isn't supported when recording/replaying.
+  if (recordreplay::IsRecordingOrReplaying()) return nullptr;
+
   auto result = std::make_unique<std::vector<MemoryRegion>>();
 
   // Create parser. If fp is provided, use its fd.

--- a/src/base/platform/platform-linux.cc
+++ b/src/base/platform/platform-linux.cc
@@ -93,7 +93,11 @@ std::optional<OS::MemoryRange> OS::GetFirstFreeMemoryRangeWithin(
     OS::Address boundary_start, OS::Address boundary_end, size_t minimum_size,
     size_t alignment) {
   // Reading from /proc/self/maps isn't supported when recording/replaying.
-  if (recordreplay::IsRecordingOrReplaying()) return {};
+  // C ABI referenced weakly so libbase-only build tools (torque/mksnapshot) link
+  // (recordreplay::IsRecordingOrReplaying() is defined in v8_base/api.cc).
+  extern "C" V8_WEAK bool V8IsRecordingOrReplaying(const char*, const char*);
+  if (V8IsRecordingOrReplaying && V8IsRecordingOrReplaying(nullptr, nullptr))
+    return {};
 
   std::optional<OS::MemoryRange> result;
   SignalSafeMapsParser parser;
@@ -137,7 +141,10 @@ std::unique_ptr<std::vector<MemoryRegion>> ParseProcSelfMaps(
     FILE* fp, std::function<bool(const MemoryRegion&)> predicate,
     bool early_stopping) {
   // Reading from /proc/self/maps isn't supported when recording/replaying.
-  if (recordreplay::IsRecordingOrReplaying()) return nullptr;
+  // C ABI referenced weakly so libbase-only build tools (torque/mksnapshot) link.
+  extern "C" V8_WEAK bool V8IsRecordingOrReplaying(const char*, const char*);
+  if (V8IsRecordingOrReplaying && V8IsRecordingOrReplaying(nullptr, nullptr))
+    return nullptr;
 
   auto result = std::make_unique<std::vector<MemoryRegion>>();
 

--- a/src/base/platform/platform-linux.cc
+++ b/src/base/platform/platform-linux.cc
@@ -50,9 +50,13 @@
 namespace v8 {
 namespace base {
 
-// Defined in v8_base (api.cc); declared weak so libbase-only build tools
-// (torque/mksnapshot) link with it resolving to null (they never record).
-extern "C" V8_WEAK bool V8IsRecordingOrReplaying(const char*, const char*);
+// Weak DEFINITION (not just a declaration): a weak undefined reference links on
+// ELF but not on macOS Mach-O. The strong DLLEXPORT definition in v8_base
+// (api.cc) overrides this for libv8; libbase-only build tools (torque/mksnapshot)
+// get this false stub (they never record).
+extern "C" V8_WEAK bool V8IsRecordingOrReplaying(const char*, const char*) {
+  return false;
+}
 
 TimezoneCache* OS::CreateTimezoneCache() {
   return new PosixDefaultTimezoneCache();
@@ -99,7 +103,7 @@ std::optional<OS::MemoryRange> OS::GetFirstFreeMemoryRangeWithin(
   // Reading from /proc/self/maps isn't supported when recording/replaying.
   // C ABI referenced weakly so libbase-only build tools (torque/mksnapshot) link
   // (recordreplay::IsRecordingOrReplaying() is defined in v8_base/api.cc).
-  if (V8IsRecordingOrReplaying && V8IsRecordingOrReplaying(nullptr, nullptr))
+  if (V8IsRecordingOrReplaying(nullptr, nullptr))
     return {};
 
   std::optional<OS::MemoryRange> result;
@@ -145,7 +149,7 @@ std::unique_ptr<std::vector<MemoryRegion>> ParseProcSelfMaps(
     bool early_stopping) {
   // Reading from /proc/self/maps isn't supported when recording/replaying.
   // C ABI referenced weakly so libbase-only build tools (torque/mksnapshot) link.
-  if (V8IsRecordingOrReplaying && V8IsRecordingOrReplaying(nullptr, nullptr))
+  if (V8IsRecordingOrReplaying(nullptr, nullptr))
     return nullptr;
 
   auto result = std::make_unique<std::vector<MemoryRegion>>();

--- a/src/base/platform/platform-linux.cc
+++ b/src/base/platform/platform-linux.cc
@@ -50,6 +50,10 @@
 namespace v8 {
 namespace base {
 
+// Defined in v8_base (api.cc); declared weak so libbase-only build tools
+// (torque/mksnapshot) link with it resolving to null (they never record).
+extern "C" V8_WEAK bool V8IsRecordingOrReplaying(const char*, const char*);
+
 TimezoneCache* OS::CreateTimezoneCache() {
   return new PosixDefaultTimezoneCache();
 }
@@ -95,7 +99,6 @@ std::optional<OS::MemoryRange> OS::GetFirstFreeMemoryRangeWithin(
   // Reading from /proc/self/maps isn't supported when recording/replaying.
   // C ABI referenced weakly so libbase-only build tools (torque/mksnapshot) link
   // (recordreplay::IsRecordingOrReplaying() is defined in v8_base/api.cc).
-  extern "C" V8_WEAK bool V8IsRecordingOrReplaying(const char*, const char*);
   if (V8IsRecordingOrReplaying && V8IsRecordingOrReplaying(nullptr, nullptr))
     return {};
 
@@ -142,7 +145,6 @@ std::unique_ptr<std::vector<MemoryRegion>> ParseProcSelfMaps(
     bool early_stopping) {
   // Reading from /proc/self/maps isn't supported when recording/replaying.
   // C ABI referenced weakly so libbase-only build tools (torque/mksnapshot) link.
-  extern "C" V8_WEAK bool V8IsRecordingOrReplaying(const char*, const char*);
   if (V8IsRecordingOrReplaying && V8IsRecordingOrReplaying(nullptr, nullptr))
     return nullptr;
 

--- a/src/base/platform/platform-win32.cc
+++ b/src/base/platform/platform-win32.cc
@@ -1081,7 +1081,10 @@ void OS::SetDataReadOnly(void* address, size_t size) {
 
   DWORD old_protection;
   CHECK(VirtualProtect(address, size, PAGE_READONLY, &old_protection));
-  CHECK(old_protection == PAGE_READWRITE || old_protection == PAGE_WRITECOPY);
+
+  // When replaying VirtualProtect doesn't indicate the old protection,
+  // so disable the check.
+  //CHECK(old_protection == PAGE_READWRITE || old_protection == PAGE_WRITECOPY);
 }
 
 bool OS::SetMemoryRegionName(const void* address, size_t size,

--- a/src/base/platform/platform.h
+++ b/src/base/platform/platform.h
@@ -78,6 +78,9 @@ namespace v8::base {
 // ----------------------------------------------------------------------------
 // Fast TLS support
 
+// The Record Replay driver does not currently support direct access to TLS.
+#define V8_NO_FAST_TLS
+
 #ifndef V8_NO_FAST_TLS
 
 #if V8_CC_MSVC && V8_HOST_ARCH_IA32

--- a/src/base/platform/time.cc
+++ b/src/base/platform/time.cc
@@ -131,14 +131,20 @@ V8_INLINE int64_t ClockNow(clockid_t clk_id) {
 #endif
 }
 
+/*
 V8_INLINE int64_t NanosecondsNow() {
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
   return int64_t{ts.tv_sec} * v8::base::Time::kNanosecondsPerSecond +
          ts.tv_nsec;
 }
+*/
 
 inline bool IsHighResolutionTimer(clockid_t clk_id) {
+  // Avoid interacting with the system when recording/replaying.
+  // Testing IsRecordingOrReplaying() here leads to link errors...
+  return true;
+  /*
   // Currently this is only needed for CLOCK_MONOTONIC. If other clocks need
   // to be checked, care must be taken to support all platforms correctly;
   // see ClockNow() above for precedent.
@@ -162,6 +168,7 @@ inline bool IsHighResolutionTimer(clockid_t clk_id) {
   // a fast desktop). If we still haven't seen a non-zero clock increment
   // in sub-microsecond range, assume a low resolution timer.
   return false;
+  */
 }
 
 #elif V8_OS_WIN

--- a/src/base/replayio.h
+++ b/src/base/replayio.h
@@ -11,7 +11,7 @@
 
 #include "include/replayio.h"
 
-#include "src/base/optional.h"
+#include <optional>
 
 namespace v8 {
 namespace replayio {
@@ -24,7 +24,7 @@ struct AutoMaybeDisallowEvents {
   }
   
 private:
-  v8::base::Optional<v8::replayio::AutoDisallowEvents> disallow;
+  std::optional<v8::replayio::AutoDisallowEvents> disallow;
 };
 
 }  // namespace replayio

--- a/src/base/replayio.h
+++ b/src/base/replayio.h
@@ -1,0 +1,33 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file is a clone of "base/optional.h" in chromium.
+// Keep in sync, especially when fixing bugs.
+// Copyright 2017 the V8 project authors. All rights reserved.
+
+#ifndef V8_BASE_REPLAYIO_H
+#define V8_BASE_REPLAYIO_H
+
+#include "include/replayio.h"
+
+#include "src/base/optional.h"
+
+namespace v8 {
+namespace replayio {
+
+struct AutoMaybeDisallowEvents {
+  AutoMaybeDisallowEvents(bool disallowEvents, const char* label) {
+    if (disallowEvents) {
+      disallow.emplace(label);
+    }
+  }
+  
+private:
+  v8::base::Optional<v8::replayio::AutoDisallowEvents> disallow;
+};
+
+}  // namespace replayio
+}  // namespace v8
+
+#endif  // V8_BASE_REPLAYIO_H

--- a/src/baseline/baseline-assembler.h
+++ b/src/baseline/baseline-assembler.h
@@ -234,6 +234,8 @@ class BaselineAssembler {
   inline void SmiUntag(Register value);
   inline void SmiUntag(Register output, Register value);
 
+  inline void AddPointer(Register output, Immediate value);
+
   inline void Word32And(Register output, Register lhs, int rhs);
 
   inline void Switch(Register reg, int case_value_base, Label** labels,

--- a/src/baseline/baseline-compiler.cc
+++ b/src/baseline/baseline-compiler.cc
@@ -63,6 +63,7 @@
 
 namespace v8 {
 namespace internal {
+
 namespace baseline {
 
 #define __ basm_.
@@ -2695,6 +2696,68 @@ void BaselineCompiler::VisitIncBlockCounter() {
   SaveAccumulatorScope accumulator_scope(this, &basm_);
   CallBuiltin<Builtin::kIncBlockCounter>(
       __ FunctionOperand(), CoverageSlotAsSmi(0));  // coverage array slot
+}
+
+void BaselineCompiler::VisitRecordReplayIncExecutionProgressCounter() {
+  // The optimized path is currently disabled.
+  // See https://linear.app/replay/issue/RUN-744
+  if ((true)/*gRecordReplayAssertProgress*/) {
+    CallRuntime(Runtime::kRecordReplayAssertExecutionProgress,
+                __ FunctionOperand());
+  } else {
+    /*
+    BaselineAssembler::ScratchRegisterScope scratch_scope(&basm_);
+    Register reg1 = scratch_scope.AcquireScratch();
+    Register reg2 = scratch_scope.AcquireScratch();
+    __ Move(reg1, ExternalReference::record_replay_progress_counter());
+    __ Move(reg2, MemOperand(reg1, 0));
+    __ AddPointer(reg2, Immediate(1));
+    __ Move(MemOperand(reg1, 0), reg2);
+    __ Move(reg1, ExternalReference::record_replay_target_progress());
+    __ ComparePointer(reg2, MemOperand(reg1, 0));
+    Label done;
+    __ JumpIf(Condition::kNotEqual, &done, Label::kNear);
+    CallRuntime(Runtime::kRecordReplayTargetProgressReached);
+    __ Bind(&done);
+    */
+  }
+}
+
+void BaselineCompiler::VisitRecordReplayNotifyActivity() {
+  CallRuntime(Runtime::kRecordReplayNotifyActivity);
+}
+
+void BaselineCompiler::VisitRecordReplayInstrumentation() {
+  SaveAccumulatorScope accumulator_scope(&basm_);
+  uint32_t index = Index(0);
+  CallRuntime(Runtime::kRecordReplayInstrumentation,
+              __ FunctionOperand(), Smi::FromInt(index));
+}
+
+void BaselineCompiler::VisitRecordReplayInstrumentationGenerator() {
+  SaveAccumulatorScope accumulator_scope(&basm_);
+  uint32_t index = Index(0);
+  CallRuntime(Runtime::kRecordReplayInstrumentationGenerator,
+              __ FunctionOperand(), Smi::FromInt(index), RegisterOperand(1));
+}
+
+void BaselineCompiler::VisitRecordReplayInstrumentationReturn() {
+  SaveAccumulatorScope accumulator_scope(&basm_);
+  uint32_t index = Index(0);
+  CallRuntime(Runtime::kRecordReplayInstrumentationReturn,
+              __ FunctionOperand(), Smi::FromInt(index), RegisterOperand(1));
+}
+
+void BaselineCompiler::VisitRecordReplayAssertValue() {
+  SaveAccumulatorScope accumulator_scope(&basm_);
+  CallRuntime(Runtime::kRecordReplayAssertValue,
+              __ FunctionOperand(), Smi::FromInt(Index(0)),
+              kInterpreterAccumulatorRegister);
+}
+
+void BaselineCompiler::VisitRecordReplayTrackObjectId() {
+  SaveAccumulatorScope accumulator_scope(&basm_);
+  CallRuntime(Runtime::kRecordReplayTrackObjectId, RegisterOperand(0));
 }
 
 void BaselineCompiler::VisitAbort() {

--- a/src/baseline/baseline-compiler.cc
+++ b/src/baseline/baseline-compiler.cc
@@ -2728,35 +2728,35 @@ void BaselineCompiler::VisitRecordReplayNotifyActivity() {
 }
 
 void BaselineCompiler::VisitRecordReplayInstrumentation() {
-  SaveAccumulatorScope accumulator_scope(&basm_);
-  uint32_t index = Index(0);
+  SaveAccumulatorScope accumulator_scope(this, &basm_);
+  uint32_t index = Uint(0);
   CallRuntime(Runtime::kRecordReplayInstrumentation,
               __ FunctionOperand(), Smi::FromInt(index));
 }
 
 void BaselineCompiler::VisitRecordReplayInstrumentationGenerator() {
-  SaveAccumulatorScope accumulator_scope(&basm_);
-  uint32_t index = Index(0);
+  SaveAccumulatorScope accumulator_scope(this, &basm_);
+  uint32_t index = Uint(0);
   CallRuntime(Runtime::kRecordReplayInstrumentationGenerator,
               __ FunctionOperand(), Smi::FromInt(index), RegisterOperand(1));
 }
 
 void BaselineCompiler::VisitRecordReplayInstrumentationReturn() {
-  SaveAccumulatorScope accumulator_scope(&basm_);
-  uint32_t index = Index(0);
+  SaveAccumulatorScope accumulator_scope(this, &basm_);
+  uint32_t index = Uint(0);
   CallRuntime(Runtime::kRecordReplayInstrumentationReturn,
               __ FunctionOperand(), Smi::FromInt(index), RegisterOperand(1));
 }
 
 void BaselineCompiler::VisitRecordReplayAssertValue() {
-  SaveAccumulatorScope accumulator_scope(&basm_);
+  SaveAccumulatorScope accumulator_scope(this, &basm_);
   CallRuntime(Runtime::kRecordReplayAssertValue,
-              __ FunctionOperand(), Smi::FromInt(Index(0)),
+              __ FunctionOperand(), Smi::FromInt(Uint(0)),
               kInterpreterAccumulatorRegister);
 }
 
 void BaselineCompiler::VisitRecordReplayTrackObjectId() {
-  SaveAccumulatorScope accumulator_scope(&basm_);
+  SaveAccumulatorScope accumulator_scope(this, &basm_);
   CallRuntime(Runtime::kRecordReplayTrackObjectId, RegisterOperand(0));
 }
 

--- a/src/baseline/x64/baseline-assembler-x64-inl.h
+++ b/src/baseline/x64/baseline-assembler-x64-inl.h
@@ -567,6 +567,10 @@ void BaselineAssembler::IncrementSmi(MemOperand lhs) {
   __ SmiAddConstant(lhs, Smi::FromInt(1));
 }
 
+void BaselineAssembler::AddPointer(Register output, Immediate value) {
+  __ addq(output, value);
+}
+
 void BaselineAssembler::Word32And(Register output, Register lhs, int rhs) {
   Move(output, lhs);
   __ andq(output, Immediate(rhs));

--- a/src/builtins/builtins-global.cc
+++ b/src/builtins/builtins-global.cc
@@ -82,6 +82,9 @@ BUILTIN(GlobalUnescape) {
 
 // ES6 section 18.2.1 eval (x)
 BUILTIN(GlobalEval) {
+  // https://linear.app/replay/issue/RUN-544
+  recordreplay::Assert("BUILTIN(GlobalEval) Start");
+
   HandleScope scope(isolate);
   Handle<Object> x = args.atOrUndefined(isolate, 1);
   DirectHandle<JSFunction> target = args.target();
@@ -99,7 +102,11 @@ BUILTIN(GlobalEval) {
   std::tie(source, unhandled_object) =
       Compiler::ValidateDynamicCompilationSource(
           isolate, direct_handle(target->native_context(), isolate), x);
-  if (unhandled_object) return *x;
+  if (unhandled_object) {
+    // https://linear.app/replay/issue/RUN-544
+    recordreplay::Assert("BUILTIN(GlobalEval) #2");
+    return *x;
+  }
 
   DirectHandle<JSFunction> function;
   ASSIGN_RETURN_FAILURE_ON_EXCEPTION(
@@ -107,6 +114,10 @@ BUILTIN(GlobalEval) {
       Compiler::GetFunctionFromValidatedString(
           isolate, direct_handle(target->native_context(), isolate), source,
           NO_PARSE_RESTRICTION, kNoSourcePosition));
+
+  // https://linear.app/replay/issue/RUN-544
+  recordreplay::Assert("BUILTIN(GlobalEval) #3");
+
   RETURN_RESULT_OR_FAILURE(
       isolate, Execution::Call(isolate, function, target_global_proxy, {}));
 }

--- a/src/builtins/weak-ref.tq
+++ b/src/builtins/weak-ref.tq
@@ -9,6 +9,12 @@ namespace runtime {
 extern runtime JSWeakRefAddToKeptObjects(
     implicit context: Context)(JSReceiver|Symbol): void;
 
+extern runtime JSReplayWeakRefConstruct(implicit context: Context)(
+    JSReceiver | Symbol): void;
+
+extern runtime JSReplayWeakRefDeref(implicit context: Context)(
+    JSWeakRef): JSAny;
+
 }  // namespace runtime
 
 namespace weakref {
@@ -44,6 +50,7 @@ transitioning javascript builtin WeakRefConstructor(
   // and don't need generational barriers for the reference from `weakRef` to
   // `weakTarget`.
   weakRef.target = weakTarget;
+  runtime::JSReplayWeakRefConstruct(weakTarget);
   // 4. Perfom ! AddToKeptObjects(target).
   runtime::JSWeakRefAddToKeptObjects(weakTarget);
   // 6. Return weakRef.
@@ -59,7 +66,7 @@ transitioning javascript builtin WeakRefDeref(
       MessageTemplate::kIncompatibleMethodReceiver, 'WeakRef.prototype.deref',
       receiver);
   // 3. Let target be the value of weakRef.[[WeakRefTarget]].
-  const target = weakRef.target;
+  const target = runtime::JSReplayWeakRefDeref(weakRef);
   // 4. If target is not empty,
   //   a. Perform ! AddToKeptObjects(target).
   //   b. Return target.

--- a/src/codegen/compilation-cache.cc
+++ b/src/codegen/compilation-cache.cc
@@ -265,6 +265,11 @@ InfoCellPair CompilationCache::LookupEval(
   InfoCellPair result;
   if (!IsEnabledScriptAndEval()) return result;
 
+  // Evaluations aren't cached when recording/replaying because new sources
+  // will not be generated on a cache hit, and sources need to be generated
+  // at deterministic points.
+  if (recordreplay::IsRecordingOrReplaying("no-eval-cache")) return result;
+
   const char* cache_type;
 
   DirectHandle<NativeContext> maybe_native_context;
@@ -274,7 +279,7 @@ InfoCellPair CompilationCache::LookupEval(
     cache_type = "eval-global";
 
   } else {
-    DCHECK_NE(position, kNoSourcePosition);
+    //DCHECK_NE(position, kNoSourcePosition);
     DirectHandle<NativeContext> native_context(context->native_context(),
                                                isolate());
     result = eval_contextual_.Lookup(source, outer_info, native_context,
@@ -309,12 +314,14 @@ void CompilationCache::PutEval(DirectHandle<String> source,
                                int position) {
   if (!IsEnabledScriptAndEval()) return;
 
+  if (recordreplay::IsRecordingOrReplaying("no-eval-cache")) return;
+
   const char* cache_type;
   if (IsNativeContext(js_function->context())) {
     eval_global_.Put(source, outer_info, js_function, position);
     cache_type = "eval-global";
   } else {
-    DCHECK_NE(position, kNoSourcePosition);
+    //DCHECK_NE(position, kNoSourcePosition);
     eval_contextual_.Put(source, outer_info, js_function, position);
     cache_type = "eval-contextual";
   }

--- a/src/codegen/compiler.cc
+++ b/src/codegen/compiler.cc
@@ -1604,18 +1604,11 @@ Handle<SharedFunctionInfo> GetOrCreateTopLevelSharedFunctionInfo(
   return CreateTopLevelSharedFunctionInfo(parse_info, script, isolate);
 }
 
-MaybeHandle<SharedFunctionInfo> CompileToplevel(
-    ParseInfo* parse_info, Handle<Script> script,
-    MaybeDirectHandle<ScopeInfo> maybe_outer_scope_info, Isolate* isolate,
-    IsCompiledScope* is_compiled_scope) {
-  TimerEventScope<TimerEventCompileCode> top_level_timer(isolate);
-  TRACE_EVENT(TRACE_DISABLED_BY_DEFAULT("v8.compile"), "V8.CompileCode");
-  DCHECK_EQ(ThreadId::Current(), isolate->thread_id());
-
 extern bool RecordReplayHasDefaultContext();
 extern bool RecordReplayAssertValues(const std::string& url);
 
-static void SetRecordReplayFlags(UnoptimizedCompileFlags& flags, const std::string& url) {
+static void SetRecordReplayFlags(UnoptimizedCompileFlags& flags,
+                                 const std::string& url) {
   if (!recordreplay::IsRecordingOrReplaying()) {
     return;
   }
@@ -1632,6 +1625,14 @@ static void SetRecordReplayFlags(UnoptimizedCompileFlags& flags, const std::stri
     flags.set_record_replay_assert_values(true);
   }
 }
+
+MaybeHandle<SharedFunctionInfo> CompileToplevel(
+    ParseInfo* parse_info, Handle<Script> script,
+    MaybeDirectHandle<ScopeInfo> maybe_outer_scope_info, Isolate* isolate,
+    IsCompiledScope* is_compiled_scope) {
+  TimerEventScope<TimerEventCompileCode> top_level_timer(isolate);
+  TRACE_EVENT(TRACE_DISABLED_BY_DEFAULT("v8.compile"), "V8.CompileCode");
+  DCHECK_EQ(ThreadId::Current(), isolate->thread_id());
 
   PostponeInterruptsScope postpone(isolate);
   DCHECK(!isolate->native_context().is_null());
@@ -1681,14 +1682,6 @@ static void SetRecordReplayFlags(UnoptimizedCompileFlags& flags, const std::stri
   FinalizeUnoptimizedScriptCompilation(
       isolate, script, parse_info->flags(), parse_info->state(),
       finalize_unoptimized_compilation_data_list);
-
-  std::string url;
-  Handle<Script> script(Script::cast(shared_info->script()), isolate);
-  if (!script->name().IsUndefined()) {
-    std::unique_ptr<char[]> name = String::cast(script->name()).ToCString();
-    url = name.get();
-  }
-  SetRecordReplayFlags(flags_, url);
 
   if (v8_flags.always_sparkplug) {
     CompileAllWithBaseline(isolate, finalize_unoptimized_compilation_data_list);
@@ -3962,14 +3955,6 @@ class StressBackgroundCompileThread : public ParkingThread {
     std::unique_ptr<uint16_t[]> source_buffer_;
     bool done_;
   };
-
-    std::string url;
-    Handle<Object> script_name;
-    if (script_details.name_obj.ToHandle(&script_name) && script_name->IsString()) {
-      std::unique_ptr<char[]> name = String::cast(*script_name).ToCString();
-      url = name.get();
-    }
-    SetRecordReplayFlags(flags, url);
 
   Handle<String> source_;
   v8::ScriptCompiler::StreamedSource streamed_source_;

--- a/src/codegen/compiler.cc
+++ b/src/codegen/compiler.cc
@@ -4429,37 +4429,37 @@ MaybeDirectHandle<JSFunction> Compiler::GetWrappedFunction(
   // replace the result.
   MaybeHandle<String> new_source = ReplayingReplaceScriptContents(isolate, source);
   if (!new_source.is_null()) {
-    MaybeHandle<ScopeInfo> maybe_outer_scope_info;
-    if (!context->IsNativeContext()) {
-      maybe_outer_scope_info = handle(context->scope_info(), isolate);
-    }
-
+    // Mirror the wrapped-function compile path above, but for the replaced
+    // source, and replace |result| with the recompiled SharedFunctionInfo.
     UnoptimizedCompileFlags flags = UnoptimizedCompileFlags::ForToplevelCompile(
-        isolate, true, language_mode, REPLMode::kNo, ScriptType::kClassic,
-        v8_flags.lazy_eval, script->id());
-    flags.set_is_eval(true);
-    flags.set_parsing_while_debugging(parsing_while_debugging);
-    DCHECK(!flags.is_module());
-    flags.set_parse_restriction(restriction);
+        isolate, true, language_mode, script_details.repl_mode,
+        ScriptType::kClassic, v8_flags.lazy);
+    flags.set_is_eval(true);  // Use an eval scope as declaration scope.
+    flags.set_function_syntax_kind(FunctionSyntaxKind::kWrapped);
+    flags.set_collect_source_positions(true);
+    flags.set_is_eager(compile_options & ScriptCompiler::kEagerCompile);
 
     SetRecordReplayFlags(flags, "");
 
     UnoptimizedCompileState compile_state;
     ReusableUnoptimizedCompileState reusable_state(isolate);
     ParseInfo parse_info(isolate, flags, &compile_state, &reusable_state);
-    parse_info.set_parameters_end_pos(parameters_end_pos);
 
-    Handle<Script> new_script = parse_info.CreateScript(
-        isolate, new_source.ToHandleChecked(), kNullMaybeHandle,
-        OriginOptionsForEval(outer_info->script(), parsing_while_debugging));
+    MaybeDirectHandle<ScopeInfo> maybe_outer_scope_info;
+    if (!IsNativeContext(*context)) {
+      maybe_outer_scope_info = direct_handle(context->scope_info(), isolate);
+    }
+    Handle<Script> new_script = NewScript(
+        isolate, &parse_info, new_source.ToHandleChecked(), script_details,
+        NOT_NATIVES_CODE);
 
-    Handle<SharedFunctionInfo> new_shared_info =
-      v8::internal::CompileToplevel(&parse_info, new_script,
-                                    maybe_outer_scope_info, isolate,
-                                    &is_compiled_scope)
-        .ToHandleChecked();
+    DirectHandle<SharedFunctionInfo> new_shared_info =
+        v8::internal::CompileToplevel(&parse_info, new_script,
+                                      maybe_outer_scope_info, isolate,
+                                      &is_compiled_scope)
+            .ToHandleChecked();
 
-    result = Factory::JSFunctionBuilder{isolate, new_shared_info, context}.Build();
+    result = new_shared_info;
   }
 
   return Factory::JSFunctionBuilder{isolate, result, context}

--- a/src/codegen/compiler.cc
+++ b/src/codegen/compiler.cc
@@ -81,6 +81,14 @@
 namespace v8 {
 namespace internal {
 
+extern MaybeHandle<Script> MaybeGetScript(Isolate* isolate, int script_id);
+extern Handle<Script> GetScript(Isolate* isolate, int script_id);
+
+extern int gReplaceSourceContentsScriptId;
+
+extern MaybeHandle<String>
+ReplayingReplaceScriptContents(Isolate* isolate, Handle<String> source);
+
 namespace {
 
 constexpr bool IsOSR(BytecodeOffset osr_offset) { return !osr_offset.IsNone(); }
@@ -154,6 +162,10 @@ class CompilerTracer : public AllStatic {
                                           DirectHandle<JSFunction> function,
                                           BytecodeOffset osr_offset,
                                           ConcurrencyMode mode) {
+  // The point at which optimized compilations occur can vary between recording
+  // and replaying.
+  replayio::AutoDisallowEvents disallow("Compiler::CompileOptimizedOSR");
+
     if (!v8_flags.trace_osr) return;
     CodeTracer::Scope scope(isolate->GetCodeTracer());
     PrintF(scope.file(),
@@ -671,6 +683,10 @@ bool UseAsmWasm(FunctionLiteral* literal, bool asm_wasm_broken) {
   // Modules that have validated successfully, but were subsequently broken by
   // invalid module instantiation attempts are off limit forever.
   if (asm_wasm_broken) return false;
+
+  // Instrumentation added when recording/replaying requires that scripts be
+  // compiled in the regular way.
+  if (recordreplay::IsRecordingOrReplaying("no-asm-wasm")) return false;
 
   // In stress mode we want to run the validator on everything.
   if (v8_flags.stress_validate_asm) return true;
@@ -1595,6 +1611,27 @@ MaybeHandle<SharedFunctionInfo> CompileToplevel(
   TRACE_EVENT(TRACE_DISABLED_BY_DEFAULT("v8.compile"), "V8.CompileCode");
   DCHECK_EQ(ThreadId::Current(), isolate->thread_id());
 
+extern bool RecordReplayHasDefaultContext();
+extern bool RecordReplayAssertValues(const std::string& url);
+
+static void SetRecordReplayFlags(UnoptimizedCompileFlags& flags, const std::string& url) {
+  if (!recordreplay::IsRecordingOrReplaying()) {
+    return;
+  }
+
+  if (!IsMainThread() ||
+      !RecordReplayHasDefaultContext() ||
+      recordreplay::AreEventsDisallowed("CompileFlags") ||
+      recordreplay::IsInReplayCode("CompileFlags")) {
+    flags.set_record_replay_ignore(true);
+    return;
+  }
+
+  if (RecordReplayAssertValues(url)) {
+    flags.set_record_replay_assert_values(true);
+  }
+}
+
   PostponeInterruptsScope postpone(isolate);
   DCHECK(!isolate->native_context().is_null());
   RCS_SCOPE(isolate, parse_info->flags().is_eval()
@@ -1643,6 +1680,14 @@ MaybeHandle<SharedFunctionInfo> CompileToplevel(
   FinalizeUnoptimizedScriptCompilation(
       isolate, script, parse_info->flags(), parse_info->state(),
       finalize_unoptimized_compilation_data_list);
+
+  std::string url;
+  Handle<Script> script(Script::cast(shared_info->script()), isolate);
+  if (!script->name().IsUndefined()) {
+    std::unique_ptr<char[]> name = String::cast(script->name()).ToCString();
+    url = name.get();
+  }
+  SetRecordReplayFlags(flags_, url);
 
   if (v8_flags.always_sparkplug) {
     CompileAllWithBaseline(isolate, finalize_unoptimized_compilation_data_list);
@@ -1936,6 +1981,14 @@ class MergeAssumptionChecker final : public ObjectVisitor {
 
 }  // namespace
 
+// For use when checking that record/replay opcodes are only emitted
+// for the main thread.
+static std::atomic<size_t> gNumRunningBackgroundCompileTasks;
+
+size_t NumRunningBackgroundCompileTasks() {
+  return gNumRunningBackgroundCompileTasks;
+}
+
 bool BackgroundCompileTask::is_streaming_compilation() const {
   return function_literal_id_ == kFunctionLiteralIdTopLevel;
 }
@@ -1962,6 +2015,8 @@ void BackgroundCompileTask::RunOnMainThread(Isolate* isolate) {
 
 void BackgroundCompileTask::Run(
     LocalIsolate* isolate, ReusableUnoptimizedCompileState* reusable_state) {
+  gNumRunningBackgroundCompileTasks++;
+
   TimedHistogramScope timer(
       timer_, nullptr,
       compilation_details_
@@ -2079,6 +2134,8 @@ void BackgroundCompileTask::Run(
   outer_function_sfi_ = isolate->heap()->NewPersistentMaybeHandle(maybe_result);
   DCHECK(isolate->heap()->ContainsPersistentHandle(script_.location()));
   persistent_handles_ = isolate->heap()->DetachPersistentHandles();
+
+  gNumRunningBackgroundCompileTasks--;
 }
 
 // A class which traverses the constant pools of newly compiled
@@ -3284,6 +3341,10 @@ bool Compiler::FinalizeBackgroundCompileTask(BackgroundCompileTask* task,
 void Compiler::CompileOptimized(Isolate* isolate,
                                 DirectHandle<JSFunction> function,
                                 ConcurrencyMode mode, CodeKind code_kind) {
+  // The point at which optimized compilations occur can vary between recording
+  // and replaying.
+  replayio::AutoDisallowEvents disallow("Compiler::CompileOptimized");
+
   function->TraceOptimizationStatus("^%s", CodeKindToString(code_kind));
   DCHECK(CodeKindIsOptimizedJSFunction(code_kind));
   DCHECK(AllowCompilation::IsAllowed(isolate));
@@ -3411,6 +3472,8 @@ MaybeDirectHandle<JSFunction> Compiler::GetFunctionFromEval(
     flags.set_parsing_while_debugging(parsing_while_debugging);
     DCHECK(!flags.is_module());
     flags.set_parse_restriction(restriction);
+
+    SetRecordReplayFlags(flags, "");
 
     UnoptimizedCompileState compile_state;
     ReusableUnoptimizedCompileState reusable_state(isolate);
@@ -3899,6 +3962,14 @@ class StressBackgroundCompileThread : public ParkingThread {
     bool done_;
   };
 
+    std::string url;
+    Handle<Object> script_name;
+    if (script_details.name_obj.ToHandle(&script_name) && script_name->IsString()) {
+      std::unique_ptr<char[]> name = String::cast(*script_name).ToCString();
+      url = name.get();
+    }
+    SetRecordReplayFlags(flags, url);
+
   Handle<String> source_;
   v8::ScriptCompiler::StreamedSource streamed_source_;
 };
@@ -3942,7 +4013,11 @@ CompileScriptOnBothBackgroundAndMainThread(Handle<String> source,
   MaybeDirectHandle<SharedFunctionInfo> main_thread_maybe_result;
   bool main_thread_had_stack_overflow = false;
   // In parallel, compile on the main thread to flush out any data races.
-  {
+
+  // For now we don't support using the compilation cache with streamed scripts,
+  // due to the lack of support for handling the case when the script is present
+  // but not the top level SFI.
+  if (!recordreplay::IsRecordingOrReplaying("no-streamed-script-cache")) {
     IsCompiledScope inner_is_compiled_scope;
     // The background thread should also create any relevant exceptions, so we
     // can ignore the main-thread created ones.
@@ -4053,6 +4128,36 @@ MaybeDirectHandle<SharedFunctionInfo> GetSharedFunctionInfoForScriptImpl(
     maybe_script = lookup_result.script();
     maybe_result = lookup_result.toplevel_sfi();
     is_compiled_scope = lookup_result.is_compiled_scope();
+
+    // The compilation cache isn't enabled when replaying, but we still need
+    // to record/replay whether a script was found when recording so that the
+    // same scripts are created at the same points. The SFI will need to be
+    // recompiled when replaying but that's fine when the right script ID is used.
+    if (recordreplay::IsRecordingOrReplaying("values") &&
+        !recordreplay::AreEventsDisallowed() &&
+        IsMainThread() &&
+        !gReplaceSourceContentsScriptId) {
+      int script_id = v8::UnboundScript::kNoScriptId;
+      if (Handle<Script> script;
+          recordreplay::IsRecording() && maybe_script.ToHandle(&script)) {
+        script_id = script->id();
+        CHECK(script_id != v8::UnboundScript::kNoScriptId);
+
+        // Make sure the script has been registered, if it hasn't then we won't
+        // be able to find it when replaying.
+        if (MaybeGetScript(isolate, script_id).is_null()) {
+          maybe_script = MaybeHandle<Script>();
+          maybe_result = MaybeHandle<SharedFunctionInfo>();
+          is_compiled_scope = IsCompiledScope();
+          script_id = v8::UnboundScript::kNoScriptId;
+        }
+      }
+      script_id = (int)recordreplay::RecordReplayValue("GetSharedFunctionInfoForScriptImpl script_id", script_id);
+      if (recordreplay::IsReplaying() && script_id != v8::UnboundScript::kNoScriptId) {
+        maybe_script = GetScript(isolate, script_id);
+      }
+    }
+
     if (!maybe_result.is_null()) {
       compile_timer.set_hit_isolate_cache();
     } else if (can_consume_code_cache) {
@@ -4332,6 +4437,44 @@ MaybeDirectHandle<JSFunction> Compiler::GetWrappedFunction(
   }
 
   DCHECK(is_compiled_scope.is_compiled());
+
+  // See if we need to use replaced source contents while replaying, in which
+  // case we need to compile the new source in the same way we did above and
+  // replace the result.
+  MaybeHandle<String> new_source = ReplayingReplaceScriptContents(isolate, source);
+  if (!new_source.is_null()) {
+    MaybeHandle<ScopeInfo> maybe_outer_scope_info;
+    if (!context->IsNativeContext()) {
+      maybe_outer_scope_info = handle(context->scope_info(), isolate);
+    }
+
+    UnoptimizedCompileFlags flags = UnoptimizedCompileFlags::ForToplevelCompile(
+        isolate, true, language_mode, REPLMode::kNo, ScriptType::kClassic,
+        v8_flags.lazy_eval, script->id());
+    flags.set_is_eval(true);
+    flags.set_parsing_while_debugging(parsing_while_debugging);
+    DCHECK(!flags.is_module());
+    flags.set_parse_restriction(restriction);
+
+    SetRecordReplayFlags(flags, "");
+
+    UnoptimizedCompileState compile_state;
+    ReusableUnoptimizedCompileState reusable_state(isolate);
+    ParseInfo parse_info(isolate, flags, &compile_state, &reusable_state);
+    parse_info.set_parameters_end_pos(parameters_end_pos);
+
+    Handle<Script> new_script = parse_info.CreateScript(
+        isolate, new_source.ToHandleChecked(), kNullMaybeHandle,
+        OriginOptionsForEval(outer_info->script(), parsing_while_debugging));
+
+    Handle<SharedFunctionInfo> new_shared_info =
+      v8::internal::CompileToplevel(&parse_info, new_script,
+                                    maybe_outer_scope_info, isolate,
+                                    &is_compiled_scope)
+        .ToHandleChecked();
+
+    result = Factory::JSFunctionBuilder{isolate, new_shared_info, context}.Build();
+  }
 
   return Factory::JSFunctionBuilder{isolate, result, context}
       .set_allocation_type(AllocationType::kYoung)

--- a/src/codegen/compiler.cc
+++ b/src/codegen/compiler.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "src/codegen/compiler.h"
+#include "include/replayio.h"
 
 #include <algorithm>
 #include <memory>

--- a/src/codegen/external-reference.cc
+++ b/src/codegen/external-reference.cc
@@ -845,6 +845,17 @@ ExternalReference ExternalReference::address_of_pending_message(
 
 FUNCTION_REFERENCE(abort_with_reason, i::abort_with_reason)
 
+extern uint64_t* gProgressCounter;
+extern uint64_t gTargetProgress;
+
+ExternalReference ExternalReference::record_replay_progress_counter() {
+  return ExternalReference(gProgressCounter);
+}
+
+ExternalReference ExternalReference::record_replay_target_progress() {
+  return ExternalReference(&gTargetProgress);
+}
+
 FUNCTION_REFERENCE(abort_with_sandbox_violation,
                    i::abort_with_sandbox_violation)
 

--- a/src/codegen/external-reference.h
+++ b/src/codegen/external-reference.h
@@ -98,6 +98,8 @@ enum class IsolateFieldId : uint8_t;
 
 #define EXTERNAL_REFERENCE_LIST(V)                                             \
   V(abort_with_reason, "abort_with_reason")                                    \
+  V(record_replay_progress_counter, "record_replay_progress_counter")          \
+  V(record_replay_target_progress, "record_replay_target_progress")            \
   V(abort_with_sandbox_violation, "abort_with_sandbox_violation")              \
   V(address_of_log_or_trace_osr, "v8_flags.log_or_trace_osr")                  \
   V(address_of_builtin_subclassing_flag, "v8_flags.builtin_subclassing")       \

--- a/src/codegen/x64/assembler-x64.cc
+++ b/src/codegen/x64/assembler-x64.cc
@@ -25,6 +25,8 @@
 #include "src/flags/flags.h"
 #include "src/init/v8.h"
 
+#include "replayio.h"
+
 namespace v8 {
 namespace internal {
 
@@ -58,6 +60,18 @@ V8_INLINE uint64_t xgetbv(unsigned int xcr) {
 }
 
 bool OSHasAVXSupport() {
+  // This function can be called at different points when recording vs. replaying,
+  // depending on the features of the CPU used when recording vs. replaying.
+  replayio::AutoPassThroughEvents pt;
+
+  // All replaying happens on linux so skip macOS checks in that case which
+  // interact with the system.
+  if (recordreplay::IsReplaying()) {
+    // Check whether OS claims to support AVX.
+    uint64_t feature_mask = xgetbv(0);  // XCR_XFEATURE_ENABLED_MASK
+    return (feature_mask & 0x6) == 0x6;
+  }
+
 #if V8_OS_DARWIN
   // Mac OS X up to 10.9 has a bug where AVX transitions were indeed being
   // caused by ISRs, so we detect that here and disable AVX in that case.
@@ -75,6 +89,7 @@ bool OSHasAVXSupport() {
   long kernel_version_major = strtol(buffer, nullptr, 10);  // NOLINT
   if (kernel_version_major <= 13) return false;
 #endif  // V8_OS_DARWIN
+
   // Check whether OS claims to support AVX.
   uint64_t feature_mask = xgetbv(0);  // XCR_XFEATURE_ENABLED_MASK
   return (feature_mask & 0x6) == 0x6;

--- a/src/compiler/backend/code-generator.cc
+++ b/src/compiler/backend/code-generator.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "src/compiler/backend/code-generator.h"
+#include "include/replayio.h"
 
 #include <optional>
 

--- a/src/compiler/backend/code-generator.cc
+++ b/src/compiler/backend/code-generator.cc
@@ -512,6 +512,8 @@ base::OwnedVector<uint8_t> CodeGenerator::GetTrappingInstructionsData() {
 }
 
 MaybeHandle<Code> CodeGenerator::FinalizeCode() {
+  replayio::AutoDisallowEvents disallow("CodeGenerator::FinalizeCode");
+
   if (result_ != kSuccess) {
     masm()->AbortedCodeGeneration();
     return {};

--- a/src/compiler/bytecode-graph-builder.cc
+++ b/src/compiler/bytecode-graph-builder.cc
@@ -3949,7 +3949,7 @@ void BytecodeGraphBuilder::VisitRecordReplayInstrumentation() {
   PrepareEagerCheckpoint();
   Node* closure = GetFunctionClosure();
   uint32_t index = bytecode_iterator().GetUnsignedImmediateOperand(0);
-  Node* index_slot = jsgraph()->Constant(index);
+  Node* index_slot = jsgraph()->ConstantNoHole(index);
   const Operator* op = javascript()->CallRuntime(Runtime::kRecordReplayInstrumentation);
 
   Node* node = NewNode(op, closure, index_slot);
@@ -3962,7 +3962,7 @@ void BytecodeGraphBuilder::VisitRecordReplayInstrumentationGenerator() {
   PrepareEagerCheckpoint();
   Node* closure = GetFunctionClosure();
   uint32_t index = bytecode_iterator().GetUnsignedImmediateOperand(0);
-  Node* index_slot = jsgraph()->Constant(index);
+  Node* index_slot = jsgraph()->ConstantNoHole(index);
   Node* generator = environment()->LookupRegister(
       bytecode_iterator().GetRegisterOperand(1));
   const Operator* op = javascript()->CallRuntime(Runtime::kRecordReplayInstrumentationGenerator);
@@ -3980,7 +3980,7 @@ void BytecodeGraphBuilder::VisitRecordReplayInstrumentationReturn() {
   PrepareEagerCheckpoint();
   Node* closure = GetFunctionClosure();
   uint32_t index = bytecode_iterator().GetUnsignedImmediateOperand(0);
-  Node* index_slot = jsgraph()->Constant(index);
+  Node* index_slot = jsgraph()->ConstantNoHole(index);
   Node* return_value = environment()->LookupRegister(
       bytecode_iterator().GetRegisterOperand(1));
   const Operator* op = javascript()->CallRuntime(Runtime::kRecordReplayInstrumentationReturn);

--- a/src/compiler/bytecode-graph-builder.cc
+++ b/src/compiler/bytecode-graph-builder.cc
@@ -3948,7 +3948,7 @@ void BytecodeGraphBuilder::VisitRecordReplayInstrumentation() {
 
   PrepareEagerCheckpoint();
   Node* closure = GetFunctionClosure();
-  uint32_t index = bytecode_iterator().GetIndexOperand(0);
+  uint32_t index = bytecode_iterator().GetUnsignedImmediateOperand(0);
   Node* index_slot = jsgraph()->Constant(index);
   const Operator* op = javascript()->CallRuntime(Runtime::kRecordReplayInstrumentation);
 
@@ -3961,7 +3961,7 @@ void BytecodeGraphBuilder::VisitRecordReplayInstrumentationGenerator() {
   // see Runtime_RecordReplayInstrumentationGenerator.
   PrepareEagerCheckpoint();
   Node* closure = GetFunctionClosure();
-  uint32_t index = bytecode_iterator().GetIndexOperand(0);
+  uint32_t index = bytecode_iterator().GetUnsignedImmediateOperand(0);
   Node* index_slot = jsgraph()->Constant(index);
   Node* generator = environment()->LookupRegister(
       bytecode_iterator().GetRegisterOperand(1));
@@ -3979,7 +3979,7 @@ void BytecodeGraphBuilder::VisitRecordReplayInstrumentationReturn() {
 
   PrepareEagerCheckpoint();
   Node* closure = GetFunctionClosure();
-  uint32_t index = bytecode_iterator().GetIndexOperand(0);
+  uint32_t index = bytecode_iterator().GetUnsignedImmediateOperand(0);
   Node* index_slot = jsgraph()->Constant(index);
   Node* return_value = environment()->LookupRegister(
       bytecode_iterator().GetRegisterOperand(1));
@@ -3992,7 +3992,7 @@ void BytecodeGraphBuilder::VisitRecordReplayInstrumentationReturn() {
 void BytecodeGraphBuilder::VisitRecordReplayAssertValue() {
   PrepareEagerCheckpoint();
   Node* closure = GetFunctionClosure();
-  Node* index_slot = jsgraph()->Constant(bytecode_iterator().GetIndexOperand(0));
+  Node* index_slot = jsgraph()->Constant(bytecode_iterator().GetUnsignedImmediateOperand(0));
   Node* value = environment()->LookupAccumulator();
   const Operator* op = javascript()->CallRuntime(Runtime::kRecordReplayAssertValue);
 

--- a/src/compiler/bytecode-graph-builder.cc
+++ b/src/compiler/bytecode-graph-builder.cc
@@ -36,6 +36,10 @@
 
 namespace v8 {
 namespace internal {
+
+extern bool gRecordReplayAssertProgress;
+extern bool gRecordReplayInstrumentationEnabled;
+
 namespace compiler {
 
 class BytecodeGraphBuilder {
@@ -3905,6 +3909,105 @@ void BytecodeGraphBuilder::VisitIncBlockCounter() {
       javascript()->CallRuntime(Runtime::kInlineIncBlockCounter);
 
   NewNode(op, closure, coverage_array_slot);
+}
+
+void BytecodeGraphBuilder::VisitRecordReplayIncExecutionProgressCounter() {
+  PrepareEagerCheckpoint();
+
+  // Use a VM call instead of an optimized path when we need to add assertions
+  // to the recording, or when replaying so that the calling code can be deoptimized
+  // when the target progress value has been reached.
+  if (gRecordReplayAssertProgress || recordreplay::IsReplaying()) {
+    Node* closure = GetFunctionClosure();
+    const Operator* op = javascript()->CallRuntime(Runtime::kRecordReplayAssertExecutionProgress);
+
+    Node* node = NewNode(op, closure);
+    environment()->RecordAfterState(node, Environment::kAttachFrameState);
+  } else {
+    Node* node = NewNode(simplified()->IncrementAndCheckProgressCounter());
+    environment()->RecordAfterState(node, Environment::kAttachFrameState);
+  }
+  CHECK(needs_eager_checkpoint());
+}
+
+void BytecodeGraphBuilder::VisitRecordReplayNotifyActivity() {
+  PrepareEagerCheckpoint();
+  const Operator* op = javascript()->CallRuntime(Runtime::kRecordReplayNotifyActivity);
+
+  Node* node = NewNode(op);
+  environment()->RecordAfterState(node, Environment::kAttachFrameState);
+}
+
+void BytecodeGraphBuilder::VisitRecordReplayInstrumentation() {
+  // If instrumentation is disabled then calls can be skipped entirely.
+  // The optimized code will be discarded if instrumentation is enabled/disabled,
+  // see RecordReplayChangeInstrument.
+  if (!gRecordReplayInstrumentationEnabled) {
+    return;
+  }
+
+  PrepareEagerCheckpoint();
+  Node* closure = GetFunctionClosure();
+  uint32_t index = bytecode_iterator().GetIndexOperand(0);
+  Node* index_slot = jsgraph()->Constant(index);
+  const Operator* op = javascript()->CallRuntime(Runtime::kRecordReplayInstrumentation);
+
+  Node* node = NewNode(op, closure, index_slot);
+  environment()->RecordAfterState(node, Environment::kAttachFrameState);
+}
+
+void BytecodeGraphBuilder::VisitRecordReplayInstrumentationGenerator() {
+  // Note: we always need to call the InstrumentationGenerator function,
+  // see Runtime_RecordReplayInstrumentationGenerator.
+  PrepareEagerCheckpoint();
+  Node* closure = GetFunctionClosure();
+  uint32_t index = bytecode_iterator().GetIndexOperand(0);
+  Node* index_slot = jsgraph()->Constant(index);
+  Node* generator = environment()->LookupRegister(
+      bytecode_iterator().GetRegisterOperand(1));
+  const Operator* op = javascript()->CallRuntime(Runtime::kRecordReplayInstrumentationGenerator);
+
+  Node* node = NewNode(op, closure, index_slot, generator);
+  environment()->RecordAfterState(node, Environment::kAttachFrameState);
+}
+
+void BytecodeGraphBuilder::VisitRecordReplayInstrumentationReturn() {
+  // Disabled if instrumentation is disabled, as in VisitRecordReplayInstrumentation.
+  if (!gRecordReplayInstrumentationEnabled) {
+    return;
+  }
+
+  PrepareEagerCheckpoint();
+  Node* closure = GetFunctionClosure();
+  uint32_t index = bytecode_iterator().GetIndexOperand(0);
+  Node* index_slot = jsgraph()->Constant(index);
+  Node* return_value = environment()->LookupRegister(
+      bytecode_iterator().GetRegisterOperand(1));
+  const Operator* op = javascript()->CallRuntime(Runtime::kRecordReplayInstrumentationReturn);
+
+  Node* node = NewNode(op, closure, index_slot, return_value);
+  environment()->RecordAfterState(node, Environment::kAttachFrameState);
+}
+
+void BytecodeGraphBuilder::VisitRecordReplayAssertValue() {
+  PrepareEagerCheckpoint();
+  Node* closure = GetFunctionClosure();
+  Node* index_slot = jsgraph()->Constant(bytecode_iterator().GetIndexOperand(0));
+  Node* value = environment()->LookupAccumulator();
+  const Operator* op = javascript()->CallRuntime(Runtime::kRecordReplayAssertValue);
+
+  Node* node = NewNode(op, closure, index_slot, value);
+  environment()->BindAccumulator(node, Environment::kAttachFrameState);
+}
+
+void BytecodeGraphBuilder::VisitRecordReplayTrackObjectId() {
+  PrepareEagerCheckpoint();
+  Node* object = environment()->LookupRegister(
+      bytecode_iterator().GetRegisterOperand(0));
+  const Operator* op = javascript()->CallRuntime(Runtime::kRecordReplayTrackObjectId);
+
+  Node* node = NewNode(op, object);
+  environment()->RecordAfterState(node, Environment::kAttachFrameState);
 }
 
 void BytecodeGraphBuilder::VisitForInEnumerate() {

--- a/src/compiler/js-call-reducer.cc
+++ b/src/compiler/js-call-reducer.cc
@@ -8165,6 +8165,11 @@ Reduction JSCallReducer::ReduceStringConstructor(Node* node,
 }
 
 Reduction JSCallReducer::ReducePromiseConstructor(Node* node) {
+  if (recordreplay::IsRecordingOrReplaying(
+        "disable-v8-optimize-promises",
+        "JSCallReducer::ReducePromiseConstructor"))
+    return NoChange();
+
   PromiseBuiltinReducerAssembler a(this, node);
 
   // We only inline when we have the executor.
@@ -8249,6 +8254,11 @@ Node* JSCallReducer::CreateClosureFromBuiltinSharedFunctionInfo(
 
 // https://tc39.es/ecma262/#sec-promise.prototype.finally
 Reduction JSCallReducer::ReducePromisePrototypeFinally(Node* node) {
+  if (recordreplay::IsRecordingOrReplaying(
+        "disable-v8-optimize-promises",
+        "JSCallReducer::ReducePromisePrototypeFinally"))
+    return NoChange();
+
   JSCallNode n(node);
   CallParameters const& p = n.Parameters();
   int arity = p.arity_without_implicit_args();
@@ -8366,6 +8376,11 @@ Reduction JSCallReducer::ReducePromisePrototypeFinally(Node* node) {
 }
 
 Reduction JSCallReducer::ReducePromisePrototypeThen(Node* node) {
+  if (recordreplay::IsRecordingOrReplaying(
+        "disable-v8-optimize-promises",
+        "JSCallReducer::ReducePromisePrototypeThen"))
+    return NoChange();
+
   JSCallNode n(node);
   CallParameters const& p = n.Parameters();
   if (p.speculation_mode() != SpeculationMode::kAllowSpeculation) {

--- a/src/compiler/js-native-context-specialization.cc
+++ b/src/compiler/js-native-context-specialization.cc
@@ -240,6 +240,11 @@ bool IsStringWithNonAccessibleContent(JSHeapBroker* broker, Node* node) {
 
 Reduction JSNativeContextSpecialization::ReduceJSAsyncFunctionEnter(
     Node* node) {
+  if (recordreplay::IsRecordingOrReplaying(
+        "disable-v8-optimize-promises",
+        "JSNativeContextSpecialization::ReduceJSAsyncFunctionEnter"))
+    return NoChange();
+
   DCHECK_EQ(IrOpcode::kJSAsyncFunctionEnter, node->opcode());
   Node* closure = NodeProperties::GetValueInput(node, 0);
   Node* receiver = NodeProperties::GetValueInput(node, 1);
@@ -279,6 +284,11 @@ Reduction JSNativeContextSpecialization::ReduceJSAsyncFunctionEnter(
 
 Reduction JSNativeContextSpecialization::ReduceJSAsyncFunctionReject(
     Node* node) {
+  if (recordreplay::IsRecordingOrReplaying(
+        "disable-v8-optimize-promises",
+        "JSNativeContextSpecialization::ReduceJSAsyncFunctionReject"))
+    return NoChange();
+
   DCHECK_EQ(IrOpcode::kJSAsyncFunctionReject, node->opcode());
   Node* async_function_object = NodeProperties::GetValueInput(node, 0);
   Node* reason = NodeProperties::GetValueInput(node, 1);
@@ -315,6 +325,11 @@ Reduction JSNativeContextSpecialization::ReduceJSAsyncFunctionReject(
 
 Reduction JSNativeContextSpecialization::ReduceJSAsyncFunctionResolve(
     Node* node) {
+  if (recordreplay::IsRecordingOrReplaying(
+        "disable-v8-optimize-promises",
+        "JSNativeContextSpecialization::ReduceJSAsyncFunctionResolve"))
+    return NoChange();
+
   DCHECK_EQ(IrOpcode::kJSAsyncFunctionResolve, node->opcode());
   Node* async_function_object = NodeProperties::GetValueInput(node, 0);
   Node* value = NodeProperties::GetValueInput(node, 1);
@@ -882,6 +897,11 @@ Reduction JSNativeContextSpecialization::ReduceJSOrdinaryHasInstance(
 
 // https://tc39.es/ecma262/#sec-promise-resolve
 Reduction JSNativeContextSpecialization::ReduceJSPromiseResolve(Node* node) {
+  if (recordreplay::IsRecordingOrReplaying(
+        "disable-v8-optimize-promises",
+        "JSNativeContextSpecialization::ReduceJSPromiseResolve"))
+    return NoChange();
+
   DCHECK_EQ(IrOpcode::kJSPromiseResolve, node->opcode());
   Node* constructor = NodeProperties::GetValueInput(node, 0);
   Node* value = NodeProperties::GetValueInput(node, 1);

--- a/src/compiler/memory-optimizer.cc
+++ b/src/compiler/memory-optimizer.cc
@@ -251,6 +251,10 @@ void MemoryOptimizer::VisitNode(Node* node, AllocationState const* state,
       return VisitStoreField(node, state, effect_chain);
     case IrOpcode::kStore:
       return VisitStore(node, state, effect_chain);
+    case IrOpcode::kIncrementAndCheckProgressCounter:
+      // Note: this is the default behavior in VisitCall when allocations are
+      // possible.
+      return EnqueueUses(node, empty_state(), effect_chain);
     case IrOpcode::kStorePair:
       // Store pairing should happen after this pass.
       UNREACHABLE();

--- a/src/compiler/opcodes.h
+++ b/src/compiler/opcodes.h
@@ -505,6 +505,7 @@
   V(FastApiCall)                            \
   V(FindOrderedHashMapEntry)                \
   V(FindOrderedHashMapEntryForInt32Key)     \
+  V(IncrementAndCheckProgressCounter)       \
   V(FindOrderedHashSetEntry)                \
   V(WeakCollectionGet)                      \
   V(InitializeImmutableInObject)            \

--- a/src/compiler/simplified-lowering.cc
+++ b/src/compiler/simplified-lowering.cc
@@ -4885,6 +4885,8 @@ class RepresentationSelector {
       case IrOpcode::kDateNow:
         VisitInputs<T>(node);
         return SetOutput<T>(node, MachineRepresentation::kTagged);
+      case IrOpcode::kIncrementAndCheckProgressCounter:
+        return;
       case IrOpcode::kDoubleArrayMax: {
         return VisitUnop<T>(node, UseInfo::AnyTagged(),
                             MachineRepresentation::kTagged);

--- a/src/compiler/simplified-operator.cc
+++ b/src/compiler/simplified-operator.cc
@@ -2699,13 +2699,6 @@ const Operator* SimplifiedOperatorBuilder::TransitionAndStoreNonNumberElement(
       "TransitionAndStoreNonNumberElement", 3, 1, 1, 0, 1, 0, parameters);
 }
 
-const Operator* SimplifiedOperatorBuilder::DateNow() {
-  return zone()->New<Operator>(IrOpcode::kDateNow,
-                               Operator::kNoDeopt | Operator::kNoThrow,
-                               "DateNow",
-                               0, 1, 1, 1, 1, 0);
-}
-
 const Operator* SimplifiedOperatorBuilder::IncrementAndCheckProgressCounter() {
   return zone()->New<Operator>(IrOpcode::kIncrementAndCheckProgressCounter,
                                Operator::kNoDeopt | Operator::kNoThrow,

--- a/src/compiler/simplified-operator.cc
+++ b/src/compiler/simplified-operator.cc
@@ -2699,6 +2699,20 @@ const Operator* SimplifiedOperatorBuilder::TransitionAndStoreNonNumberElement(
       "TransitionAndStoreNonNumberElement", 3, 1, 1, 0, 1, 0, parameters);
 }
 
+const Operator* SimplifiedOperatorBuilder::DateNow() {
+  return zone()->New<Operator>(IrOpcode::kDateNow,
+                               Operator::kNoDeopt | Operator::kNoThrow,
+                               "DateNow",
+                               0, 1, 1, 1, 1, 0);
+}
+
+const Operator* SimplifiedOperatorBuilder::IncrementAndCheckProgressCounter() {
+  return zone()->New<Operator>(IrOpcode::kIncrementAndCheckProgressCounter,
+                               Operator::kNoDeopt | Operator::kNoThrow,
+                               "IncrementAndCheckProgressCounter",
+                               0, 1, 0, 1, 1, 0);
+}
+
 const Operator* SimplifiedOperatorBuilder::FastApiCall(
     FastApiCallFunction c_function, FeedbackSource const& feedback,
     CallDescriptor* descriptor) {

--- a/src/compiler/simplified-operator.h
+++ b/src/compiler/simplified-operator.h
@@ -1336,6 +1336,7 @@ class V8_EXPORT_PRIVATE SimplifiedOperatorBuilder final
 #endif
 
   const Operator* DateNow();
+  const Operator* IncrementAndCheckProgressCounter();
 
   // Math.min/max for JSArray with PACKED_DOUBLE_ELEMENTS.
   const Operator* DoubleArrayMin();

--- a/src/compiler/turbofan-typer.cc
+++ b/src/compiler/turbofan-typer.cc
@@ -1846,6 +1846,8 @@ Type Typer::Visitor::TypeJSObjectIsArray(Node* node) { return Type::Boolean(); }
 
 Type Typer::Visitor::TypeDateNow(Node* node) { return Type::Number(); }
 
+Type Typer::Visitor::TypeIncrementAndCheckProgressCounter(Node* node) { return Type::Any(); }
+
 Type Typer::Visitor::TypeDoubleArrayMin(Node* node) { return Type::Number(); }
 
 Type Typer::Visitor::TypeDoubleArrayMax(Node* node) { return Type::Number(); }

--- a/src/compiler/turboshaft/graph-builder.cc
+++ b/src/compiler/turboshaft/graph-builder.cc
@@ -2247,6 +2247,46 @@ OpIndex GraphBuilder::Process(
       __ StoreMessage(Map(node->InputAt(0)), Map(node->InputAt(1)));
       return OpIndex::Invalid();
 
+    case IrOpcode::kIncrementAndCheckProgressCounter: {
+      // Replay: atomically (with respect to JS) increment the record/replay
+      // progress counter and, when it reaches the target progress value,
+      // notify the runtime so execution can be paused at the desired point.
+      // This was originally lowered in EffectControlLinearizer; in Turboshaft
+      // the simplified opcode survives into the graph builder where we emit the
+      // equivalent machine-level sequence directly.
+      V<WordPtr> progress_counter = __ ExternalConstant(
+          ExternalReference::record_replay_progress_counter());
+      V<Word64> progress_counter_value =
+          __ LoadOffHeap(progress_counter, MemoryRepresentation::Uint64());
+      V<Word64> incremented_value =
+          __ Word64Add(progress_counter_value, __ Word64Constant(uint64_t{1}));
+      __ StoreOffHeap(progress_counter, incremented_value,
+                      MemoryRepresentation::Uint64());
+
+      V<WordPtr> target_progress = __ ExternalConstant(
+          ExternalReference::record_replay_target_progress());
+      V<Word64> target_progress_value =
+          __ LoadOffHeap(target_progress, MemoryRepresentation::Uint64());
+
+      IF (UNLIKELY(__ Word64Equal(incremented_value, target_progress_value))) {
+        Runtime::FunctionId id = Runtime::kRecordReplayTargetProgressReached;
+        const Operator::Properties properties =
+            Operator::kNoDeopt | Operator::kNoThrow;
+        auto* call_descriptor = Linkage::GetRuntimeCallDescriptor(
+            graph_zone, id, 0, properties, CallDescriptor::kNoFlags);
+        const TSCallDescriptor* ts_descriptor = TSCallDescriptor::Create(
+            call_descriptor, CanThrow::kNo, LazyDeoptOnThrow::kNo, graph_zone);
+        OpIndex arguments[] = {
+            __ ExternalConstant(ExternalReference::Create(id)),
+            __ Word32Constant(0), __ NoContextConstant()};
+        __ Call(__ CEntryStubConstant(isolate, 1),
+                OptionalV<LazyFrameState>::Nullopt(),
+                base::VectorOf(arguments, arraysize(arguments)), ts_descriptor);
+      }
+
+      return OpIndex::Invalid();
+    }
+
     case IrOpcode::kSameValue:
       return __ SameValue(Map(node->InputAt(0)), Map(node->InputAt(1)),
                           SameValueOp::Mode::kSameValue);

--- a/src/compiler/verifier.cc
+++ b/src/compiler/verifier.cc
@@ -1849,6 +1849,10 @@ void Verifier::Visitor::Check(Node* node, const AllNodes& all) {
       CHECK_EQ(0, value_count);
       CheckTypeIs(node, Type::Number());
       break;
+    case IrOpcode::kIncrementAndCheckProgressCounter:
+      CHECK_EQ(0, value_count);
+      CheckTypeIs(node, Type::Any());
+      break;
     case IrOpcode::kCheckBigInt:
       CheckValueInputIs(node, 0, Type::Any());
       CheckTypeIs(node, Type::BigInt());

--- a/src/debug/debug-interface.cc
+++ b/src/debug/debug-interface.cc
@@ -192,8 +192,7 @@ void ClearBreakOnNextFunctionCall(Isolate* isolate) {
   i_isolate->debug()->ClearBreakOnNextFunctionCall();
 }
 
-MaybeLocal<Array> GetInternalProperties(Isolate* v8_isolate,
-                                        Local<Value> value) {
+MaybeLocal<Array> GetInternalProperties(Isolate* v8_isolate, Local<Value> value) {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(v8_isolate);
   EnterV8NoScriptNoExceptionScope api_scope(isolate);
   i::DirectHandle<i::Object> val = Utils::OpenDirectHandle(*value);
@@ -1527,7 +1526,8 @@ void SetIsolateId(v8::Isolate* v8_isolate, uint64_t id) {
 }
 
 std::unique_ptr<PropertyIterator> PropertyIterator::Create(
-    Local<Context> context, Local<Object> object, bool skip_indices) {
+    Local<Context> context, Local<Object> object, bool skip_indices,
+    const v8::KeyIterationParams* params) {
   i::Isolate* isolate = reinterpret_cast<i::Isolate*>(i::Isolate::Current());
   if (isolate->is_execution_terminating()) {
     return nullptr;

--- a/src/debug/debug-interface.h
+++ b/src/debug/debug-interface.h
@@ -545,6 +545,11 @@ class V8_EXPORT_PRIVATE StackTraceIterator {
 
   virtual v8::MaybeLocal<v8::Value> Evaluate(v8::Local<v8::String> source,
                                              bool throw_on_side_effect) = 0;
+
+  virtual v8::MaybeLocal<v8::Value> GetFrameArguments() = 0;
+
+  virtual internal::StackFrameId FrameId() = 0;
+  virtual int InlineFrameIndex() = 0;
 };
 
 void GlobalLexicalScopeNames(v8::Local<v8::Context> context,
@@ -667,7 +672,8 @@ class V8_EXPORT_PRIVATE PropertyIterator {
   // The returned std::unique_ptr is empty iff that happens.
   V8_WARN_UNUSED_RESULT static std::unique_ptr<PropertyIterator> Create(
       v8::Local<v8::Context> context, v8::Local<v8::Object> object,
-      bool skip_indices = false);
+      bool skip_indices = false,
+      const v8::KeyIterationParams* params = v8::KeyIterationParams::Default());
 
   virtual ~PropertyIterator() = default;
 

--- a/src/debug/debug-property-iterator.cc
+++ b/src/debug/debug-property-iterator.cc
@@ -34,11 +34,13 @@ std::unique_ptr<DebugPropertyIterator> DebugPropertyIterator::Create(
 
 DebugPropertyIterator::DebugPropertyIterator(Isolate* isolate,
                                              DirectHandle<JSReceiver> receiver,
-                                             bool skip_indices)
+                                             bool skip_indices,
+                                             const v8::KeyIterationParams* params)
     : isolate_(isolate),
       prototype_iterator_(isolate, receiver, kStartAtReceiver,
                           PrototypeIterator::END_AT_NULL),
       skip_indices_(skip_indices),
+      key_iteration_params_(params),
       current_key_index_(0),
       current_keys_(isolate_->factory()->empty_fixed_array()),
       current_keys_length_(0) {}

--- a/src/debug/debug-property-iterator.h
+++ b/src/debug/debug-property-iterator.h
@@ -44,7 +44,8 @@ class DebugPropertyIterator final : public debug::PropertyIterator {
 
  private:
   DebugPropertyIterator(Isolate* isolate, DirectHandle<JSReceiver> receiver,
-                        bool skip_indices);
+                        bool skip_indices,
+                        const v8::KeyIterationParams* params = v8::KeyIterationParams::Default());
 
   V8_WARN_UNUSED_RESULT bool FillKeysForCurrentPrototypeAndStage();
   bool should_move_to_next_stage() const;
@@ -61,6 +62,7 @@ class DebugPropertyIterator final : public debug::PropertyIterator {
     kAllProperties = 2
   } stage_ = kExoticIndices;
   bool skip_indices_;
+  const v8::KeyIterationParams* key_iteration_params_;
 
   size_t current_key_index_;
   Handle<FixedArray> current_keys_;

--- a/src/debug/debug-scopes.cc
+++ b/src/debug/debug-scopes.cc
@@ -1000,6 +1000,9 @@ bool ScopeIterator::VisitLocals(const Visitor& visitor, Mode mode,
           break;
         }
         DCHECK(var->IsContextSlot());
+        // This index is sometimes out of range when gathering state using the
+        // Record Replay driver.
+        if (index >= context_->length()) continue;
         DCHECK_EQ(context_->scope_info()->ContextSlotIndex(*var->name()),
                   index);
         value =

--- a/src/debug/debug-stack-trace-iterator.cc
+++ b/src/debug/debug-stack-trace-iterator.cc
@@ -45,13 +45,31 @@ DebugStackTraceIterator::~DebugStackTraceIterator() = default;
 
 bool DebugStackTraceIterator::Done() const { return iterator_.done(); }
 
+extern bool RecordReplayHasRegisteredScript(Script script);
+
+// When recording/replaying, frames from scripts that weren't reported to the
+// recorder are ignored when iterating stack traces.
+static bool RecordReplayIgnoreFrame(const FrameSummary& summary) {
+  if (!recordreplay::IsRecordingOrReplaying()) {
+    return false;
+  }
+
+  if (!summary.IsJavaScript()) {
+    return true;
+  }
+
+  Handle<Object> script = summary.AsJavaScript().script();
+  return !RecordReplayHasRegisteredScript(Script::cast(*script));
+}
+
 void DebugStackTraceIterator::Advance() {
   while (true) {
     --inlined_frame_index_;
     for (; inlined_frame_index_ >= 0; --inlined_frame_index_) {
       // Omit functions from native and extension scripts.
-      if (FrameSummary::Get(iterator_.frame(), inlined_frame_index_)
-              .is_subject_to_debugging()) {
+      auto summary = FrameSummary::Get(iterator_.frame(), inlined_frame_index_);
+      if (summary.is_subject_to_debugging() &&
+          !RecordReplayIgnoreFrame(summary)) {
         break;
       }
       is_top_frame_ = false;
@@ -247,6 +265,11 @@ void DebugStackTraceIterator::UpdateInlineFrameIndexAndResumableFnOnStack() {
 
   if (resumable_fn_on_stack_) return;
 
+  if (recordreplay::IsRecordingOrReplaying() && !frames.size()) {
+    recordreplay::Warning("[RUN-1920] Frame summary was empty.");
+    return;
+  }
+
   StackFrame* frame = iterator_.frame();
   if (!frame->is_javascript()) return;
 
@@ -273,6 +296,35 @@ v8::MaybeLocal<v8::Value> DebugStackTraceIterator::Evaluate(
     return v8::MaybeLocal<v8::Value>();
   }
   return Utils::ToLocal(value);
+}
+
+MaybeLocal<v8::Value> DebugStackTraceIterator::GetFrameArguments() {
+  i::SafeForInterruptsScope safe_for_interrupt_scope(isolate_);
+  StackFrameId frame_id = iterator_.frame()->id();
+  StackTraceFrameIterator it(isolate_, frame_id);
+  if (it.is_javascript()) {
+    JavaScriptFrame* frame = it.javascript_frame();
+    Handle<JSObject> args = Accessors::FunctionGetArguments(frame, 0);
+    MaybeHandle<Object> maybe_result(args);
+
+    Handle<Object> value;
+    if (maybe_result.ToHandle(&value)) {
+      return Utils::ToLocal(value);
+    }
+    isolate_->OptionalRescheduleException(false);
+  }
+
+  return v8::MaybeLocal<v8::Value>();
+}
+
+StackFrameId DebugStackTraceIterator::FrameId() {
+  DCHECK(!Done());
+  return iterator_.frame()->id();
+}
+
+int DebugStackTraceIterator::InlineFrameIndex() {
+  DCHECK(!Done());
+  return inlined_frame_index_;
 }
 
 void DebugStackTraceIterator::PrepareRestart() {

--- a/src/debug/debug-stack-trace-iterator.h
+++ b/src/debug/debug-stack-trace-iterator.h
@@ -35,9 +35,13 @@ class DebugStackTraceIterator final : public debug::StackTraceIterator {
 
   v8::MaybeLocal<v8::Value> Evaluate(v8::Local<v8::String> source,
                                      bool throw_on_side_effect) override;
+  v8::MaybeLocal<v8::Value> GetFrameArguments() override;
   void PrepareRestart();
 
   Handle<SharedFunctionInfo> GetSharedFunctionInfo() const;
+
+  StackFrameId FrameId() override;
+  int InlineFrameIndex() override;
 
  private:
   void UpdateInlineFrameIndexAndResumableFnOnStack();

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -2778,13 +2778,6 @@ bool Debug::AllFramesOnStackAreBlackboxed() {
   return true;
 }
 
-  if (recordreplay::IsReplaying() && recordreplay::AreEventsDisallowed()) {
-    // TODO: IsInReplayCode (RUN-1502)
-    // Always allow Replay code.
-    // https://linear.app/replay/issue/RUN-1908/fix-devtools-crashes
-    return true;
-  }
-
 bool Debug::CanBreakAtEntry(DirectHandle<SharedFunctionInfo> shared) {
   RCS_SCOPE(isolate_, RuntimeCallCounterId::kDebugger);
   // Allow break at entry for builtin functions.
@@ -3479,14 +3472,15 @@ static Handle<String> CStringToHandle(Isolate* isolate, const char* str) {
 
 static Handle<Object> GetProperty(Isolate* isolate,
                                   Handle<Object> obj, const char* property) {
-  return Object::GetProperty(isolate, obj, CStringToHandle(isolate, property))
+  return Object::GetProperty(isolate, Cast<JSAny>(obj),
+                             CStringToHandle(isolate, property))
     .ToHandleChecked();
 }
 
 static void SetProperty(Isolate* isolate,
                         Handle<Object> obj, const char* property,
                         Handle<Object> value) {
-  Object::SetProperty(isolate, obj,
+  Object::SetProperty(isolate, Cast<JSAny>(obj),
                       CStringToHandle(isolate, property), value).Check();
 }
 
@@ -3553,7 +3547,7 @@ Handle<Object> RecordReplayGetSourceContents(Isolate* isolate, Handle<Object> pa
   recordreplay::Diagnostic("RecordReplayGetSourceContents #2");
 
   Script::PositionInfo info;
-  Script::GetPositionInfo(script, 0, &info, Script::WITH_OFFSET);
+  Script::GetPositionInfo(script, 0, &info, Script::OffsetFlag::kWithOffset);
 
   // Pad the start of the source with lines to adjust for its starting position.
   // Note that we don't pad the starting line with blank spaces so that columns
@@ -3687,7 +3681,7 @@ static void GetInstrumentationSiteLocation(Handle<Script> script, int instrument
                                            int* pline, int* pcolumn) {
   int source_position = InstrumentationSiteSourcePosition(instrumentation_index);
   Script::PositionInfo info;
-  Script::GetPositionInfo(script, source_position, &info, Script::WITH_OFFSET);
+  Script::GetPositionInfo(script, source_position, &info, Script::OffsetFlag::kWithOffset);
 
   // Use 1-indexed lines instead of 0-indexed.
   *pline = info.line + 1;
@@ -3990,7 +3984,7 @@ static Handle<Object> RecordReplayConvertFunctionOffsetToLocation(
   // see GetInstrumentationSiteLocation.
   if (!line) {
     Script::PositionInfo info;
-    Script::GetPositionInfo(script, function_source_position, &info, Script::WITH_OFFSET);
+    Script::GetPositionInfo(script, function_source_position, &info, Script::OffsetFlag::kWithOffset);
 
     // Use 1-indexed lines instead of 0-indexed.
     line = info.line + 1;
@@ -4247,7 +4241,7 @@ static void RecordReplayRegisterScript(Handle<Script> script) {
   // to distinguish these cases: if the starting position is anything other
   // than line zero / column zero, the script must be inlined into another file.
   Script::PositionInfo start_info;
-  Script::GetPositionInfo(script, 0, &start_info, Script::WITH_OFFSET);
+  Script::GetPositionInfo(script, 0, &start_info, Script::OffsetFlag::kWithOffset);
 
   // [RUN-2172] Blink-internal scripts sometimes might have line or column, but 
   // no URL. Since the backend requires inlineScripts to have a URL, don't flag 

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "src/debug/debug.h"
+#include "include/replayio.h"
 
 #include <memory>
 #include <optional>

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3630,7 +3630,7 @@ static void ForEachInstrumentationOp(Isolate* isolate, Handle<Script> script,
         if (bytecode == interpreter::Bytecode::kRecordReplayInstrumentation ||
             bytecode == interpreter::Bytecode::kRecordReplayInstrumentationGenerator ||
             bytecode == interpreter::Bytecode::kRecordReplayInstrumentationReturn) {
-          int index = it.GetIndexOperand(0);
+          int index = it.GetUnsignedImmediateOperand(0);
           aCallback(candidate, index);
         }
       }

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -28,6 +28,10 @@
 #include "src/handles/global-handles-inl.h"
 #include "src/heap/heap-inl.h"  // For NextDebuggingId.
 #include "src/init/bootstrapper.h"
+#include "src/inspector/v8-debugger-agent-impl.h"
+#include "src/inspector/v8-inspector-impl.h"
+#include "src/inspector/v8-inspector-session-impl.h"
+#include "src/inspector/v8-runtime-agent-impl.h"
 #include "src/interpreter/bytecode-array-iterator.h"
 #include "src/logging/counters.h"
 #include "src/logging/runtime-call-stats-scope.h"
@@ -42,6 +46,8 @@
 #include "src/wasm/wasm-debug.h"
 #include "src/wasm/wasm-objects-inl.h"
 #endif  // V8_ENABLE_WEBASSEMBLY
+
+#include "src/objects/js-collection-inl.h"
 
 namespace v8 {
 namespace internal {
@@ -2403,6 +2409,13 @@ void Debug::RemoveBreakInfoAndMaybeFree(DirectHandle<DebugInfo> debug_info) {
   }
 }
 
+void Debug::ProcessCompileEvent(bool has_compile_error, Handle<Script> script) {
+  Debug::DoProcessCompileEvent(has_compile_error, script);
+  if (!has_compile_error && recordreplay::IsRecordingOrReplaying("register-scripts") && IsMainThread()) {
+    RecordReplayRegisterScript(script);
+  }
+}
+
 bool Debug::IsBreakAtReturn(JavaScriptFrame* frame) {
   RCS_SCOPE(isolate_, RuntimeCallCounterId::kDebugger);
   HandleScope scope(isolate_);
@@ -2764,12 +2777,25 @@ bool Debug::AllFramesOnStackAreBlackboxed() {
   return true;
 }
 
+  if (recordreplay::IsReplaying() && recordreplay::AreEventsDisallowed()) {
+    // TODO: IsInReplayCode (RUN-1502)
+    // Always allow Replay code.
+    // https://linear.app/replay/issue/RUN-1908/fix-devtools-crashes
+    return true;
+  }
+
 bool Debug::CanBreakAtEntry(DirectHandle<SharedFunctionInfo> shared) {
   RCS_SCOPE(isolate_, RuntimeCallCounterId::kDebugger);
   // Allow break at entry for builtin functions.
   if (shared->native() || shared->IsApiFunction()) {
     // Functions that are subject to debugging can have regular breakpoints.
     DCHECK(!shared->IsSubjectToDebugging());
+    return true;
+  }
+  if (recordreplay::IsReplaying() && recordreplay::AreEventsDisallowed()) {
+    // TODO: IsInReplayCode (RUN-1502)
+    // Always allow Replay code.
+    // https://linear.app/replay/issue/RUN-1908/fix-devtools-crashes
     return true;
   }
   return false;
@@ -3169,7 +3195,13 @@ bool Debug::PerformSideEffectCheck(DirectHandle<JSFunction> function,
                          &is_compiled_scope)) {
     return false;
   }
-  DCHECK(is_compiled_scope.is_compiled());
+  if (recordreplay::IsReplaying() && recordreplay::AreEventsDisallowed()) {
+    // TODO: IsInReplayCode (RUN-1502)
+    // Always allow Replay code.
+    // https://linear.app/replay/issue/RUN-1908/fix-devtools-crashes
+    return true;
+  }
+  CHECK(is_compiled_scope.is_compiled());
   DirectHandle<SharedFunctionInfo> shared(function->shared(), isolate_);
   DirectHandle<DebugInfo> debug_info = GetOrCreateDebugInfo(shared);
   DebugInfo::SideEffectState side_effect_state =
@@ -3339,6 +3371,13 @@ bool Debug::PerformSideEffectCheckAtBytecode(InterpretedFrame* frame) {
   RCS_SCOPE(isolate_, RuntimeCallCounterId::kDebugger);
   using interpreter::Bytecode;
 
+  if (recordreplay::IsReplaying() && recordreplay::AreEventsDisallowed()) {
+    // TODO: IsInReplayCode (RUN-1502)
+    // Always allow Replay code.
+    // https://linear.app/replay/issue/RUN-1908/fix-devtools-crashes
+    return true;
+  }
+
   DCHECK_EQ(isolate_->debug_execution_mode(), DebugInfo::kSideEffects);
   Tagged<SharedFunctionInfo> shared = frame->function()->shared();
   Tagged<BytecodeArray> bytecode_array = shared->GetBytecodeArray(isolate_);
@@ -3421,6 +3460,1349 @@ void Debug::PrepareRestartFrame(JavaScriptFrame* frame,
   // necessary bits out of PrepareSTep into a separate method or fold them
   // into Debug::PrepareRestartFrame.
   PrepareStep(StepInto);
+}
+
+// Record Replay handlers and associated helpers. These ought to be in their
+// own file, but it's easier to put them here.
+
+////////////////////////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////////////////////////
+
+extern void RecordReplayOnNewSource(Isolate* isolate, const char* id,
+                                    const char* kind, const char* url);
+
+static Handle<String> CStringToHandle(Isolate* isolate, const char* str) {
+  return isolate->factory()->NewStringFromUtf8(base::CStrVector(str)).ToHandleChecked();
+}
+
+static Handle<Object> GetProperty(Isolate* isolate,
+                                  Handle<Object> obj, const char* property) {
+  return Object::GetProperty(isolate, obj, CStringToHandle(isolate, property))
+    .ToHandleChecked();
+}
+
+static void SetProperty(Isolate* isolate,
+                        Handle<Object> obj, const char* property,
+                        Handle<Object> value) {
+  Object::SetProperty(isolate, obj,
+                      CStringToHandle(isolate, property), value).Check();
+}
+
+static void SetProperty(Isolate* isolate,
+                        Handle<Object> obj, const char* property,
+                        const char* value) {
+  SetProperty(isolate, obj, property, CStringToHandle(isolate, value));
+}
+
+static void SetProperty(Isolate* isolate,
+                        Handle<Object> obj, const char* property,
+                        double value) {
+  SetProperty(isolate, obj, property, isolate->factory()->NewNumber(value));
+}
+
+static Handle<JSObject> NewPlainObject(Isolate* isolate) {
+  return isolate->factory()->NewJSObject(isolate->object_function());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Script State
+////////////////////////////////////////////////////////////////////////////////
+
+// Map ScriptId => Script. We keep all scripts around forever when recording/replaying.
+typedef std::unordered_map<int, Eternal<Value>> ScriptIdMap;
+static ScriptIdMap* gRecordReplayScripts;
+
+static int GetSourceIdProperty(Isolate* isolate, Handle<Object> obj) {
+  Handle<Object> sourceIdStr = GetProperty(isolate, obj, "sourceId");
+  std::unique_ptr<char[]> sourceIdText = String::cast(*sourceIdStr).ToCString();
+  int rv = atoi(sourceIdText.get());
+  recordreplay::Diagnostic("GetSourceIdProperty %s %d", sourceIdText.get(), rv);
+  return rv;
+}
+
+// Get the script from an ID.
+MaybeHandle<Script> MaybeGetScript(Isolate* isolate, int script_id) {
+  CHECK(gRecordReplayScripts);
+  auto iter = gRecordReplayScripts->find(script_id);
+  if (iter == gRecordReplayScripts->end()) {
+    return MaybeHandle<Script>();
+  }
+
+  Local<v8::Value> scriptValue = iter->second.Get((v8::Isolate*)isolate);
+  Handle<Object> scriptObj = Utils::OpenHandle(*scriptValue);
+  Handle<Script> script(Script::cast(*scriptObj), isolate);
+  CHECK(script->id() == script_id);
+  return script;
+}
+
+// Get the script from an ID.
+Handle<Script> GetScript(Isolate* isolate, int script_id) {
+  MaybeHandle<Script> script = MaybeGetScript(isolate, script_id);
+  if (script.is_null()) {
+    recordreplay::Diagnostic("GetScript unknown script %d", script_id);
+  }
+  return script.ToHandleChecked();
+}
+
+Handle<Object> RecordReplayGetSourceContents(Isolate* isolate, Handle<Object> params) {
+  int script_id = GetSourceIdProperty(isolate, params);
+  recordreplay::Diagnostic("RecordReplayGetSourceContents #1 %d", script_id);
+  Handle<Script> script = GetScript(isolate, script_id);
+  recordreplay::Diagnostic("RecordReplayGetSourceContents #2");
+
+  Script::PositionInfo info;
+  Script::GetPositionInfo(script, 0, &info, Script::WITH_OFFSET);
+
+  // Pad the start of the source with lines to adjust for its starting position.
+  // Note that we don't pad the starting line with blank spaces so that columns
+  // match up, in order to match the spidermonkey implementation.
+  std::string padded_source;
+  for (int i = 0; i < info.line; i++) {
+    padded_source += "\n";
+  }
+
+  Handle<String> source(String::cast(script->source()), isolate);
+  padded_source += source->ToCString().get();
+
+  Handle<JSObject> obj = NewPlainObject(isolate);
+  SetProperty(isolate, obj, "contents", padded_source.c_str());
+  SetProperty(isolate, obj, "contentType", "text/javascript");
+  return obj;
+}
+
+static void DecodeLocationProperty(Isolate* isolate, Handle<Object> params,
+                                   const char* property, int* line, int* column) {
+  Handle<Object> location = GetProperty(isolate, params, property);
+  if (location->IsUndefined()) {
+    return;
+  }
+
+  Handle<Object> lineProperty = GetProperty(isolate, location, "line");
+  *line = lineProperty->Number();
+
+  Handle<Object> columnProperty = GetProperty(isolate, location, "column");
+  *column = columnProperty->Number();
+}
+
+static void ForEachInstrumentationOp(Isolate* isolate, Handle<Script> script,
+                                     std::function<void(Handle<SharedFunctionInfo>,
+                                                        int)> aCallback) {
+  // Based on Debug::GetPossibleBreakpoints.
+  while (true) {
+    HandleScope scope(isolate);
+    std::vector<Handle<SharedFunctionInfo>> candidates;
+    std::vector<IsCompiledScope> compiled_scopes;
+    SharedFunctionInfo::ScriptIterator iterator(isolate, *script);
+    for (SharedFunctionInfo info = iterator.Next(); !info.is_null();
+         info = iterator.Next()) {
+      if (!info.IsSubjectToDebugging()) continue;
+      if (!info.is_compiled() && !info.allows_lazy_compilation()) continue;
+      candidates.push_back(i::handle(info, isolate));
+    }
+
+    // Compile any uncompiled functions found in the script.
+    bool was_compiled = false;
+    for (const auto& candidate : candidates) {
+      IsCompiledScope is_compiled_scope(candidate->is_compiled_scope(isolate));
+      if (!is_compiled_scope.is_compiled()) {
+        if (!Compiler::Compile(isolate, candidate, Compiler::CLEAR_EXCEPTION,
+                               &is_compiled_scope)) {
+          V8_Fatal("Compiler::Compile failed in ForEachInstrumentationOp.");
+        } else {
+          was_compiled = true;
+        }
+      }
+      DCHECK(is_compiled_scope.is_compiled());
+      compiled_scopes.push_back(is_compiled_scope);
+    }
+
+    // If we did any compilation, restart and look for any new functions
+    // that need to be compiled.
+    if (was_compiled) continue;
+
+    // Now we have a complete list of the functions in the script.
+    // Build the final locations.
+    for (const auto& candidate : candidates) {
+      if (!candidate->HasBytecodeArray()) {
+        continue;
+      }
+      Handle<BytecodeArray> bytecode(candidate->GetBytecodeArray(isolate), isolate);
+
+      for (interpreter::BytecodeArrayIterator it(bytecode); !it.done();
+           it.Advance()) {
+        interpreter::Bytecode bytecode = it.current_bytecode();
+        if (bytecode == interpreter::Bytecode::kRecordReplayInstrumentation ||
+            bytecode == interpreter::Bytecode::kRecordReplayInstrumentationGenerator ||
+            bytecode == interpreter::Bytecode::kRecordReplayInstrumentationReturn) {
+          int index = it.GetIndexOperand(0);
+          aCallback(candidate, index);
+        }
+      }
+    }
+    return;
+  }
+}
+
+// Information about breakpoints that have been sent to the record replay driver.
+struct BreakpointInfo {
+  std::string function_id_;
+  int bytecode_offset_;
+  BreakpointInfo(const std::string& function_id, int bytecode_offset)
+    : function_id_(function_id), bytecode_offset_(bytecode_offset) {}
+};
+typedef std::unordered_map<std::string, BreakpointInfo> BreakpointInfoMap;
+static BreakpointInfoMap* gBreakpoints;
+
+static std::string BreakpointKey(int script_id, int line, int column) {
+  std::ostringstream os;
+  os << script_id << ":" << line << ":" << column;
+  return os.str();
+}
+
+// Inverse of gBreakpoints mapping.
+struct BreakpointPosition {
+  int line_;
+  int column_;
+  BreakpointPosition(int line, int column)
+    : line_(line), column_(column) {}
+};
+typedef std::unordered_map<std::string, BreakpointPosition> BreakpointPositionMap;
+static BreakpointPositionMap* gBreakpointPositions;
+
+static std::string BreakpointPositionKey(std::string function_id,
+                                         int bytecode_offset) {
+  std::ostringstream os;
+  os << function_id << ":" << bytecode_offset;
+  return os.str();
+}
+
+extern const char* InstrumentationSiteKind(int index);
+extern int InstrumentationSiteSourcePosition(int index);
+extern int InstrumentationSiteFunctionIndex(int index);
+extern std::string GetRecordReplayFunctionId(Handle<SharedFunctionInfo> shared);
+
+static void GetInstrumentationSiteLocation(Handle<Script> script, int instrumentation_index,
+                                           int* pline, int* pcolumn) {
+  int source_position = InstrumentationSiteSourcePosition(instrumentation_index);
+  Script::PositionInfo info;
+  Script::GetPositionInfo(script, source_position, &info, Script::WITH_OFFSET);
+
+  // Use 1-indexed lines instead of 0-indexed.
+  *pline = info.line + 1;
+  *pcolumn = info.column;
+}
+
+static void ForEachInstrumentationOpInRange(
+  Isolate* isolate, Handle<Object> params,
+  const std::function<void(Handle<Script> script, int bytecode_offset,
+                           const std::string& function_id, int line, int column)> callback) {
+  int script_id = GetSourceIdProperty(isolate, params);
+  MaybeHandle<Script> maybe_script = MaybeGetScript(isolate, script_id);
+
+  if (maybe_script.is_null()) {
+    return;
+  }
+
+  Handle<Script> script = maybe_script.ToHandleChecked();
+
+  int beginLine = 1, beginColumn = 0;
+  DecodeLocationProperty(isolate, params, "begin", &beginLine, &beginColumn);
+
+  int endLine = INT32_MAX, endColumn = INT32_MAX;
+  DecodeLocationProperty(isolate, params, "end", &endLine, &endColumn);
+
+  ForEachInstrumentationOp(isolate, script, [&](Handle<SharedFunctionInfo> shared,
+                                                int instrumentation_index) {
+    if (strcmp(InstrumentationSiteKind(instrumentation_index), "breakpoint")) {
+      return;
+    }
+
+    int line, column;
+    GetInstrumentationSiteLocation(script, instrumentation_index, &line, &column);
+
+    if (line < beginLine ||
+        (line == beginLine && column < beginColumn) ||
+        line > endLine ||
+        (line == endLine && column > endColumn)) {
+      return;
+    }
+
+    int bytecode_offset = InstrumentationSiteFunctionIndex(instrumentation_index);
+
+    std::string function_id = GetRecordReplayFunctionId(shared);
+    callback(script, bytecode_offset, function_id, line, column);
+  });
+}
+
+static void GenerateBreakpointInfo(Isolate* isolate, Handle<Script> script) {
+  if (!gBreakpoints) {
+    gBreakpoints = new BreakpointInfoMap();
+  }
+  if (!gBreakpointPositions) {
+    gBreakpointPositions = new BreakpointPositionMap();
+  }
+
+  ForEachInstrumentationOp(isolate, script, [&](Handle<SharedFunctionInfo> shared,
+                                                int instrumentation_index) {
+    int line, column;
+    GetInstrumentationSiteLocation(script, instrumentation_index, &line, &column);
+
+    std::string function_id = GetRecordReplayFunctionId(shared);
+    int bytecode_offset = InstrumentationSiteFunctionIndex(instrumentation_index);
+
+    std::string key = BreakpointKey(script->id(), line, column);
+    BreakpointInfo value(function_id, bytecode_offset);
+    gBreakpoints->insert(std::pair<std::string, BreakpointInfo>
+                         (key, value));
+
+    std::string positionKey = BreakpointPositionKey(function_id, bytecode_offset);
+    BreakpointPosition position(line, column);
+    gBreakpointPositions->insert(std::pair<std::string, BreakpointPosition>
+                                 (positionKey, position));
+  });
+}
+
+static Handle<Object> RecordReplayGetPossibleBreakpoints(Isolate* isolate,
+                                                         Handle<Object> params) {
+  std::vector<std::vector<int>> lineColumns;
+  int numLines = 0;
+
+  ForEachInstrumentationOpInRange(isolate, params,
+     [&](Handle<Script> script, int bytecode_offset,
+         const std::string& function_id, int line, int column) {
+    while ((size_t)line >= lineColumns.size()) {
+      lineColumns.emplace_back();
+    }
+    if (!lineColumns[line].size()) {
+      numLines++;
+    }
+    lineColumns[line].push_back(column);
+  });
+
+  Handle<FixedArray> lineLocations = isolate->factory()->NewFixedArray(numLines);
+  int lineLocationsIndex = 0;
+  for (size_t line = 0; line < lineColumns.size(); line++) {
+    const std::vector<int>& baseColumns = lineColumns[line];
+    if (!baseColumns.size()) {
+      continue;
+    }
+
+    Handle<FixedArray> columns = isolate->factory()->NewFixedArray((int)baseColumns.size());
+    for (int i = 0; i < (int)baseColumns.size(); i++) {
+      columns->set(i, Smi::FromInt(baseColumns[i]));
+    }
+    Handle<JSArray> columnsArray = isolate->factory()->NewJSArrayWithElements(columns);
+
+    Handle<JSObject> lineObj = NewPlainObject(isolate);
+    SetProperty(isolate, lineObj, "line", line);
+    SetProperty(isolate, lineObj, "columns", columnsArray);
+    lineLocations->set(lineLocationsIndex++, *lineObj);
+  }
+  DCHECK(lineLocationsIndex == numLines);
+
+  Handle<JSArray> lineLocationsArray =
+    isolate->factory()->NewJSArrayWithElements(lineLocations);
+
+  Handle<JSObject> rv = NewPlainObject(isolate);
+  SetProperty(isolate, rv, "lineLocations", lineLocationsArray);
+  return rv;
+}
+
+static SharedFunctionInfo GetSharedFunctionInfoById(Isolate* isolate,
+                                                    Handle<Script> script,
+                                                    int startPosition) {
+  SharedFunctionInfo::ScriptIterator iterator(isolate, *script);
+  for (SharedFunctionInfo info = iterator.Next(); !info.is_null();
+       info = iterator.Next()) {
+    if (info.StartPosition() == startPosition) {
+      return info;
+    }
+  }
+  SharedFunctionInfo empty;
+  return empty;
+}
+
+extern void ParseRecordReplayFunctionId(const std::string& function_id,
+                                        int* script_id, int* source_position);
+
+static void ParseRecordReplayFunctionIdFromParams(Isolate* isolate,
+                                                  Handle<Object> params,
+                                                  std::string* function_id,
+                                                  int* script_id,
+                                                  int* source_position) {
+  Handle<Object> function_id_raw = GetProperty(isolate, params, "functionId");
+  std::unique_ptr<char[]> function_id_chars =
+      String::cast(*function_id_raw).ToCString();
+  *function_id = function_id_chars.get();
+  ParseRecordReplayFunctionId(*function_id, script_id, source_position);
+}
+
+v8::Local<v8::Object> RecordReplayGetBytecode(v8::Isolate* isolate_,
+                                                     v8::Local<v8::Object> paramsObj) {
+  i::Isolate* isolate = reinterpret_cast<i::Isolate*>(isolate_);
+  int script_id, function_source_position;
+  std::string function_id;
+  Handle<Object> params = Utils::OpenHandle(*paramsObj);
+  ParseRecordReplayFunctionIdFromParams(isolate, params, &function_id,
+                                        &script_id, &function_source_position);
+  MaybeHandle<Script> maybe_script = MaybeGetScript(isolate, script_id);
+  Handle<JSObject> rv = NewPlainObject(isolate);
+
+  if (!maybe_script.is_null()) {
+    Handle<Script> script = maybe_script.ToHandleChecked();
+    SetProperty(isolate, rv, "sourceId", script_id);
+
+    SharedFunctionInfo info =
+        GetSharedFunctionInfoById(isolate, script, function_source_position);
+    if (!info.is_null()) {
+      SetProperty(isolate, rv, "name", SharedFunctionInfo::DebugName(handle(info, isolate)));
+      SetProperty(isolate, rv, "debuggable", info.IsSubjectToDebugging());
+      SetProperty(isolate, rv, "compiled", info.is_compiled());
+      SetProperty(isolate, rv, "hasBytecode", info.HasBytecodeArray());
+
+      if (info.IsSubjectToDebugging() && info.is_compiled() &&
+          info.HasBytecodeArray()) {
+        // Get Bytecode.
+        // (based on InterpreterCompilationJob::DoFinalizeJobImpl)
+        BytecodeArray bytecode = info.GetBytecodeArray(isolate);
+        std::ostringstream bytecodeResult;
+        bytecode.Disassemble(bytecodeResult);
+
+        SetProperty(isolate, rv, "bytecode", bytecodeResult.str().c_str());
+        SetProperty(isolate, rv, "bytecodeLength", bytecode.length());
+      }
+    }
+  }
+
+  return v8::Utils::ToLocal(rv);
+}
+
+extern void RecordReplayAddPossibleBreakpoint(int line, int column, const char* function_id, int function_index);
+
+static void EnsureIsolateContext(Isolate* isolate, base::Optional<SaveAndSwitchContext>& ssc);
+
+void RecordReplayGetPossibleBreakpointsCallback(const char* script_id_str) {
+  Isolate* isolate = Isolate::Current();
+  base::Optional<SaveAndSwitchContext> ssc;
+  EnsureIsolateContext(isolate, ssc);
+
+  HandleScope scope(isolate);
+
+  int script_id = atoi(script_id_str);
+  MaybeHandle<Script> maybe_script = MaybeGetScript(isolate, script_id);
+
+  if (maybe_script.is_null()) {
+    return;
+  }
+
+  Handle<Script> script = maybe_script.ToHandleChecked();
+
+  ForEachInstrumentationOp(isolate, script, [&](Handle<SharedFunctionInfo> shared,
+                                                int instrumentation_index) {
+    if (strcmp(InstrumentationSiteKind(instrumentation_index), "breakpoint")) {
+      return;
+    }
+
+    int line, column;
+    GetInstrumentationSiteLocation(script, instrumentation_index, &line, &column);
+
+    int function_index = InstrumentationSiteFunctionIndex(instrumentation_index);
+
+    std::string function_id = GetRecordReplayFunctionId(shared);
+    RecordReplayAddPossibleBreakpoint(line, column, function_id.c_str(), function_index);
+  });
+}
+
+Handle<Object> RecordReplayConvertLocationToFunctionOffset(Isolate* isolate,
+                                                           Handle<Object> params) {
+  Handle<Object> location = GetProperty(isolate, params, "location");
+  int sourceId = GetSourceIdProperty(isolate, location);
+  int line = GetProperty(isolate, location, "line")->Number();
+  int column = GetProperty(isolate, location, "column")->Number();
+
+  std::string key = BreakpointKey(sourceId, line, column);
+  if (!gBreakpoints) {
+    Handle<Script> script = GetScript(isolate, sourceId);
+    GenerateBreakpointInfo(isolate, script);
+  }
+  auto iter = gBreakpoints->find(key);
+  if (iter == gBreakpoints->end()) {
+    Handle<Script> script = GetScript(isolate, sourceId);
+    GenerateBreakpointInfo(isolate, script);
+
+    iter = gBreakpoints->find(key);
+    if (iter == gBreakpoints->end()) {
+      return NewPlainObject(isolate);
+    }
+  }
+
+  Handle<JSObject> rv = NewPlainObject(isolate);
+  SetProperty(isolate, rv, "functionId", iter->second.function_id_.c_str());
+  SetProperty(isolate, rv, "offset", iter->second.bytecode_offset_);
+  return rv;
+}
+
+static Handle<String> GetProtocolSourceId(Isolate* isolate, Handle<Script> script) {
+  std::ostringstream os;
+  os << script->id();
+  return CStringToHandle(isolate, os.str().c_str());
+}
+
+static Handle<Object> RecordReplayConvertFunctionOffsetToLocation(
+    Isolate* isolate, Handle<Object> params) {
+  int script_id, function_source_position;
+  std::string function_id;
+  ParseRecordReplayFunctionIdFromParams(isolate, params, &function_id,
+                                        &script_id, &function_source_position);
+  Handle<Script> script = GetScript(isolate, script_id);
+  Handle<Object> offset_raw = GetProperty(isolate, params, "offset");
+
+  // The offset may or may not be present. If the offset is present, use it as the
+  // instrumentation site to get the source position.
+  int line = 0, column = 0;
+  if (offset_raw->IsNumber()) {
+    int bytecode_offset = offset_raw->Number();
+
+    std::string key = BreakpointPositionKey(function_id, bytecode_offset);
+    if (!gBreakpointPositions) {
+      GenerateBreakpointInfo(isolate, script);
+    }
+    auto iter = gBreakpointPositions->find(key);
+    if (iter == gBreakpointPositions->end()) {
+      GenerateBreakpointInfo(isolate, script);
+      iter = gBreakpointPositions->find(key);
+    }
+
+    if (iter != gBreakpointPositions->end()) {
+      line = iter->second.line_;
+      column = iter->second.column_;
+    } else {
+      recordreplay::Diagnostic("Unknown offset %s %d for RecordReplayConvertFunctionOffsetToLocation",
+                                function_id.c_str(), bytecode_offset);
+    }
+  }
+
+  // If there wasn't an offset or an unexpected unknown offset was encountered,
+  // fallback to the position of the function itself. Note that if we successfully
+  // looked up a breakpoint position the line will not be zero because it is 1-indexed,
+  // see GetInstrumentationSiteLocation.
+  if (!line) {
+    Script::PositionInfo info;
+    Script::GetPositionInfo(script, function_source_position, &info, Script::WITH_OFFSET);
+
+    // Use 1-indexed lines instead of 0-indexed.
+    line = info.line + 1;
+    column = info.column;
+  }
+
+  Handle<JSObject> location = NewPlainObject(isolate);
+  SetProperty(isolate, location, "sourceId", GetProtocolSourceId(isolate, script));
+  SetProperty(isolate, location, "line", line);
+  SetProperty(isolate, location, "column", column);
+
+  Handle<JSObject> rv = NewPlainObject(isolate);
+  SetProperty(isolate, rv, "location", location);
+  return rv;
+}
+
+bool RecordReplayHasRegisteredScript(Script script);
+
+static Handle<Object> RecordReplayCountStackFrames(Isolate* isolate,
+                                                   Handle<Object> params) {
+  // This is handled in C++ instead of via a protocol JS handler for efficiency.
+  // Counting the stack frames is a common operation when there are many
+  // exception unwinds and so forth.
+  size_t count = 0;
+  for (StackFrameIterator it(isolate); !it.done(); it.Advance()) {
+    StackFrame* frame = it.frame();
+    if (!frame->is_java_script()) {
+      continue;
+    }
+    std::vector<FrameSummary> frames;
+    CommonFrame::cast(frame)->Summarize(&frames);
+
+    // We don't strictly need to iterate the frames in reverse order, but it
+    // helps when logging the stack contents for debugging.
+    for (int i = (int)frames.size() - 1; i >= 0; i--) {
+      const auto& summary = frames[i];
+      CHECK(summary.IsJavaScript());
+      const auto& js = summary.AsJavaScript();
+
+      Handle<SharedFunctionInfo> shared(js.function()->shared(), isolate);
+
+      // See GetStackLocation.
+      if (!shared->StartPosition() && !shared->EndPosition()) {
+        continue;
+      }
+
+      Handle<Script> script(Script::cast(shared->script()), isolate);
+      if (script->id() && RecordReplayHasRegisteredScript(*script)) {
+        count++;
+      }
+    }
+  }
+
+  Handle<JSObject> rv = NewPlainObject(isolate);
+  SetProperty(isolate, rv, "count", count);
+  return rv;
+}
+
+static Handle<Object> RecordReplayGetFunctionsInRange(Isolate* isolate,
+                                                      Handle<Object> params) {
+  std::set<std::string> functions;
+  ForEachInstrumentationOpInRange(isolate, params,
+     [&](Handle<Script> script, int bytecode_offset,
+         const std::string& function_id, int line, int column) {
+    functions.insert(function_id);
+  });
+
+  Handle<FixedArray> functionsArray = isolate->factory()->NewFixedArray((int)functions.size());
+
+  int index = 0;
+  for (const std::string& function_id : functions) {
+    Handle<String> str = CStringToHandle(isolate, function_id.c_str());
+    functionsArray->set(index++, *str);
+  }
+  CHECK(index == (int)functions.size());
+
+  Handle<JSArray> functionsJSArray =
+    isolate->factory()->NewJSArrayWithElements(functionsArray);
+
+  Handle<JSObject> rv = NewPlainObject(isolate);
+  SetProperty(isolate, rv, "functions", functionsJSArray);
+  return rv;
+}
+
+struct HTMLParseData {
+  void* token_;
+  std::string url_;
+  std::string contents_;
+  HTMLParseData(void* token, const char* url) : token_(token), url_(url) {}
+};
+typedef std::vector<HTMLParseData> HTMLParseDataVector;
+static HTMLParseDataVector* gHTMLParses;
+
+extern void RecordReplayAddHTMLParse(const char* url);
+
+extern "C" void V8RecordReplayHTMLParseStart(void* token, const char* url) {
+  if (!gHTMLParses) {
+    gHTMLParses = new HTMLParseDataVector();
+  }
+  RecordReplayAddHTMLParse(url);
+  gHTMLParses->emplace_back(token, url);
+}
+
+extern "C" void V8RecordReplayHTMLParseFinish(void* token) {
+  if (gHTMLParses) {
+    for (HTMLParseData& data : *gHTMLParses) {
+      if (data.token_ == token) {
+        data.token_ = nullptr;
+      }
+    }
+  }
+}
+
+extern "C" void V8RecordReplayHTMLParseAddData(void* token, const char* text) {
+  if (gHTMLParses) {
+    for (HTMLParseData& data : *gHTMLParses) {
+      if (data.token_ == token) {
+        data.contents_ += text;
+        break;
+      }
+    }
+  }
+}
+
+static Handle<Object> RecordReplayGetHTMLSource(Isolate* isolate, Handle<Object> params) {
+  Handle<Object> url_raw = GetProperty(isolate, params, "url");
+  std::unique_ptr<char[]> url_chars = String::cast(*url_raw).ToCString();
+
+  std::string contents;
+  if (gHTMLParses) {
+    for (const HTMLParseData& data : *gHTMLParses) {
+      if (data.url_ == url_chars.get()) {
+        contents = data.contents_;
+        break;
+      }
+    }
+  }
+
+  Handle<JSObject> rv = NewPlainObject(isolate);
+  SetProperty(isolate, rv, "contents", contents.c_str());
+  return rv;
+}
+
+extern int RecordReplayCurrentGeneratorIdRaw();
+
+static Handle<Object> RecordReplayCurrentGeneratorId(Isolate* isolate, Handle<Object> params) {
+  Handle<JSObject> rv = NewPlainObject(isolate);
+  int id = RecordReplayCurrentGeneratorIdRaw();
+  if (id) {
+    SetProperty(isolate, rv, "id", id);
+  }
+  return rv;
+}
+
+extern void RecordReplayAddInterestingSource(const char* url);
+
+// Return whether a script is an uninteresting internal URL, but which still needs
+// to be registered with the recorder so that breakpoints can be created.
+bool RecordReplayIsInternalScriptURL(const char* url) {
+  return !strcmp(url, "record-replay-react-devtools") ||
+         !strcmp(url, "record-replay-internal") ||
+         !strncmp(url, "extensions::", 12);
+}
+
+extern bool RecordReplayHasDefaultContext();
+
+typedef std::unordered_set<int> ScriptIdSet;
+static ScriptIdSet* gRegisteredScripts;
+
+bool RecordReplayHasRegisteredScript(Script script) {
+  return IsMainThread() &&
+    gRegisteredScripts &&
+    gRegisteredScripts->find(script.id()) != gRegisteredScripts->end();
+}
+
+bool RecordReplayIsDivergentUserJSWithoutPause(
+    const SharedFunctionInfo& shared) {
+  return recordreplay::AreEventsDisallowed() &&
+         !recordreplay::HasDivergedFromRecording() &&
+         shared.script().IsScript() &&
+         RecordReplayHasRegisteredScript(
+             Script::cast(shared.script()));
+}
+
+typedef std::vector<std::pair<Eternal<Value>*, bool>> NewScriptHandlerVector;
+static NewScriptHandlerVector* gNewScriptHandlers;
+
+extern "C" void V8RecordReplayEnterReplayCode();
+extern "C" void V8RecordReplayExitReplayCode();
+
+namespace {
+
+struct AutoMarkReplayCode {
+  AutoMarkReplayCode() {
+    V8RecordReplayEnterReplayCode();
+  }
+  ~AutoMarkReplayCode() {
+    V8RecordReplayExitReplayCode();
+  }
+};
+
+} // anonymous namespace
+
+static void RecordReplayRegisterScript(Handle<Script> script) {
+  CHECK(IsMainThread());
+
+  if (!gRecordReplayScripts) {
+    gRecordReplayScripts = new ScriptIdMap();
+  }
+  auto iter = gRecordReplayScripts->find(script->id());
+  if (iter != gRecordReplayScripts->end()) {
+    // Ignore duplicate registers.
+    return;
+  }
+
+  Isolate* isolate = Isolate::Current();
+
+  (*gRecordReplayScripts)[script->id()] =
+    Eternal<Value>((v8::Isolate*)isolate, v8::Utils::ToLocal(script));
+
+  if (!RecordReplayHasDefaultContext()) {
+    return;
+  }
+
+  Handle<String> idStr = GetProtocolSourceId(isolate, script);
+  std::unique_ptr<char[]> id = String::cast(*idStr).ToCString();
+
+  if (script->type() == Script::TYPE_WASM) {
+    return;
+  }
+
+  if (recordreplay::AreEventsDisallowed()) {
+    return;
+  }
+
+  std::string url;
+  if (!script->name().IsUndefined()) {
+    std::unique_ptr<char[]> name = String::cast(script->name()).ToCString();
+    url = name.get();
+  }
+
+  if (!strcmp(url.c_str(), "record-replay-internal")) {
+    // [TT-1390] Hackfix to not register the sourcemap handling script.
+    // We will have a better fix in the upcoming patch for TT-1112.
+    return;
+  }
+
+  if (!RecordReplayIsInternalScriptURL(url.c_str())) {
+    RecordReplayAddInterestingSource(url.c_str());
+  }
+
+  // It's not clear how we can distinguish inline scripts from HTML files vs.
+  // scripts loaded in other ways here. Use the initial position of the script
+  // to distinguish these cases: if the starting position is anything other
+  // than line zero / column zero, the script must be inlined into another file.
+  Script::PositionInfo start_info;
+  Script::GetPositionInfo(script, 0, &start_info, Script::WITH_OFFSET);
+
+  // [RUN-2172] Blink-internal scripts sometimes might have line or column, but 
+  // no URL. Since the backend requires inlineScripts to have a URL, don't flag 
+  // it as such.
+  const char* kind = ((start_info.line || start_info.column) && !url.empty())
+                         ? "inlineScript"
+                         : "scriptSource";
+
+  recordreplay::Diagnostic("OnNewSource %s %s", id.get(), kind);
+
+  if (!gRegisteredScripts) {
+    gRegisteredScripts = new ScriptIdSet;
+  }
+  gRegisteredScripts->insert(script->id());
+
+  if (gNewScriptHandlers) {
+    for (auto entry : *gNewScriptHandlers) {
+      auto handlerEternalValue = entry.first;
+      auto disallowEvents = entry.second;
+
+      AutoMarkReplayCode amrc;
+      base::Optional<replayio::AutoDisallowEvents> disallow;
+      if (disallowEvents) {
+        disallow.emplace("RecordReplayRegisterScript");
+      }
+
+      Local<v8::Value> handlerValue = handlerEternalValue->Get((v8::Isolate*)isolate);
+      Handle<Object> handler = Utils::OpenHandle(*handlerValue);
+
+      Handle<Object> callArgs[3];
+      callArgs[0] = idStr;
+      callArgs[1] = Handle<Object>(script->GetNameOrSourceURL(), isolate);
+      callArgs[2] = Handle<Object>(script->source_mapping_url(), isolate);
+
+      Handle<Object> undefined = isolate->factory()->undefined_value();
+      MaybeHandle<Object> rv = Execution::Call(isolate, handler, undefined, 3, callArgs);
+      CHECK(!rv.is_null());
+    }
+  }
+
+  RecordReplayOnNewSource(isolate, id.get(), kind, url.length() ? url.c_str() : nullptr);
+}
+
+// Command callbacks which we handle directly.
+struct InternalCommandCallback {
+  const char* mCommand;
+  Handle<Object> (*mCallback)(Isolate* isolate, Handle<Object> params);
+};
+static InternalCommandCallback gInternalCommandCallbacks[] = {
+  { "Debugger.getSourceContents", RecordReplayGetSourceContents },
+  { "Debugger.getPossibleBreakpoints", RecordReplayGetPossibleBreakpoints },
+  { "Target.convertLocationToFunctionOffset", RecordReplayConvertLocationToFunctionOffset },
+  { "Target.convertFunctionOffsetToLocation", RecordReplayConvertFunctionOffsetToLocation },
+  { "Target.countStackFrames", RecordReplayCountStackFrames },
+  { "Target.getFunctionsInRange", RecordReplayGetFunctionsInRange },
+  { "Target.getHTMLSource", RecordReplayGetHTMLSource },
+  { "Target.currentGeneratorId", RecordReplayCurrentGeneratorId },
+};
+
+// Function to invoke on command callbacks which we don't have a C++ implementation for.
+static Eternal<Value>* gCommandCallback;
+
+extern "C" void V8RecordReplayGetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context>* cx);
+extern uint64_t* gProgressCounter;
+extern int gRecordReplayCheckProgress;
+static int gPauseContextGroupId = 0;
+
+// Make sure that the isolate has a context by switching to the default
+// context if necessary.
+static void EnsureIsolateContext(Isolate* isolate, base::Optional<SaveAndSwitchContext>& ssc) {
+  if (isolate->context().is_null()) {
+    Local<v8::Context> v8_context;
+    V8RecordReplayGetDefaultContext((v8::Isolate*)isolate, &v8_context);
+    Handle<Context> context = Utils::OpenHandle(*v8_context);
+    ssc.emplace(isolate, *context);
+  }
+}
+
+
+char* CommandCallback(const char* command, const char* params) {
+  CHECK(IsMainThread());
+  AutoMarkReplayCode amrc;
+  uint64_t startProgressCounter = *gProgressCounter;
+  replayio::AutoDisallowEvents disallow("CommandCallback");
+
+  Isolate* isolate = Isolate::Current();
+  base::Optional<SaveAndSwitchContext> ssc;
+  EnsureIsolateContext(isolate, ssc);
+
+  HandleScope scope(isolate);
+
+  if (recordreplay::HasDivergedFromRecording()) {
+    v8_inspector::V8Inspector* inspectorRaw = v8::debug::GetInspector((v8::Isolate*)isolate);
+    int currentGroupId;
+    if (!inspectorRaw) {
+      currentGroupId = -1;
+    } else {
+      v8_inspector::V8InspectorImpl* inspector =
+          static_cast<v8_inspector::V8InspectorImpl*>(inspectorRaw);
+      int contextId = v8_inspector::InspectedContext::contextId(
+        ((v8::Isolate*)isolate)->GetCurrentContext()
+      );
+      currentGroupId = inspector->contextGroupId(contextId);
+    }
+    if (!gPauseContextGroupId) {
+      gPauseContextGroupId = currentGroupId;
+    } else {
+      // [RUN-3123] Don't allow querying different context groups on the
+      // same pause.
+      CHECK(gPauseContextGroupId == currentGroupId);
+    }
+  }
+
+
+  Handle<Object> undefined = isolate->factory()->undefined_value();
+  Handle<String> paramsStr = CStringToHandle(isolate, params);
+
+  MaybeHandle<Object> maybeParams = JsonParser<uint8_t>::Parse(isolate, paramsStr, undefined);
+  if (maybeParams.is_null()) {
+    recordreplay::Diagnostic("Error: CommandCallback Parse %s failed", params);
+    IMMEDIATE_CRASH();
+  }
+  Handle<Object> paramsObj = maybeParams.ToHandleChecked();
+
+  MaybeHandle<Object> rv;
+  for (const InternalCommandCallback& cb : gInternalCommandCallbacks) {
+    if (!strcmp(cb.mCommand, command)) {
+      rv = cb.mCallback(isolate, paramsObj);
+      if (rv.is_null()) {
+        recordreplay::Diagnostic("Error: CommandCallback internal command %s failed", command);
+        IMMEDIATE_CRASH();
+      }
+    }
+  }
+  if (rv.is_null()) {
+    CHECK(gCommandCallback);
+    Local<v8::Value> callbackValue = gCommandCallback->Get((v8::Isolate*)isolate);
+    Handle<Object> callback = Utils::OpenHandle(*callbackValue);
+
+    Handle<Object> callArgs[2];
+    callArgs[0] = CStringToHandle(isolate, command);
+    callArgs[1] = paramsObj;
+    rv = Execution::Call(isolate, callback, undefined, 2, callArgs);
+    if (rv.is_null()) {
+      recordreplay::Diagnostic("Error: CommandCallback generic command %s failed", command);
+      IMMEDIATE_CRASH();
+    }
+  }
+
+  Handle<Object> result = rv.ToHandleChecked();
+  Handle<Object> rvStr = JsonStringify(isolate, result, undefined, undefined).ToHandleChecked();
+  std::unique_ptr<char[]> rvCStr = String::cast(*rvStr).ToCString();
+
+  if (startProgressCounter < *gProgressCounter && !recordreplay::HasDivergedFromRecording()) {
+    // [RUN-1988] Our command handler incremented the PC by accidentally calling
+    // into instrumented user code.
+    // Note that a warning has already been generated due to
+    // gRecordReplayCheckProgress being set.
+    // → Let's reset the PC.
+    *gProgressCounter = startProgressCounter;
+  }
+
+  return strdup(rvCStr.get());
+}
+
+static Eternal<Value>* gClearPauseDataCallback;
+
+void ClearPauseDataCallback() {
+  CHECK(IsMainThread());
+  AutoMarkReplayCode amrc;
+  replayio::AutoDisallowEvents disallow("ClearPauseDataCallback");
+
+  if (!gClearPauseDataCallback) {
+    return;
+  }
+
+  Isolate* isolate = Isolate::Current();
+  base::Optional<SaveAndSwitchContext> ssc;
+  EnsureIsolateContext(isolate, ssc);
+
+  HandleScope scope(isolate);
+
+  Local<v8::Value> callbackValue = gClearPauseDataCallback->Get((v8::Isolate*)isolate);
+  Handle<Object> callback = Utils::OpenHandle(*callbackValue);
+
+  Handle<Object> undefined = isolate->factory()->undefined_value();
+  MaybeHandle<Object> rv = Execution::Call(isolate, callback, undefined, 0, nullptr);
+  CHECK(!rv.is_null());
+}
+
+static std::string StringPrintf(const char* format, ...) {
+  char buf[4096];
+  buf[sizeof(buf) - 1] = 0;
+  va_list ap;
+  va_start(ap, format);
+  vsnprintf(buf, sizeof(buf) - 1, format, ap);
+  va_end(ap);
+  return std::string(buf);
+}
+
+// When assertions are used we assign an ID to each object that is ever
+// encountered in one, so that we can determine whether consistent objects
+// are used when replaying.
+struct ContextObjectIdMap {
+  v8::Global<v8::Context> context_;
+  v8::Global<v8::Value> object_ids_;
+};
+typedef std::vector<ContextObjectIdMap> ContextObjectIdMapVector;
+static ContextObjectIdMapVector* gRecordReplayObjectIds;
+
+static Local<v8::Value> GetObjectIdMapForContext(v8::Isolate* v8_isolate, Local<v8::Context> cx) {
+  Isolate* isolate = (Isolate*)v8_isolate;
+
+  if (!gRecordReplayObjectIds) {
+    gRecordReplayObjectIds = new ContextObjectIdMapVector();
+  }
+
+  for (const auto& entry : *gRecordReplayObjectIds) {
+    if (entry.context_ == cx) {
+      return entry.object_ids_.Get(v8_isolate);
+    }
+  }
+
+  Handle<Object> object_ids = isolate->factory()->NewJSWeakMap();
+
+  ContextObjectIdMap new_entry;
+  new_entry.context_.Reset(v8_isolate, cx);
+  new_entry.object_ids_.Reset(v8_isolate, v8::Utils::ToLocal(object_ids));
+  gRecordReplayObjectIds->push_back(std::move(new_entry));
+  return gRecordReplayObjectIds->back().object_ids_.Get(v8_isolate);
+}
+
+extern bool gRecordReplayAssertTrackedObjects;
+extern bool gRecordReplayAssertDependencyGraph;
+extern int (*gGetAPIObjectIdCallback)(v8::Local<v8::Object> object);
+
+static int gNextObjectId = 1;
+
+int RecordReplayObjectId(v8::Isolate* v8_isolate, v8::Local<v8::Context> cx,
+                         v8::Local<v8::Value> v8_object, bool allow_create) {
+  CHECK(IsMainThread());
+
+  if (!v8_object->IsObject()) {
+    return 0;
+  }
+
+  if (gGetAPIObjectIdCallback) {
+    // Check for Blink objects.
+    int api_id = gGetAPIObjectIdCallback(v8_object.As<v8::Object>());
+    if (api_id) {
+      return api_id;
+    }
+  }
+
+  Isolate* isolate = (Isolate*)v8_isolate;
+  Handle<Object> object = Utils::OpenHandle(*v8_object);
+
+  // Look through all weak maps we've created, the object might not be associated
+  // with the current context.
+  if (gRecordReplayObjectIds) {
+    for (const auto& entry : *gRecordReplayObjectIds) {
+      Local<v8::Value> object_ids_val = entry.object_ids_.Get(v8_isolate);
+      Handle<JSWeakMap> object_ids = Handle<JSWeakMap>::cast(Utils::OpenHandle(*object_ids_val));
+
+      Handle<Object> existing(EphemeronHashTable::cast(object_ids->table()).Lookup(object), isolate);
+      if (!existing->IsTheHole(isolate)) {
+        v8::Local<v8::Value> id_value = v8::Utils::ToLocal(existing);
+        if (id_value->IsInt32()) {
+          int id = id_value.As<v8::Int32>()->Value();
+          if (gRecordReplayAssertTrackedObjects) {
+            recordreplay::AssertMaybeEventsDisallowed("JS ReuseObjectId %d", id);
+          }
+          return id;
+        }
+      }
+    }
+  }
+
+  if (!allow_create) {
+    return 0;
+  }
+
+  int id = gNextObjectId++;
+
+  if (gRecordReplayAssertTrackedObjects) {
+    recordreplay::AssertMaybeEventsDisallowed("JS NewObjectId %d", id);
+  }
+
+  Local<Value> id_value = v8::Integer::New(v8_isolate, id);
+
+  int32_t hash = object->GetOrCreateHash(isolate).value();
+
+  Local<v8::Value> object_ids_val = GetObjectIdMapForContext(v8_isolate, cx);
+  Handle<JSWeakMap> object_ids = Handle<JSWeakMap>::cast(Utils::OpenHandle(*object_ids_val));
+  JSWeakCollection::Set(object_ids, object, Utils::OpenHandle(*id_value), hash);
+
+  return id;
+}
+
+static bool gTrackObjects = false;
+
+// Called by the recorder when we need to track persistent IDs for as many objects
+// as we are able to. Currently this is enabled while replaying via the
+// enablePersistentIDs experimental setting.
+void TrackObjectsCallback(bool track_objects) {
+  CHECK(recordreplay::IsReplaying());
+  gTrackObjects = track_objects;
+}
+
+// Whether to keep track of 'this' objects being assigned a property.
+bool RecordReplayTrackThisObjectAssignment(const std::string& property) {
+  // If we've been told to track objects then all 'this' objects which are
+  // assigned a property will be tracked.
+  if (gRecordReplayAssertTrackedObjects || gTrackObjects) {
+    return true;
+  }
+
+  // By default we only track objects which might be React fibers. These will
+  // have an "alternate" property assigned to in the constructor. Tracking objects
+  // is only needed when replaying.
+  if (recordreplay::IsReplaying() && property == "alternate") {
+    return true;
+  }
+
+  return false;
+}
+
+// Print a message if an object does not have a persistent ID. For use in testing.
+void RecordReplayConfirmObjectHasId(v8::Isolate* isolate, v8::Local<v8::Context> cx,
+                                    v8::Local<v8::Value> object) {
+  int id = RecordReplayObjectId(isolate, cx, object, /* allow_create */ false);
+  if (!id) {
+    recordreplay::Print("RecordReplayConfirmObjectHasId unexpected missing persistent ID");
+  }
+}
+
+inline int HashBytes(const void* aPtr, size_t aSize) {
+  int hash = 0;
+  uint8_t* ptr = (uint8_t*)aPtr;
+  for (size_t i = 0; i < aSize; i++) {
+    hash = (((hash << 5) - hash) + ptr[i]) | 0;
+  }
+  return hash;
+}
+
+int (*gGetAPIObjectIdCallback)(v8::Local<v8::Object> object);
+
+extern "C" void V8RecordReplaySetAPIObjectIdCallback(int (*callback)(v8::Local<v8::Object>)) {
+  gGetAPIObjectIdCallback = callback;
+}
+
+// Get a string that can be included in recording assertions.
+static std::string ToReadableString(const char* str) {
+  std::ostringstream o;
+  for (; *str; str++) {
+    if ((int)*str >= 32 && (int)*str <= 126) {
+      o << *str;
+    } else {
+      o << "\\" << (int)*str;
+    }
+  }
+  return o.str();
+}
+
+// Get a string describing a value which can be used in assertions.
+// Only basic information about the value is obtained, to keep things fast.
+std::string RecordReplayBasicValueContents(Handle<Object> value) {
+  if (value->IsNumber()) {
+    double num = value->Number();
+    if (std::isnan(num)) {
+      return "NaN";
+    }
+    int num2 = num;
+    if (num2 != num) {
+      num2 = -1;
+    }
+    return StringPrintf("Number %d %llu", num2, *(uint64_t*)&num);
+  }
+
+  if (value->IsBoolean()) {
+    return StringPrintf("Boolean %d", value->IsTrue());
+  }
+
+  if (value->IsUndefined()) {
+    return "Undefined";
+  }
+
+  if (value->IsNull()) {
+    return "Null";
+  }
+
+  if (value->IsString()) {
+    String str = String::cast(*value);
+    if (str.length() <= 200) {
+      std::unique_ptr<char[]> name = str.ToCString();
+      std::string readable_name = ToReadableString(name.get());
+      return StringPrintf("String %s", readable_name.c_str());
+    }
+    return StringPrintf("LongString %d", str.length());
+  }
+
+  if (value->IsJSObject()) {
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::Local<v8::Context> cx = isolate->GetCurrentContext();
+    int object_id = RecordReplayObjectId(isolate, cx, v8::Utils::ToLocal(value),
+                                         /* allow_create */ true);
+
+    InstanceType type = JSObject::cast(*value).map().instance_type();
+    const char* typeStr;
+    switch (type) {
+#define STRINGIFY_TYPE(TYPE) case TYPE: typeStr = #TYPE; break;
+    INSTANCE_TYPE_LIST(STRINGIFY_TYPE)
+#undef STRINGIFY_TYPE
+    default:
+      typeStr = "<unknown>";
+    }
+    if (!strcmp(typeStr, "JS_DATE_TYPE")) {
+      JSDate date = JSDate::cast(*value);
+      double time = date.value().Number();
+      return StringPrintf("Date %d %.2f", object_id, time);
+    }
+    if (!strcmp(typeStr, "JS_TYPED_ARRAY_TYPE")) {
+      v8::Local<v8::Value> obj = v8::Utils::ToLocal(value);
+      v8::Local<v8::TypedArray> tarr = obj.As<v8::TypedArray>();
+      char buf[50];
+      size_t written = tarr->CopyContents(buf, sizeof(buf));
+      int hash = HashBytes(buf, written);
+      return StringPrintf("TypedArray %d %lu %d", object_id, tarr->ByteLength(), hash);
+    }
+    return StringPrintf("Object %d %s", object_id, typeStr);
+  }
+
+  if (value->IsJSProxy()) {
+    return "Proxy";
+  }
+
+  return "Unknown";
+}
+
+// Information in the dependency graph for a JS promise.
+struct PromiseDependencyGraphData {
+  // persistent_id of the promise value.
+  int persistent_id = 0;
+
+  // Graph node ID for the point the promise was created.
+  int new_node_id = 0;
+
+  // Graph node ID for the point the promise was settled.
+  int settled_node_id = 0;
+};
+
+typedef std::unordered_map<int32_t, PromiseDependencyGraphData> PromiseDependencyGraphDataMap;
+static PromiseDependencyGraphDataMap* gPromiseDependencyGraphDataMap;
+
+static PromiseDependencyGraphData&
+GetOrCreatePromiseDependencyGraphData(Isolate* isolate, Handle<Object> promise) {
+  v8::Isolate* v8_isolate = (v8::Isolate*) isolate;
+  int promise_persistent_id =
+    RecordReplayObjectId(v8_isolate, v8_isolate->GetCurrentContext(),
+                         v8::Utils::ToLocal(promise), /* allow_create */ true);
+
+  CHECK(IsMainThread());
+  if (!gPromiseDependencyGraphDataMap) {
+    gPromiseDependencyGraphDataMap = new PromiseDependencyGraphDataMap();
+  }
+  auto iter = gPromiseDependencyGraphDataMap->find(promise_persistent_id);
+  if (iter == gPromiseDependencyGraphDataMap->end()) {
+    // Previously unseen promise.
+    PromiseDependencyGraphData data = PromiseDependencyGraphData();
+    data.persistent_id = promise_persistent_id;
+    (*gPromiseDependencyGraphDataMap)[promise_persistent_id] = data;
+    iter = gPromiseDependencyGraphDataMap->find(promise_persistent_id);
+  }
+  return iter->second;
+}
+
+void AddPromiseDependencyGraphAdoption(Isolate* isolate, Handle<Object> promise, Handle<Object> adopted) {
+  PromiseDependencyGraphData& data = GetOrCreatePromiseDependencyGraphData(isolate, promise);
+  PromiseDependencyGraphData& adopted_data = GetOrCreatePromiseDependencyGraphData(isolate, adopted);
+
+  if (adopted_data.new_node_id) {
+    recordreplay::AddDependencyGraphEdge(data.settled_node_id,
+                                         adopted_data.new_node_id,
+                                         "{\"kind\":\"adoptedPromise\"}");
+  }
+}
+
+extern bool gRecordReplayEnableDependencyGraph;
+
+bool RecordReplayShouldCallOnPromiseHook() {
+  // Ideally we would be able to avoid calling the promise hook when recording
+  // and its results aren't needed, but the isolate state we set to ensure
+  // the hook gets called have effects on the state of certain promises that
+  // affect how the process behaves and are not fully understood.
+  //
+  // See https://linear.app/replay/issue/TT-1361
+  //
+  // For now we workaround this problem by setting this state consistently and
+  // add a small amount of recording overhead.
+  return gRecordReplayEnableDependencyGraph && IsMainThread();
+}
+
+void RecordReplayOnPromiseHook(Isolate* isolate, PromiseHookType type,
+                               Handle<JSPromise> promise, Handle<Object> parent) {
+  if (!gRecordReplayEnableDependencyGraph) {
+    return;
+  }
+
+  // The promise hook only needs to report nodes/edges while replaying,
+  // but can assign persistent IDs to objects so the calls below are needed
+  // while recording if we are asserting on those IDs.
+  if (!recordreplay::IsReplaying() &&
+      !gRecordReplayAssertTrackedObjects &&
+      !gRecordReplayAssertDependencyGraph) {
+    return;
+  }
+
+  PromiseDependencyGraphData& data =
+    GetOrCreatePromiseDependencyGraphData(isolate, promise);
+
+  switch (type) {
+    case PromiseHookType::kInit: {
+      CHECK(!data.new_node_id);
+      std::string new_node_str = StringPrintf("{\"kind\":\"newPromise\",\"persistentId\":%d}",
+                                               data.persistent_id);
+      data.new_node_id = recordreplay::NewDependencyGraphNode(new_node_str.c_str());
+      if (!parent->IsUndefined()) {
+        PromiseDependencyGraphData& parent_data =
+          GetOrCreatePromiseDependencyGraphData(isolate, parent);
+        if (parent_data.new_node_id) {
+          recordreplay::AddDependencyGraphEdge(parent_data.new_node_id, data.new_node_id,
+                                               "{\"kind\":\"parentPromise\"}");
+        }
+      }
+      break;
+    }
+    case PromiseHookType::kResolve: {
+      if (!data.new_node_id || data.settled_node_id) {
+        break;
+      }
+      data.settled_node_id =
+        recordreplay::NewDependencyGraphNode("{\"kind\":\"promiseSettled\"}");
+      recordreplay::AddDependencyGraphEdge(data.new_node_id, data.settled_node_id,
+                                           "{\"kind\":\"basePromise\"}");
+      break;
+    }
+    case PromiseHookType::kBefore: {
+      int node_id = data.settled_node_id ? data.settled_node_id : data.new_node_id;
+      recordreplay::BeginDependencyExecution(node_id);
+      break;
+    }
+    case PromiseHookType::kAfter: {
+      recordreplay::EndDependencyExecution();
+      break;
+    }
+  }
 }
 
 }  // namespace internal

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -20,6 +20,8 @@
 #include "src/debug/liveedit.h"
 #include "src/deoptimizer/deoptimizer.h"
 #include "src/execution/execution.h"
+#include "src/json/json-parser.h"
+#include "src/json/json-stringifier.h"
 #include "src/execution/frames-inl.h"
 #include "src/execution/frames.h"
 #include "src/execution/isolate-inl.h"
@@ -4271,13 +4273,14 @@ static void RecordReplayRegisterScript(Handle<Script> script) {
       Local<v8::Value> handlerValue = handlerEternalValue->Get((v8::Isolate*)isolate);
       Handle<Object> handler = Utils::OpenHandle(*handlerValue);
 
-      Handle<Object> callArgs[3];
+      DirectHandle<Object> callArgs[3];
       callArgs[0] = idStr;
       callArgs[1] = Handle<Object>(script->GetNameOrSourceURL(), isolate);
       callArgs[2] = Handle<Object>(script->source_mapping_url(), isolate);
 
       Handle<Object> undefined = isolate->factory()->undefined_value();
-      MaybeHandle<Object> rv = Execution::Call(isolate, handler, undefined, 3, callArgs);
+      MaybeHandle<Object> rv =
+          Execution::Call(isolate, handler, undefined, base::VectorOf(callArgs));
       CHECK(!rv.is_null());
     }
   }
@@ -4359,7 +4362,8 @@ char* CommandCallback(const char* command, const char* params) {
   Handle<Object> undefined = isolate->factory()->undefined_value();
   Handle<String> paramsStr = CStringToHandle(isolate, params);
 
-  MaybeHandle<Object> maybeParams = JsonParser<uint8_t>::Parse(isolate, paramsStr, undefined);
+  MaybeHandle<Object> maybeParams =
+      JsonParser<uint8_t>::Parse(isolate, paramsStr, undefined, std::nullopt);
   if (maybeParams.is_null()) {
     recordreplay::Diagnostic("Error: CommandCallback Parse %s failed", params);
     IMMEDIATE_CRASH();
@@ -4381,10 +4385,10 @@ char* CommandCallback(const char* command, const char* params) {
     Local<v8::Value> callbackValue = gCommandCallback->Get((v8::Isolate*)isolate);
     Handle<Object> callback = Utils::OpenHandle(*callbackValue);
 
-    Handle<Object> callArgs[2];
+    DirectHandle<Object> callArgs[2];
     callArgs[0] = CStringToHandle(isolate, command);
     callArgs[1] = paramsObj;
-    rv = Execution::Call(isolate, callback, undefined, 2, callArgs);
+    rv = Execution::Call(isolate, callback, undefined, base::VectorOf(callArgs));
     if (rv.is_null()) {
       recordreplay::Diagnostic("Error: CommandCallback generic command %s failed", command);
       IMMEDIATE_CRASH();
@@ -4392,8 +4396,11 @@ char* CommandCallback(const char* command, const char* params) {
   }
 
   Handle<Object> result = rv.ToHandleChecked();
-  Handle<Object> rvStr = JsonStringify(isolate, result, undefined, undefined).ToHandleChecked();
-  std::unique_ptr<char[]> rvCStr = String::cast(*rvStr).ToCString();
+  DirectHandle<Object> rvStr =
+      JsonStringify(isolate, Cast<JSAny>(result), Cast<JSAny>(undefined),
+                    undefined)
+          .ToHandleChecked();
+  std::unique_ptr<char[]> rvCStr = Cast<String>(*rvStr)->ToCString();
 
   if (startProgressCounter < *gProgressCounter && !recordreplay::HasDivergedFromRecording()) {
     // [RUN-1988] Our command handler incremented the PC by accidentally calling
@@ -4428,7 +4435,7 @@ void ClearPauseDataCallback() {
   Handle<Object> callback = Utils::OpenHandle(*callbackValue);
 
   Handle<Object> undefined = isolate->factory()->undefined_value();
-  MaybeHandle<Object> rv = Execution::Call(isolate, callback, undefined, 0, nullptr);
+  MaybeHandle<Object> rv = Execution::Call(isolate, callback, undefined, {});
   CHECK(!rv.is_null());
 }
 

--- a/src/debug/debug.h
+++ b/src/debug/debug.h
@@ -534,6 +534,8 @@ class V8_EXPORT_PRIVATE Debug {
                    bool is_stack_overflow = false);
 
   void ProcessCompileEvent(bool has_compile_error, DirectHandle<Script> script);
+  void DoProcessCompileEvent(bool has_compile_error,
+                             DirectHandle<Script> script);
 
   // Find the closest source position for a break point for a given position.
   int FindBreakablePosition(Handle<DebugInfo> debug_info, int source_position);

--- a/src/execution/execution.cc
+++ b/src/execution/execution.cc
@@ -282,14 +282,14 @@ static std::string GetFunctionLocationInfo(Isolate* isolate, Handle<JSFunction> 
 
   Script::PositionInfo info;
   Script::GetPositionInfo(script, function->shared().StartPosition(),
-                          &info, Script::WITH_OFFSET);
+                          &info, Script::OffsetFlag::kWithOffset);
 
   std::string name = script->name().IsString()
     ? String::cast(script->name()).ToCString().get()
     : "(anonymous script)";
 
   std::ostringstream os;
-  os << "scriptId=" << (script.is_null() ? script->id() : -1);
+  os << "scriptId=" << (!script.is_null() ? script->id() : -1);
   os << " @" << name << ":" << info.line + 1 << ":" << info.column;
   return os.str();
 }

--- a/src/execution/execution.cc
+++ b/src/execution/execution.cc
@@ -18,6 +18,8 @@
 #include "src/wasm/wasm-engine-globals.h"
 #endif  // V8_ENABLE_WEBASSEMBLY
 
+extern "C" int V8RecordReplayDependencyGraphExecutionNode();
+
 namespace v8 {
 namespace internal {
 
@@ -270,6 +272,28 @@ MaybeDirectHandle<Context> NewScriptContext(
   return result;
 }
 
+// Get a description of a function's location for logging etc.
+static std::string GetFunctionLocationInfo(Isolate* isolate, Handle<JSFunction> function) {
+  if (!function->shared().script().IsScript()) {
+    return "<not-script>";
+  }
+
+  Handle<Script> script(Script::cast(function->shared().script()), isolate);
+
+  Script::PositionInfo info;
+  Script::GetPositionInfo(script, function->shared().StartPosition(),
+                          &info, Script::WITH_OFFSET);
+
+  std::string name = script->name().IsString()
+    ? String::cast(script->name()).ToCString().get()
+    : "(anonymous script)";
+
+  std::ostringstream os;
+  os << "scriptId=" << (script.is_null() ? script->id() : -1);
+  os << " @" << name << ":" << info.line + 1 << ":" << info.column;
+  return os.str();
+}
+
 V8_WARN_UNUSED_RESULT MaybeHandle<Object> Invoke(Isolate* isolate,
                                                  const InvokeParams& params) {
   RCS_SCOPE(isolate, RuntimeCallCounterId::kInvoke);
@@ -340,6 +364,34 @@ V8_WARN_UNUSED_RESULT MaybeHandle<Object> Invoke(Isolate* isolate,
       DCHECK(!params.IsScript());
     }
 #endif
+
+    if (RecordReplayIsDivergentUserJSWithoutPause(function->shared())) {
+      // User JS should not get executed in divergent code paths,
+      // unless we have paused.
+      // → Print log and prevent execution.
+      std::string location = GetFunctionLocationInfo(isolate, function);
+      std::stringstream stack;
+      isolate->PrintCurrentStackTrace(stack);
+
+      recordreplay::Warning(
+          "JS Invoke: Non-deterministic user JS PC=%zu %s stack=%s",
+          *gProgressCounter, location.c_str(), stack.str().c_str());
+      return isolate->factory()->undefined_value();
+    }
+
+    if (recordreplay::IsReplaying() &&
+        IsMainThread() &&
+        gRecordReplayEnableDependencyGraph &&
+        !recordreplay::AreEventsDisallowed() &&
+        V8RecordReplayDependencyGraphExecutionNode() == 0 &&
+        function->shared().script().IsScript()) {
+      static bool show_warning = !!getenv("RECORD_REPLAY_WARN_MISSING_EXECUTION");
+      if (show_warning) {
+        std::string location = GetFunctionLocationInfo(isolate, function);
+        recordreplay::Warning("DependencyGraph missing execution: %s", location.c_str());
+      }
+    }
+
     // Set up a ScriptContext when running scripts that need it.
     if (function->shared()->needs_script_context()) {
       DirectHandle<Context> context;

--- a/src/execution/frames.cc
+++ b/src/execution/frames.cc
@@ -395,7 +395,13 @@ DebuggableStackFrameIterator::DebuggableStackFrameIterator(Isolate* isolate)
 DebuggableStackFrameIterator::DebuggableStackFrameIterator(Isolate* isolate,
                                                            StackFrameId id)
     : DebuggableStackFrameIterator(isolate) {
-  while (!done() && frame()->id() != id) Advance();
+  if (id == NO_ID) {
+    // Support stack trace iteration when stopped by the Record Replay driver,
+    // where there is no break frame.
+    if (!done() && !IsValidFrame(iterator_.frame())) Advance();
+  } else {
+    while (!done() && frame()->id() != id) Advance();
+  }
 }
 
 void DebuggableStackFrameIterator::Advance() {
@@ -3133,6 +3139,13 @@ FrameSummaries OptimizedJSFrame::Summarize(
     }
 
     CHECK(data.is_null());
+
+    if (recordreplay::IsRecordingOrReplaying()) {
+      // Replay workaround: Sometimes, DeoptimizationData could not be found for an unknown reason.
+      // → Let this be a no-op instead of a crash.
+      recordreplay::Warning("[RUN-1920] Missing deoptimization information for OptimizedFrame::Summarize.");
+      return;
+    }
     FATAL(
         "Missing deoptimization information for OptimizedJSFrame::Summarize.");
   }

--- a/src/execution/frames.cc
+++ b/src/execution/frames.cc
@@ -3144,7 +3144,7 @@ FrameSummaries OptimizedJSFrame::Summarize(
       // Replay workaround: Sometimes, DeoptimizationData could not be found for an unknown reason.
       // → Let this be a no-op instead of a crash.
       recordreplay::Warning("[RUN-1920] Missing deoptimization information for OptimizedFrame::Summarize.");
-      return;
+      return summaries;
     }
     FATAL(
         "Missing deoptimization information for OptimizedJSFrame::Summarize.");

--- a/src/execution/futex-emulation.cc
+++ b/src/execution/futex-emulation.cc
@@ -563,7 +563,6 @@ Tagged<Object> FutexEmulation::WaitAsync(
   FutexWaitList* wait_list = GetWaitList();
   {
     replayio::AutoDisallowEvents disallow("FutexEmulation::WaitAsync");
-    replayio::AutoDisallowEvents disallow("AtomicsWaitWakeHandle::Wake");
     // 16. Perform EnterCriticalSection(WL).
     NoGarbageCollectionMutexGuard lock_guard(wait_list->mutex());
 
@@ -676,8 +675,8 @@ int FutexEmulation::Wake(Tagged<JSArrayBuffer> array_buffer, size_t addr,
   return Wake(wait_location, num_waiters_to_wake);
 }
 
-  replayio::AutoDisallowEvents disallow("FutexEmulation::Wake");
 int FutexEmulation::Wake(void* wait_location, uint32_t num_waiters_to_wake) {
+  replayio::AutoDisallowEvents disallow("FutexEmulation::Wake");
   int num_waiters_woken = 0;
   FutexWaitList* wait_list = GetWaitList();
   NoGarbageCollectionMutexGuard lock_guard(wait_list->mutex());
@@ -944,7 +943,6 @@ void FutexEmulation::IsolateDeinit(Isolate* isolate) {
   FutexWaitList* wait_list = GetWaitList();
   NoGarbageCollectionMutexGuard lock_guard(wait_list->mutex());
 
-  replayio::AutoDisallowEvents disallow("FutexEmulation::NumWaitersForTesting");
   // Iterate all locations to find nodes belonging to "isolate" and delete them.
   // The Isolate is going away; don't bother cleaning up the Promises in the
   // NativeContext. Also we don't need to cancel the timeout tasks, since they

--- a/src/execution/futex-emulation.cc
+++ b/src/execution/futex-emulation.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "src/execution/futex-emulation.h"
+#include "include/replayio.h"
 
 #include <limits>
 

--- a/src/execution/futex-emulation.cc
+++ b/src/execution/futex-emulation.cc
@@ -142,6 +142,9 @@ bool FutexWaitListNode::CancelTimeoutTask() {
 
 void FutexWaitListNode::NotifyWake() {
   DCHECK(!IsAsync());
+
+  replayio::AutoDisallowEvents disallow("FutexWaitListNode::NotifyWake");
+
   // Lock the global mutex before notifying. We know that the mutex
   // will have been unlocked if we are currently waiting on the condition
   // variable. The mutex will not be locked if FutexEmulation::Wait hasn't
@@ -380,6 +383,9 @@ Tagged<Object> FutexEmulation::Wait(Isolate* isolate, WaitMode mode,
     }
   }
 
+  recordreplay::AutoAssertMaybeEventsDisallowed assrt("[RUN-2378] FutexEmulation::Wait");
+
+
   if (mode == WaitMode::kSync) {
     return WaitSync(isolate, FutexWaitList::ToWaitLocation(*array_buffer, addr),
                     value, use_timeout, rel_timeout_ns, call_type);
@@ -555,6 +561,8 @@ Tagged<Object> FutexEmulation::WaitAsync(
   std::weak_ptr<BackingStore> backing_store{array_buffer->GetBackingStore()};
   FutexWaitList* wait_list = GetWaitList();
   {
+    replayio::AutoDisallowEvents disallow("FutexEmulation::WaitAsync");
+    replayio::AutoDisallowEvents disallow("AtomicsWaitWakeHandle::Wake");
     // 16. Perform EnterCriticalSection(WL).
     NoGarbageCollectionMutexGuard lock_guard(wait_list->mutex());
 
@@ -667,6 +675,7 @@ int FutexEmulation::Wake(Tagged<JSArrayBuffer> array_buffer, size_t addr,
   return Wake(wait_location, num_waiters_to_wake);
 }
 
+  replayio::AutoDisallowEvents disallow("FutexEmulation::Wake");
 int FutexEmulation::Wake(void* wait_location, uint32_t num_waiters_to_wake) {
   int num_waiters_woken = 0;
   FutexWaitList* wait_list = GetWaitList();
@@ -870,6 +879,7 @@ void FutexEmulation::ResolveAsyncWaiterPromises(Isolate* isolate) {
   FutexWaitList* wait_list = GetWaitList();
   FutexWaitListNode* node;
   {
+    replayio::AutoDisallowEvents disallow("FutexEmulation::ResolveAsyncWaiterPromises");
     NoGarbageCollectionMutexGuard lock_guard(wait_list->mutex());
 
     auto& isolate_map = wait_list->isolate_promises_to_resolve_;
@@ -907,6 +917,7 @@ void FutexEmulation::HandleAsyncWaiterTimeout(FutexWaitListNode* node) {
   FutexWaitList* wait_list = GetWaitList();
 
   {
+    replayio::AutoDisallowEvents disallow("FutexEmulation::HandleAsyncWaiterTimeout");
     NoGarbageCollectionMutexGuard lock_guard(wait_list->mutex());
 
     node->async_state_->timeout_task_id = CancelableTaskManager::kInvalidTaskId;
@@ -928,9 +939,11 @@ void FutexEmulation::HandleAsyncWaiterTimeout(FutexWaitListNode* node) {
 }
 
 void FutexEmulation::IsolateDeinit(Isolate* isolate) {
+  replayio::AutoDisallowEvents disallow("FutexEmulation::IsolateDeinit");
   FutexWaitList* wait_list = GetWaitList();
   NoGarbageCollectionMutexGuard lock_guard(wait_list->mutex());
 
+  replayio::AutoDisallowEvents disallow("FutexEmulation::NumWaitersForTesting");
   // Iterate all locations to find nodes belonging to "isolate" and delete them.
   // The Isolate is going away; don't bother cleaning up the Promises in the
   // NativeContext. Also we don't need to cancel the timeout tasks, since they
@@ -981,6 +994,7 @@ int FutexEmulation::NumWaitersForTesting(Tagged<JSArrayBuffer> array_buffer,
   auto it = location_lists.find(wait_location);
   if (it == location_lists.end()) return num_waiters;
 
+  replayio::AutoDisallowEvents disallow("FutexEmulation::NumUnresolvedAsyncPromisesForTesting");
   for (FutexWaitListNode* node = it->second.head; node; node = node->next_) {
     if (!node->waiting_) continue;
     if (node->IsAsync()) {

--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -117,6 +117,7 @@
 #include "src/profiler/heap-profiler.h"
 #include "src/profiler/tracing-cpu-profiler.h"
 #include "src/regexp/regexp-stack.h"
+#include "src/replay/replay-isolate-data.h"
 #include "src/roots/roots.h"
 #include "src/roots/static-roots.h"
 #include "src/sandbox/js-dispatch-table-inl.h"
@@ -1520,6 +1521,8 @@ void CaptureAsyncStackTrace(Isolate* isolate, CallSiteBuilder* builder) {
   }
 }
 
+extern "C" bool V8RecordReplayIsInReplayCode();
+
 // Summarize a single frame and pass each logical frame to the visitor.
 template <typename Visitor>
 void VisitStack(Isolate* isolate, Visitor* visitor,
@@ -1569,6 +1572,8 @@ void VisitStack(Isolate* isolate, Visitor* visitor,
     }
   }
 }
+
+static bool gHasPrintedStack = false;
 
 // Specialized stack walk for CallSiteBuilder, handling deferred baseline
 // frames and the construct-call flag on the previous frame.
@@ -1631,6 +1636,29 @@ void VisitStack_ForCallSiteBuilder(Isolate* isolate, CallSiteBuilder* visitor) {
       default:
         break;
     }
+  }
+}
+
+void Isolate::RecordReplayInvokeApiInterruptCallbacksAtProgress() {
+  CHECK(recordreplay::IsRecordingOrReplaying("interrupts"));
+  CHECK(IsMainThread());
+
+  while (true) {
+    InterruptEntry entry;
+    recordreplay::OrderedLock(record_replay_api_interrupts_ordered_lock_id_);
+    {
+      ExecutionAccess access(this);
+      if (api_interrupts_queue_.empty()) {
+        recordreplay::OrderedUnlock(record_replay_api_interrupts_ordered_lock_id_);
+        return;
+      }
+      entry = api_interrupts_queue_.front();
+      api_interrupts_queue_.pop();
+    }
+    recordreplay::OrderedUnlock(record_replay_api_interrupts_ordered_lock_id_);
+    VMState<EXTERNAL> state(this);
+    HandleScope handle_scope(this);
+    entry.first(reinterpret_cast<v8::Isolate*>(this), entry.second);
   }
 }
 
@@ -2413,6 +2441,10 @@ bool Isolate::MayAccess(DirectHandle<NativeContext> accessing_context,
 
   // During bootstrapping, callback functions are not enabled yet.
   if (bootstrapper()->IsActive()) return true;
+
+  // Allow all accesses made while replay code is running.
+  if (V8RecordReplayIsInReplayCode()) return true;
+
   {
     DisallowGarbageCollection no_gc;
 
@@ -2548,6 +2580,7 @@ void Isolate::CancelTerminateExecution() {
 }
 
 void Isolate::RequestInterrupt(InterruptCallback callback, void* data) {
+  recordreplay::OrderedLock(record_replay_api_interrupts_ordered_lock_id_);
   ExecutionAccess access(this);
   api_interrupts_queue_.push(InterruptEntry(callback, data));
   stack_guard()->RequestApiInterrupt();
@@ -3493,6 +3526,9 @@ Tagged<Object> Isolate::ThrowIllegalOperation() {
   if (v8_flags.stack_trace_on_illegal) PrintStack(stdout);
   return Throw(ReadOnlyRoots(heap()).illegal_access_string());
 }
+
+extern void RecordReplayOnMainThreadIsolateCreated(Isolate* isolate);
+extern bool RecordReplayShouldCallOnPromiseHook();
 
 void Isolate::PrintCurrentStackTrace(
     std::ostream& out,
@@ -4797,6 +4833,24 @@ Isolate::Isolate(IsolateGroup* isolate_group)
 #endif  // V8_ENABLE_WEBASSEMBLY
 
   MicrotaskQueue::SetUpDefaultMicrotaskQueue(this);
+
+  record_replay_api_interrupts_ordered_lock_id_ = (int)recordreplay::CreateOrderedLock("APIInterrupts");
+
+  if (recordreplay::IsRecordingOrReplaying() && IsMainThread()) {
+    RecordReplayOnMainThreadIsolateCreated(this);
+  }
+
+  if (RecordReplayShouldCallOnPromiseHook()) {
+    promise_hook_flags_ =
+      PromiseHookFields::HasIsolatePromiseHook::encode(true);
+  }
+}
+
+replayio::ReplayIsolateData* Isolate::EnsureReplayData() {
+  if (!replay_data_) {
+    replay_data_ = std::make_unique<replayio::ReplayIsolateData>();
+  }
+  return replay_data_.get();
 }
 
 void Isolate::CheckIsolateLayout() {
@@ -5288,6 +5342,9 @@ void Isolate::SetIsolateThreadLocals(Isolate* isolate,
     WriteBarrier::SetForThread(nullptr);
   }
 }
+
+extern void RecordReplayOnPromiseHook(Isolate* isolate, PromiseHookType type,
+                                      Handle<JSPromise> promise, Handle<Object> parent);
 
 Isolate::~Isolate() {
   TRACE_ISOLATE(destructor);
@@ -7156,10 +7213,10 @@ void Isolate::UpdatePromiseHookProtector() {
 
 void Isolate::PromiseHookStateUpdated() {
   promise_hook_flags_ =
-      (promise_hook_flags_ & PromiseHookFields::HasContextPromiseHook::kMask) |
-      PromiseHookFields::HasIsolatePromiseHook::encode(promise_hook_) |
-      PromiseHookFields::HasAsyncEventDelegate::encode(async_event_delegate_) |
-      PromiseHookFields::IsDebugActive::encode(debug()->is_active());
+    (promise_hook_flags_ & PromiseHookFields::HasContextPromiseHook::kMask) |
+    PromiseHookFields::HasIsolatePromiseHook::encode(promise_hook_ || RecordReplayShouldCallOnPromiseHook()) |
+    PromiseHookFields::HasAsyncEventDelegate::encode(async_event_delegate_) |
+    PromiseHookFields::IsDebugActive::encode(debug()->is_active());
 
   if (promise_hook_flags_ != 0) {
     UpdatePromiseHookProtector();
@@ -7754,6 +7811,9 @@ void Isolate::OnTerminationDuringRunMicrotasks() {
 
 void Isolate::SetPromiseRejectCallback(PromiseRejectCallback callback) {
   promise_reject_callback_ = callback;
+
+  recordreplay::Assert("[TT-1029-1030] Isolate::SetPromiseRejectCallback %d",
+                       !!promise_reject_callback_);
 }
 
 void Isolate::ReportPromiseReject(DirectHandle<JSPromise> promise,
@@ -7770,6 +7830,13 @@ void Isolate::SetUseCounterCallback(v8::Isolate::UseCounterCallback callback) {
 }
 
 void Isolate::CountUsage(v8::Isolate::UseCounterFeature feature) {
+  // Don't count usage when recording/replaying, as this can involve posting
+  // tasks to other threads in places that run non-deterministically
+  // (e.g. compilation).
+  if (recordreplay::IsRecordingOrReplaying("no-count-usage")) {
+    return;
+  }
+
   CountUsage(base::VectorOf({feature}));
 }
 
@@ -7795,7 +7862,20 @@ void Isolate::CountUsage(
   }
 }
 
-int Isolate::GetNextScriptId() { return heap()->NextScriptId(); }
+// Start disallowed script IDs at a value that won't conflict with regular IDs,
+// which start at one and increment from there.
+static int gNextDisallowedScriptId = 1 << 30;
+
+int Isolate::GetNextScriptId() {
+  // Use a separate pool of IDs when events are disallowed, as these scripts
+  // won't be created at consistently when recording vs. replaying.
+  if (recordreplay::AreEventsDisallowed("Isolate::GetNextScriptId")) {
+    CHECK(IsMainThread());
+    return gNextDisallowedScriptId++;
+  }
+
+  return heap()->NextScriptId();
+}
 
 // static
 std::string Isolate::GetTurboCfgFileName(Isolate* isolate) {

--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -1664,6 +1664,8 @@ void Isolate::RecordReplayInvokeApiInterruptCallbacksAtProgress() {
   }
 }
 
+namespace {
+
 Handle<FixedArray> CaptureSimpleStackTrace(Isolate* isolate, int limit,
                                            FrameSkipMode mode,
                                            Handle<Object> caller) {

--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -1639,6 +1639,8 @@ void VisitStack_ForCallSiteBuilder(Isolate* isolate, CallSiteBuilder* visitor) {
   }
 }
 
+}  // namespace
+
 void Isolate::RecordReplayInvokeApiInterruptCallbacksAtProgress() {
   CHECK(recordreplay::IsRecordingOrReplaying("interrupts"));
   CHECK(IsMainThread());

--- a/src/execution/isolate.h
+++ b/src/execution/isolate.h
@@ -100,6 +100,10 @@ class ConsoleDelegate;
 class AsyncEventDelegate;
 }  // namespace debug
 
+namespace replayio {
+class ReplayIsolateData;
+}  // namespace replayio
+
 namespace internal {
 
 void DefaultWasmAsyncResolvePromiseCallback(
@@ -1125,6 +1129,8 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
   void RequestInterrupt(InterruptCallback callback, void* data);
   void InvokeApiInterruptCallbacks();
 
+  void RecordReplayInvokeApiInterruptCallbacksAtProgress();
+
   void RequestInvalidateNoProfilingProtector();
 
   // Administration
@@ -1432,6 +1438,9 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
   TracedHandles* traced_handles() { return &traced_handles_; }
 
   EternalHandles* eternal_handles() const { return eternal_handles_; }
+
+  replayio::ReplayIsolateData* replay_data() const { return replay_data_.get(); }
+  replayio::ReplayIsolateData* EnsureReplayData();
 
   ThreadManager* thread_manager() const { return thread_manager_; }
 
@@ -2790,6 +2799,12 @@ class V8_EXPORT_PRIVATE Isolate final : private HiddenFactory {
 
   using InterruptEntry = std::pair<InterruptCallback, void*>;
   std::queue<InterruptEntry> api_interrupts_queue_;
+
+  // Lock to ensure consistent ordering of other threads adding API interrupts
+  // vs. the isolate's thread removing and running them.
+  int record_replay_api_interrupts_ordered_lock_id_ = 0;
+
+  std::unique_ptr<replayio::ReplayIsolateData> replay_data_;
 
 #define GLOBAL_BACKING_STORE(type, name, initialvalue) type name##_;
   ISOLATE_INIT_LIST(GLOBAL_BACKING_STORE)

--- a/src/execution/messages.cc
+++ b/src/execution/messages.cc
@@ -75,6 +75,9 @@ void MessageHandler::DefaultMessageReport(Isolate* isolate,
   }
 }
 
+extern Handle<Object>* gCurrentException;
+extern "C" uint64_t V8RecordReplayNewBookmark();
+
 Handle<JSMessageObject> MessageHandler::MakeMessageObject(
     Isolate* isolate, MessageTemplate message, const MessageLocation* location,
     DirectHandle<Object> argument, DirectHandle<StackTraceInfo> stack_trace) {
@@ -399,7 +402,15 @@ MaybeDirectHandle<JSAny> ErrorUtils::FormatStackTrace(
     }
   }
 
-  return builder.Finish();
+  MaybeHandle<String> rv = builder.Finish();
+  if (recordreplay::IsRecordingOrReplaying("ErrorUtils::FormatStackTrace") &&
+      !recordreplay::AreEventsDisallowed()) {
+    // [PRO-1150] Replay Error.stack
+    std::string str = rv.ToHandleChecked()->ToCString().get();
+    recordreplay::RecordReplayString("ErrorUtils::FormatStackTrace", str);
+    rv = isolate->factory()->NewStringFromUtf8(base::CStrVector(str.c_str()));
+  }
+  return rv;
 }
 
 DirectHandle<String> MessageFormatter::Format(
@@ -1214,7 +1225,10 @@ void ErrorUtils::SetFormattedStack(Isolate* isolate,
 
   if (IsErrorStackData(*lookup.error_stack)) {
     auto error_stack_data = Cast<ErrorStackData>(lookup.error_stack);
-    error_stack_data->set_formatted_stack(*formatted_stack);
+    if (!recordreplay::AreEventsDisallowed()) {
+      // [PRO-2368] Don't cache the formatted stack during replay-only invocations.
+      error_stack_data->set_formatted_stack(*formatted_stack);
+    }
   } else {
     Object::SetProperty(isolate, error_object,
                         isolate->factory()->error_stack_symbol(),

--- a/src/execution/messages.cc
+++ b/src/execution/messages.cc
@@ -402,7 +402,7 @@ MaybeDirectHandle<JSAny> ErrorUtils::FormatStackTrace(
     }
   }
 
-  MaybeHandle<String> rv = builder.Finish();
+  MaybeDirectHandle<String> rv = builder.Finish();
   if (recordreplay::IsRecordingOrReplaying("ErrorUtils::FormatStackTrace") &&
       !recordreplay::AreEventsDisallowed()) {
     // [PRO-1150] Replay Error.stack
@@ -410,7 +410,7 @@ MaybeDirectHandle<JSAny> ErrorUtils::FormatStackTrace(
     recordreplay::RecordReplayString("ErrorUtils::FormatStackTrace", str);
     rv = isolate->factory()->NewStringFromUtf8(base::CStrVector(str.c_str()));
   }
-  return rv;
+  return Cast<JSAny>(rv);
 }
 
 DirectHandle<String> MessageFormatter::Format(

--- a/src/execution/microtask-queue.h
+++ b/src/execution/microtask-queue.h
@@ -14,6 +14,8 @@
 #include "include/v8-microtask-queue.h"
 #include "src/base/macros.h"
 
+#include "include/v8.h"  // For replay.
+
 namespace v8 {
 namespace internal {
 
@@ -47,6 +49,11 @@ class V8_EXPORT_PRIVATE MicrotaskQueue final : public v8::MicrotaskQueue {
                         v8::MicrotaskCallbackWithData callback,
                         v8::Local<v8::Data> data) override;
   void PerformCheckpoint(v8::Isolate* isolate) override {
+    v8::recordreplay::AssertMaybeEventsDisallowed(
+      "MicrotaskQueue::PerformCheckpoint %d",
+      ShouldPerfomCheckpoint()
+    );
+
     if (!ShouldPerfomCheckpoint()) return;
     PerformCheckpointInternal(isolate);
   }

--- a/src/execution/stack-guard.cc
+++ b/src/execution/stack-guard.cc
@@ -302,6 +302,11 @@ Tagged<Object> StackGuard::HandleInterrupts(InterruptLevel level) {
   isolate_->heap()->VerifyNewSpaceTop();
 #endif
 
+  // Interrupts must happen at deterministic points, ignore them when code is running
+  // while events are disallowed, such as during command callbacks.
+  if (recordreplay::AreEventsDisallowed())
+    return ReadOnlyRoots(isolate_).undefined_value();
+
   if (v8_flags.verify_predictable) {
     // Advance synthetic time by making a time request.
     isolate_->heap()->MonotonicallyIncreasingTimeInMs();

--- a/src/handles/handles.cc
+++ b/src/handles/handles.cc
@@ -75,6 +75,9 @@ Address* HandleBase::indirect_handle(Address object, LocalHeap* local_heap) {
 #ifdef DEBUG
 
 bool HandleBase::IsDereferenceAllowed() const {
+  // FIXME disabling to support debugging from lldb. Surely there is a better way to do this.
+  return true;
+
   DCHECK_NOT_NULL(location_);
   Tagged<Object> object(*location_);
   if (IsSmi(object)) return true;
@@ -181,6 +184,10 @@ Address* HandleScope::Extend(Isolate* isolate) {
   DCHECK(result == current->limit);
   // Make sure there's at least one scope on the stack and that the
   // top of the scope stack isn't a barrier.
+  if (current->level == current->sealed_level) {
+    recordreplay::Diagnostic("Bad HandleScope level %d isolate %p",
+                             current->level, isolate);
+  }
   if (!Utils::ApiCheck(current->level != current->sealed_level,
                        "v8::HandleScope::CreateHandle()",
                        "Cannot create a handle without a HandleScope")) {

--- a/src/heap/allocation-observer.cc
+++ b/src/heap/allocation-observer.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "src/heap/allocation-observer.h"
+#include "include/replayio.h"
 
 #include <algorithm>
 

--- a/src/heap/allocation-observer.cc
+++ b/src/heap/allocation-observer.cc
@@ -55,6 +55,8 @@ void AllocationCounter::RemoveAllocationObserver(AllocationObserver* observer) {
     return;
   }
 
+  replayio::AutoDisallowEvents disallow("AllocationCounter::InvokeAllocationObservers");
+
   observers_.erase(it);
 
   if (observers_.empty()) {

--- a/src/heap/concurrent-marking.cc
+++ b/src/heap/concurrent-marking.cc
@@ -650,6 +650,8 @@ void ConcurrentMarking::TryScheduleJob(GarbageCollector garbage_collector,
   DCHECK(!heap_->IsTearingDown());
   DCHECK(IsStopped());
 
+  replayio::AutoDisallowEvents disallow("ConcurrentMarking::ScheduleJob");
+
   DCHECK_NE(garbage_collector, GarbageCollector::SCAVENGER);
   if (garbage_collector == GarbageCollector::MARK_COMPACTOR &&
       !heap_->mark_compact_collector()->UseBackgroundThreadsInCycle()) {

--- a/src/heap/concurrent-marking.cc
+++ b/src/heap/concurrent-marking.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "src/heap/concurrent-marking.h"
+#include "include/replayio.h"
 
 #include <algorithm>
 #include <atomic>

--- a/src/heap/cppgc/concurrent-marker.cc
+++ b/src/heap/cppgc/concurrent-marker.cc
@@ -4,6 +4,7 @@
 
 #include "src/heap/cppgc/concurrent-marker.h"
 
+#include "v8.h"
 #include "include/cppgc/platform.h"
 #include "src/heap/cppgc/heap-base.h"
 #include "src/heap/cppgc/heap-object-header.h"
@@ -100,7 +101,7 @@ void ConcurrentMarkingTask::Run(JobDelegate* job_delegate) {
 size_t ConcurrentMarkingTask::GetMaxConcurrency(
     size_t current_worker_count) const {
   return WorkSizeForConcurrentMarking(concurrent_marker_.marking_worklists()) +
-         current_worker_count;
+              current_worker_count;
 }
 
 void ConcurrentMarkingTask::ProcessWorklists(

--- a/src/heap/cppgc/stats-collector.cc
+++ b/src/heap/cppgc/stats-collector.cc
@@ -13,6 +13,8 @@
 #include "src/base/platform/time.h"
 #include "src/heap/cppgc/metric-recorder.h"
 
+#include "replayio.h"
+
 namespace cppgc {
 namespace internal {
 
@@ -70,6 +72,8 @@ void StatsCollector::NotifySafePointForTesting() {
 }
 
 void StatsCollector::AllocatedObjectSizeSafepointImpl() {
+  v8::replayio::AutoDisallowEvents disallow("StatsCollector::AllocatedObjectSizeSafepointImpl");
+
   allocated_bytes_since_end_of_marking_ +=
       static_cast<int64_t>(allocated_bytes_since_safepoint_) -
       static_cast<int64_t>(explicitly_freed_bytes_since_safepoint_);

--- a/src/heap/cppgc/sweeper.cc
+++ b/src/heap/cppgc/sweeper.cc
@@ -30,6 +30,8 @@
 #include "src/heap/cppgc/stats-collector.h"
 #include "src/heap/cppgc/task-handle.h"
 
+#include "replayio.h"
+
 namespace cppgc::internal {
 
 namespace {
@@ -1080,6 +1082,8 @@ class Sweeper::SweeperImpl final {
 
   bool SweepForLargeAllocation(BaseSpace* space, size_t size,
                                v8::base::TimeDelta max_duration) {
+    v8::replayio::AutoDisallowEvents disallow("Sweeper::SweepForAllocationIfRunning");
+
     DCHECK(space->is_large());
 #ifdef DEBUG
     // SpaceState for large objects is emtpy as those objects are put directly
@@ -1212,6 +1216,8 @@ class Sweeper::SweeperImpl final {
   }
 
   bool FinishIfRunning() {
+    v8::replayio::AutoDisallowEvents disallow("SweeperImpl::FinishIfRunning");
+
     if (!is_in_progress_) {
       return false;
     }

--- a/src/heap/factory.cc
+++ b/src/heap/factory.cc
@@ -4415,7 +4415,7 @@ Handle<JSMessageObject> Factory::NewJSMessageObject(
     MessageTemplate message, DirectHandle<Object> argument, int start_position,
     int end_position, DirectHandle<SharedFunctionInfo> shared_info,
     int bytecode_offset, DirectHandle<Script> script,
-    DirectHandle<StackTraceInfo> stack_trace) {
+    DirectHandle<StackTraceInfo> stack_trace, int record_replay_bookmark) {
   DirectHandle<Map> map = message_object_map();
   Tagged<JSMessageObject> message_obj =
       Cast<JSMessageObject>(New(map, AllocationType::kYoung));
@@ -4452,6 +4452,7 @@ Handle<JSMessageObject> Factory::NewJSMessageObject(
     message_obj->set_stack_trace(*stack_trace, SKIP_WRITE_BARRIER);
   }
   message_obj->set_error_level(v8::Isolate::kMessageError);
+  message_obj->set_record_replay_bookmark(record_replay_bookmark);
   return handle(message_obj, isolate());
 }
 

--- a/src/heap/factory.h
+++ b/src/heap/factory.h
@@ -1154,7 +1154,8 @@ class V8_EXPORT_PRIVATE Factory : public FactoryBase<Factory> {
       DirectHandle<SharedFunctionInfo> shared_info, int bytecode_offset,
       DirectHandle<Script> script,
       DirectHandle<StackTraceInfo> stack_trace =
-          DirectHandle<StackTraceInfo>::null());
+          DirectHandle<StackTraceInfo>::null(),
+      int record_replay_bookmark = 0);
 
   Handle<DebugInfo> NewDebugInfo(DirectHandle<SharedFunctionInfo> shared);
 

--- a/src/heap/gc-tracer.cc
+++ b/src/heap/gc-tracer.cc
@@ -878,6 +878,11 @@ void GCTracer::Output(const char* format, ...) const {
 }
 
 void GCTracer::Print() const {
+  // Avoid getting the current time below at non-deterministic points.
+  if (recordreplay::IsRecordingOrReplaying("gc-changes", "GCTracer::Print")) {
+    return;
+  }
+
   const base::TimeDelta duration = current_.end_time - current_.start_time;
   const size_t kIncrementalStatsSize = 128;
   char incremental_buffer[kIncrementalStatsSize] = {0};

--- a/src/heap/heap-inl.h
+++ b/src/heap/heap-inl.h
@@ -436,3 +436,6 @@ IgnoreLocalGCRequests::~IgnoreLocalGCRequests() {
 }  // namespace v8
 
 #endif  // V8_HEAP_HEAP_INL_H_
+
+  recordreplay::OrderedUnlock(script_ordered_lock_id_);
+  recordreplay::Assert("Heap::NextScriptId %d", new_id.value());

--- a/src/heap/heap-inl.h
+++ b/src/heap/heap-inl.h
@@ -436,6 +436,3 @@ IgnoreLocalGCRequests::~IgnoreLocalGCRequests() {
 }  // namespace v8
 
 #endif  // V8_HEAP_HEAP_INL_H_
-
-  recordreplay::OrderedUnlock(script_ordered_lock_id_);
-  recordreplay::Assert("Heap::NextScriptId %d", new_id.value());

--- a/src/heap/heap.cc
+++ b/src/heap/heap.cc
@@ -7760,6 +7760,8 @@ int Heap::NextScriptId() {
         Cast<Smi>(last_script_id_slot.Relaxed_CompareAndSwap(last_id, new_id));
   } while (last_id != last_id_before_cas);
 
+  recordreplay::OrderedUnlock(script_ordered_lock_id_);
+  recordreplay::Assert("Heap::NextScriptId %d", new_id.value());
   return new_id.value();
 }
 

--- a/src/heap/heap.cc
+++ b/src/heap/heap.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "src/heap/heap.h"
+#include "include/replayio.h"
 
 #include <algorithm>
 #include <atomic>
@@ -3881,6 +3882,11 @@ void Heap::NotifyObjectLayoutChange(
     const Address clear_range_end = object.address() + new_size;
 
     if (incremental_marking()->IsMarking()) {
+      // Replay: relocated from the removed
+      // IncrementalMarking::MarkBlackAndVisitObjectDueToLayoutChange hook. The
+      // marking-time layout-change bookkeeping must not emit record/replay
+      // events. (TODO: confirm scope during deterministic-replay validation.)
+      replayio::AutoDisallowEvents disallow("Heap::NotifyObjectLayoutChange");
       ObjectLock::Lock(isolate(), object);
       DCHECK_EQ(pending_layout_change_object_address, kNullAddress);
       pending_layout_change_object_address = object.address();

--- a/src/heap/heap.cc
+++ b/src/heap/heap.cc
@@ -926,6 +926,7 @@ void Heap::IncrementDeferredCounts(
 void Heap::GarbageCollectionPrologue(
     GarbageCollectionReason gc_reason,
     const v8::GCCallbackFlags gc_callback_flags) {
+  replayio::AutoDisallowEvents disallow("Heap::CollectGarbage");
   TRACE_GC(tracer(), GCTracer::Scope::HEAP_PROLOGUE);
 
   is_current_gc_forced_ = gc_callback_flags & v8::kGCCallbackFlagForced ||
@@ -1288,6 +1289,7 @@ void FreeCachesOnMemoryPressure(Isolate* isolate,
 }  // anonymous namespace
 
 void Heap::CollectAllAvailableGarbage(GarbageCollectionReason gc_reason) {
+  replayio::AutoDisallowEvents disallow("Heap::CollectAllAvailableGarbage");
   // Min and max number of attempts for GC. The method will continue with more
   // GCs until the root set is stable.
   static constexpr int kMaxNumberOfAttempts = 7;
@@ -1827,6 +1829,8 @@ void Heap::StartIncrementalMarking(GCFlags gc_flags,
     // guarantee.
     return;
   }
+
+  replayio::AutoDisallowEvents disallow("Heap::StartIncrementalMarking");
 
   TRACE_EVENT(
       "v8",
@@ -4026,6 +4030,8 @@ void Heap::CheckMemoryPressure() {
 }
 
 void Heap::CollectGarbageOnMemoryPressure() {
+  replayio::AutoDisallowEvents disallow("Heap::CollectGarbageOnMemoryPressure");
+
   const int kGarbageThresholdInBytes = 8 * MB;
   const double kGarbageThresholdAsFractionOfTotalMemory = 0.1;
   // This constant is the maximum response time in RAIL performance model.
@@ -4062,6 +4068,8 @@ void Heap::CollectGarbageOnMemoryPressure() {
 
 void Heap::MemoryPressureNotification(MemoryPressureLevel level,
                                       bool is_isolate_locked) {
+  replayio::AutoDisallowEvents disallow("Heap::MemoryPressureNotification");
+
   TRACE_EVENT("devtools.timeline,v8", "V8.MemoryPressureNotification", "level",
               static_cast<int>(level));
   MemoryPressureLevel previous =
@@ -6262,6 +6270,8 @@ const ::heap::base::Stack& Heap::stack() const {
 }
 
 void Heap::StartTearDown() {
+  replayio::AutoDisallowEvents disallow("Heap::StartTearDown");
+
   if (cpp_heap_) {
     // This may invoke a GC in case marking is running to get us into a
     // well-defined state for tear down.

--- a/src/heap/heap.h
+++ b/src/heap/heap.h
@@ -2456,6 +2456,9 @@ class Heap final {
   const uint8_t* gc_tracing_category_enabled_ = nullptr;
   size_t notify_context_disposed_counter_ = 1;
 
+  // For ordering allocations of new script IDs.
+  int script_ordered_lock_id_ = 0;
+
   // Classes in "heap" can be friends.
   friend class ActivateMemoryReducerTask;
   friend class AlwaysAllocateScope;

--- a/src/heap/incremental-marking-job.cc
+++ b/src/heap/incremental-marking-job.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "src/heap/incremental-marking-job.h"
+#include "include/replayio.h"
 
 #include <optional>
 

--- a/src/heap/incremental-marking-job.cc
+++ b/src/heap/incremental-marking-job.cc
@@ -35,6 +35,8 @@ class IncrementalMarkingJob::Task final : public CancelableTask {
   // CancelableTask overrides.
   void RunInternal() override;
 
+  bool IsRecordReplayNonDeterministic() const override { return true; }
+
   Isolate* isolate() const { return isolate_; }
 
  private:
@@ -51,6 +53,8 @@ IncrementalMarkingJob::IncrementalMarkingJob(Heap* heap)
 }
 
 void IncrementalMarkingJob::ScheduleTask() {
+  replayio::AutoDisallowEvents disallow("IncrementalMarkingJob::ScheduleTask");
+
   base::MutexGuard guard(&mutex_);
 
   if (pending_task_ || heap_->IsTearingDown()) {
@@ -78,6 +82,10 @@ void IncrementalMarkingJob::ScheduleTask() {
 }
 
 void IncrementalMarkingJob::Task::RunInternal() {
+  // RUN-2140: This shouldn't be necessary, this task should run at non-deterministic
+  // points in general and be unordered.
+  replayio::AutoDisallowEvents disallow("IncrementalMarkingJob::Task::RunInternal");
+
   VMState<GC> state(isolate());
   TRACE_EVENT_CALL_STATS_SCOPED(isolate(), "v8",
                                 "V8.IncrementalMarkingJob.Task");

--- a/src/heap/large-spaces.cc
+++ b/src/heap/large-spaces.cc
@@ -121,6 +121,11 @@ AllocationResult OldLargeObjectSpace::AllocateRaw(LocalHeap* local_heap,
   if (!heap()->ShouldExpandOldGenerationOnSlowAllocation(
           local_heap, AllocationOrigin::kRuntime) ||
       !heap()->CanExpandOldGeneration(object_size)) {
+    recordreplay::Diagnostic(
+        "[RUN-851] OldLargeObjectSpace::AllocateRaw Failed %d %d",
+        heap()->ShouldExpandOldGenerationOnSlowAllocation(
+            local_heap, AllocationOrigin::kRuntime),
+        heap()->CanExpandOldGeneration(object_size));
     return AllocationResult::Failure();
   }
 

--- a/src/heap/local-heap.cc
+++ b/src/heap/local-heap.cc
@@ -28,6 +28,8 @@
 namespace v8 {
 namespace internal {
 
+#if V8_OS_WIN
+
 thread_local LocalHeap* g_current_local_heap_ V8_CONSTINIT = nullptr;
 
 V8_TLS_DEFINE_GETTER(LocalHeap::TryGetCurrent, LocalHeap*,
@@ -96,6 +98,8 @@ LocalHeap::LocalHeap(Heap* heap, ThreadKind kind,
 }
 
 LocalHeap::~LocalHeap() {
+  recordreplay::Diagnostic("LocalHeap Destroy %p", this);
+
   // Park thread since removing the local heap could block.
   EnsureParkedBeforeDestruction();
 
@@ -283,6 +287,8 @@ void LocalHeap::ParkSlowPath() {
 }
 
 void LocalHeap::UnparkSlowPath() {
+  replayio::AutoDisallowEvents disallow("LocalHeap::UnparkSlowPath");
+
   while (true) {
     ThreadState current_state = ThreadState::Parked();
     if (state_.CompareExchangeStrong(current_state, ThreadState::Running())) {
@@ -345,6 +351,8 @@ void LocalHeap::EnsureParkedBeforeDestruction() {
 }
 
 void LocalHeap::SafepointSlowPath() {
+  replayio::AutoDisallowEvents disallow("LocalHeap::SafepointSlowPath");
+
   ThreadState current_state = state_.load_relaxed();
   DCHECK(current_state.IsRunning());
 

--- a/src/heap/local-heap.cc
+++ b/src/heap/local-heap.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "src/heap/local-heap.h"
+#include "include/replayio.h"
 
 #include <atomic>
 #include <memory>

--- a/src/heap/local-heap.cc
+++ b/src/heap/local-heap.cc
@@ -29,8 +29,6 @@
 namespace v8 {
 namespace internal {
 
-#if V8_OS_WIN
-
 thread_local LocalHeap* g_current_local_heap_ V8_CONSTINIT = nullptr;
 
 V8_TLS_DEFINE_GETTER(LocalHeap::TryGetCurrent, LocalHeap*,

--- a/src/heap/main-allocator.cc
+++ b/src/heap/main-allocator.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "src/heap/main-allocator.h"
+#include "include/replayio.h"
 
 #include <optional>
 
@@ -652,6 +653,8 @@ bool PagedSpaceAllocatorPolicy::RefillLab(int size_in_bytes,
   // Allocation in this space has failed.
   DCHECK_GE(size_in_bytes, 0);
 
+  replayio::AutoDisallowEvents disallow("PagedSpaceAllocatorPolicy::RefillLab");
+
   if (TryExtendLAB(size_in_bytes)) return true;
 
   if (TryAllocationFromFreeList(size_in_bytes, origin)) return true;
@@ -733,6 +736,14 @@ bool PagedSpaceAllocatorPolicy::RefillLab(int size_in_bytes,
     if (TryExpandAndAllocate(static_cast<size_t>(size_in_bytes), origin)) {
       return true;
     }
+    recordreplay::Diagnostic(
+        "[RUN-851] PagedSpaceAllocatorPolicy::RefillLab TryExpandAndAllocateFailed");
+  } else {
+    recordreplay::Diagnostic(
+        "[RUN-851] PagedSpaceAllocatorPolicy::RefillLab CantExpand %d %d",
+        space_heap()->ShouldExpandOldGenerationOnSlowAllocation(
+            allocator_->local_heap(), origin),
+        space_heap()->CanExpandOldGeneration(space_->AreaSize()));
   }
 
   // Try sweeping all pages.

--- a/src/heap/mark-compact.cc
+++ b/src/heap/mark-compact.cc
@@ -4949,7 +4949,7 @@ class PageEvacuationJob : public v8::JobTask {
     SetCurrentIsolateScope isolate_scope(collector_->heap()->isolate());
 
     Evacuator* evacuator = (*evacuators_)[delegate->GetTaskId()].get();
-    if (delegate->IsJoiningThread()) {
+    if (!delegate || delegate->IsJoiningThread()) {
       TRACE_GC_WITH_FLOW(tracer_, GCTracer::Scope::MC_EVACUATE_COPY_PARALLEL,
                          perfetto::TerminatingFlow::ProcessScoped(trace_id_));
       ProcessItems(delegate, evacuator);

--- a/src/heap/memory-reducer.cc
+++ b/src/heap/memory-reducer.cc
@@ -228,6 +228,11 @@ MemoryReducer::State MemoryReducer::Step(const State& state,
 }
 
 void MemoryReducer::ScheduleTimer(double delay_ms) {
+  // Posting tasks non-deterministically with a delay is not currently supported
+  // when recording/replaying.
+  if (recordreplay::IsRecordingOrReplaying("gc-changes", "MemoryReducer::ScheduleTimer")) {
+    return;
+  }
   DCHECK_LT(0, delay_ms);
   if (heap()->IsTearingDown()) return;
   // Leave some room for precision error in task scheduler.

--- a/src/heap/memory-reducer.h
+++ b/src/heap/memory-reducer.h
@@ -188,6 +188,8 @@ class V8_EXPORT_PRIVATE MemoryReducer {
     TimerTask(const TimerTask&) = delete;
     TimerTask& operator=(const TimerTask&) = delete;
 
+    bool IsRecordReplayNonDeterministic() const override { return true; }
+
    private:
     // v8::internal::CancelableTask overrides.
     void RunInternal() override;

--- a/src/heap/minor-gc-job.cc
+++ b/src/heap/minor-gc-job.cc
@@ -123,6 +123,8 @@ class MinorGCJob::Task : public CancelableTask {
   // CancelableTask overrides.
   void RunInternal() override;
 
+  bool IsRecordReplayNonDeterministic() const override { return true; }
+
   Isolate* isolate() const { return isolate_; }
 
  private:

--- a/src/heap/paged-spaces.cc
+++ b/src/heap/paged-spaces.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "src/heap/paged-spaces.h"
+#include "include/replayio.h"
 
 #include <atomic>
 #include <iterator>

--- a/src/heap/paged-spaces.cc
+++ b/src/heap/paged-spaces.cc
@@ -609,5 +609,3 @@ void StickySpace::AdjustDifferenceInAllocatedBytes(size_t diff) {
 
 }  // namespace internal
 }  // namespace v8
-
-  replayio::AutoDisallowEvents disallow("PagedSpaceBase::RawRefillLabMain");

--- a/src/heap/paged-spaces.cc
+++ b/src/heap/paged-spaces.cc
@@ -608,3 +608,5 @@ void StickySpace::AdjustDifferenceInAllocatedBytes(size_t diff) {
 
 }  // namespace internal
 }  // namespace v8
+
+  replayio::AutoDisallowEvents disallow("PagedSpaceBase::RawRefillLabMain");

--- a/src/inspector/injected-script.cc
+++ b/src/inspector/injected-script.cc
@@ -55,6 +55,15 @@
 #include "src/inspector/v8-value-utils.h"
 #include "src/inspector/value-mirror.h"
 
+#include "v8.h"
+
+namespace v8 {
+  namespace internal {
+    extern int RecordReplayObjectId(v8::Isolate* isolate, Local<v8::Context> cx,
+                                    v8::Local<v8::Value> object, bool allow_create);
+  }
+}
+
 namespace v8_inspector {
 
 namespace {
@@ -433,10 +442,14 @@ Response InjectedScript::getProperties(
 
   *properties = std::make_unique<Array<PropertyDescriptor>>();
   std::vector<PropertyMirror> mirrors;
-  PropertyAccumulator accumulator(&mirrors);
+  // [RUN-3149] pass params to the accumulator, which will stop us
+  // by returning false from .Add() after it's added enough properties.
+  PropertyAccumulator accumulator(&mirrors, params);
   if (!ValueMirror::getProperties(context, object, ownProperties,
                                   accessorPropertiesOnly,
-                                  nonIndexedPropertiesOnly, &accumulator)) {
+                                  nonIndexedPropertiesOnly,
+                                  &accumulator,
+                                  params)) {
     return createExceptionDetails(tryCatch, groupName, exceptionDetails);
   }
   for (const PropertyMirror& mirror : mirrors) {
@@ -505,6 +518,7 @@ Response InjectedScript::getProperties(
 Response InjectedScript::getInternalAndPrivateProperties(
     v8::Local<v8::Value> value, const String16& groupName,
     bool accessorPropertiesOnly,
+    const v8::KeyIterationParams* params,
     std::unique_ptr<protocol::Array<InternalPropertyDescriptor>>*
         internalProperties,
     std::unique_ptr<protocol::Array<PrivatePropertyDescriptor>>*
@@ -522,7 +536,7 @@ Response InjectedScript::getInternalAndPrivateProperties(
   if (!accessorPropertiesOnly) {
     std::vector<InternalPropertyMirror> internalPropertiesWrappers;
     ValueMirror::getInternalProperties(m_context->context(), value_obj,
-                                       &internalPropertiesWrappers);
+                                       &internalPropertiesWrappers, params);
     for (const auto& internalProperty : internalPropertiesWrappers) {
       std::unique_ptr<RemoteObject> remoteObject;
       Response response = internalProperty.value->buildRemoteObject(
@@ -839,7 +853,9 @@ Response InjectedScript::resolveCallArgument(
     std::unique_ptr<RemoteObjectId> remoteObjectId;
     Response response =
         RemoteObjectId::parse(callArgument->getObjectId(""), &remoteObjectId);
-    if (!response.IsSuccess()) return response;
+    if (!response.IsSuccess()) {
+      return response;
+    }
     if (remoteObjectId->contextId() != m_context->contextId() ||
         remoteObjectId->isolateId() != m_context->inspector()->isolateId()) {
       return Response::ServerError(
@@ -1044,7 +1060,9 @@ void InjectedScript::Scope::installCommandLineAPI() {
 void InjectedScript::Scope::ignoreExceptionsAndMuteConsole() {
   DCHECK(!m_ignoreExceptionsAndMuteConsole);
   m_ignoreExceptionsAndMuteConsole = true;
-  m_inspector->client()->muteMetrics(m_contextGroupId);
+  if (m_inspector->client()) {
+    m_inspector->client()->muteMetrics(m_contextGroupId);
+  }
   m_inspector->muteExceptions(m_contextGroupId);
   m_previousPauseOnExceptionsState =
       setPauseOnExceptionsState(v8::debug::NoBreakOnException);
@@ -1090,7 +1108,9 @@ void InjectedScript::Scope::cleanup() {
 InjectedScript::Scope::~Scope() {
   if (m_ignoreExceptionsAndMuteConsole) {
     setPauseOnExceptionsState(m_previousPauseOnExceptionsState);
-    m_inspector->client()->unmuteMetrics(m_contextGroupId);
+    if (m_inspector->client()) {
+      m_inspector->client()->unmuteMetrics(m_contextGroupId);
+    }
     m_inspector->unmuteExceptions(m_contextGroupId);
   }
   if (m_userGesture) m_inspector->client()->endUserGesture();
@@ -1179,6 +1199,11 @@ Response InjectedScript::bindRemoteObjectIfNeeded(
         inspectedContext ? inspectedContext->getInjectedScript(sessionId)
                          : nullptr;
     if (!injectedScript) {
+      if (v8::recordreplay::IsInReplayCode("InjectedScript::bindRemoteObjectIfNeeded")) {
+        v8::recordreplay::Warning(
+          "[RUN-2486-2498] Cannot find context with specified id A %d %d %d",
+          sessionId, InspectedContext::contextId(context), !!inspectedContext);
+      }
       return Response::ServerError("Cannot find context with specified id");
     }
     remoteObject->setObjectId(injectedScript->bindObject(value, groupName));

--- a/src/inspector/injected-script.cc
+++ b/src/inspector/injected-script.cc
@@ -416,15 +416,26 @@ InjectedScript::~InjectedScript() { discardEvaluateCallbacks(); }
 namespace {
 class PropertyAccumulator : public ValueMirror::PropertyAccumulator {
  public:
-  explicit PropertyAccumulator(std::vector<PropertyMirror>* mirrors)
-      : m_mirrors(mirrors) {}
+  PropertyAccumulator(std::vector<PropertyMirror>* mirrors,
+                      const v8::KeyIterationParams* params)
+      : m_mirrors(mirrors), m_params(params) {}
   bool Add(PropertyMirror mirror) override {
     m_mirrors->push_back(std::move(mirror));
+    // [RUN-3149] When pagination params are given, stop collecting once we have
+    // gathered a full page worth of properties.
+    if (m_params && *m_params) {
+      v8::KeyIterationIndex pageSize = m_params->PageSize(
+          static_cast<v8::KeyIterationIndex>(m_mirrors->size()) + 1);
+      if (static_cast<v8::KeyIterationIndex>(m_mirrors->size()) >= pageSize) {
+        return false;
+      }
+    }
     return true;
   }
 
  private:
   std::vector<PropertyMirror>* m_mirrors;
+  const v8::KeyIterationParams* m_params;
 };
 }  // anonymous namespace
 
@@ -432,6 +443,7 @@ Response InjectedScript::getProperties(
     v8::Local<v8::Object> object, const String16& groupName, bool ownProperties,
     bool accessorPropertiesOnly, bool nonIndexedPropertiesOnly,
     const WrapOptions& wrapOptions,
+    const v8::KeyIterationParams* params,
     std::unique_ptr<Array<PropertyDescriptor>>* properties,
     std::unique_ptr<protocol::Runtime::ExceptionDetails>* exceptionDetails) {
   v8::HandleScope handles(m_context->isolate());

--- a/src/inspector/injected-script.h
+++ b/src/inspector/injected-script.h
@@ -88,13 +88,14 @@ class InjectedScript final {
       v8::Local<v8::Object>, const String16& groupName, bool ownProperties,
       bool accessorPropertiesOnly, bool nonIndexedPropertiesOnly,
       const WrapOptions& wrapOptions,
+      const v8::KeyIterationParams* params,
       std::unique_ptr<protocol::Array<protocol::Runtime::PropertyDescriptor>>*
           result,
       std::unique_ptr<protocol::Runtime::ExceptionDetails>*);
 
   Response getInternalAndPrivateProperties(
       v8::Local<v8::Value>, const String16& groupName,
-      bool accessorPropertiesOnly,
+      bool accessorPropertiesOnly, const v8::KeyIterationParams* params,
       std::unique_ptr<
           protocol::Array<protocol::Runtime::InternalPropertyDescriptor>>*
           internalProperties,

--- a/src/inspector/v8-console-message.cc
+++ b/src/inspector/v8-console-message.cc
@@ -21,6 +21,8 @@
 #include "src/inspector/value-mirror.h"
 #include "src/tracing/trace-event.h"
 
+#include "include/v8.h"
+
 namespace v8_inspector {
 
 namespace {
@@ -573,6 +575,10 @@ void TraceV8ConsoleMessageEvent(V8MessageOrigin origin, ConsoleAPIType type) {
 
 }  // anonymous namespace
 
+extern "C" void V8RecordReplayOnConsoleMessage(size_t bookmark);
+extern "C" void SetContextGroupIdForSendCDPMessage(int contextGroupId);
+extern "C" void ClearContextGroupIdForSendCDPMessage();
+
 void V8ConsoleMessageStorage::addMessage(
     std::unique_ptr<V8ConsoleMessage> message) {
   int contextGroupId = m_contextGroupId;
@@ -580,6 +586,8 @@ void V8ConsoleMessageStorage::addMessage(
   if (message->type() == ConsoleAPIType::kClear) clear();
 
   TraceV8ConsoleMessageEvent(message->origin(), message->type());
+
+  v8::recordreplay::Assert("[RUN-1596] V8ConsoleMessageStorage::addMessage #1");
 
   inspector->forEachSession(
       contextGroupId, [&message](V8InspectorSessionImpl* session) {

--- a/src/inspector/v8-console.cc
+++ b/src/inspector/v8-console.cc
@@ -34,6 +34,8 @@
 #include "src/tracing/trace-id.h"
 #include "v8-object.h"
 
+#include "v8.h"
+
 namespace v8_inspector {
 
 namespace {

--- a/src/inspector/v8-debugger-agent-impl.cc
+++ b/src/inspector/v8-debugger-agent-impl.cc
@@ -346,6 +346,7 @@ String16 scopeType(v8::debug::ScopeIterator::ScopeType type) {
 
 Response buildScopes(v8::Isolate* isolate, v8::debug::ScopeIterator* iterator,
                      InjectedScript* injectedScript,
+                     const String16& objectGroup,
                      std::unique_ptr<Array<Scope>>* scopes) {
   *scopes = std::make_unique<Array<Scope>>();
   if (!injectedScript) return Response::Success();
@@ -356,7 +357,7 @@ Response buildScopes(v8::Isolate* isolate, v8::debug::ScopeIterator* iterator,
   for (; !iterator->Done(); iterator->Advance()) {
     std::unique_ptr<RemoteObject> object;
     Response result =
-        injectedScript->wrapObject(iterator->GetObject(), kBacktraceObjectGroup,
+        injectedScript->wrapObject(iterator->GetObject(), objectGroup,
                                    WrapOptions({WrapMode::kIdOnly}), &object);
     if (!result.IsSuccess()) return result;
 
@@ -1439,6 +1440,31 @@ class DisassemblyCollectorImpl final : public v8::debug::DisassemblyCollector {
     return std::move(chunks_[reading_chunk_index_++]);
   }
 
+// [replay] Always offer `arguments`, even if not usually available.
+//   -> https://linear.app/replay/issue/RUN-1061#comment-fc1c3ee4
+v8::MaybeLocal<v8::Value> V8DebuggerAgentImpl::getArgumentsOfCallFrame(
+    const String16& callFrameId) {
+  InjectedScript::CallFrameScope scope(m_session, callFrameId);
+  Response response = scope.initialize();
+  if (!response.IsSuccess()) {
+    v8::MaybeLocal<v8::Value> emptyValue;
+    return emptyValue;
+  }
+
+  int frameOrdinal = static_cast<int>(scope.frameOrdinal());
+  auto it = v8::debug::StackTraceIterator::Create(m_isolate, frameOrdinal);
+  if (it->Done()) {
+    // could not find frame
+    v8::MaybeLocal<v8::Value> emptyValue;
+    return emptyValue;
+  }
+
+  {
+    V8InspectorImpl::EvaluateScope evaluateScope(scope);
+    return it->GetFrameArguments();
+  }
+}
+
  private:
   // For a large Ritz module, the average is about 50 chars per line,
   // so (with 2-byte String16 chars) this should give approximately 20 MB
@@ -1621,6 +1647,56 @@ Response V8DebuggerAgentImpl::pause() {
   } else {
     pushBreakDetails(protocol::Debugger::Paused::ReasonEnum::Other, nullptr);
     m_debugger->setPauseOnNextCall(true, m_session->contextGroupId());
+  }
+
+  return Response::Success();
+}
+
+Response V8DebuggerAgentImpl::getCallFrames(
+    Maybe<int> maxFrames, Maybe<bool> noContents,
+    Maybe<String16> objectGroup,
+    std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>* out_callFrames) {
+  return currentCallFrames(std::move(maxFrames), std::move(noContents),
+                           std::move(objectGroup), out_callFrames);
+}
+
+Response V8DebuggerAgentImpl::getTopFrameLocation(Maybe<protocol::Debugger::Location>* out_location) {
+  if (!isPaused()) {
+    return Response::Success();
+  }
+
+  v8::HandleScope handles(m_isolate);
+  auto iterator = v8::debug::StackTraceIterator::Create(m_isolate);
+  if (!iterator->Done()) {
+    v8::debug::Location loc = iterator->GetSourceLocation();
+
+    v8::Local<v8::debug::Script> script = iterator->GetScript();
+    DCHECK(!script.IsEmpty());
+    *out_location =
+        protocol::Debugger::Location::create()
+            .setScriptId(String16::fromInteger(script->Id()))
+            .setLineNumber(loc.GetLineNumber())
+            .setColumnNumber(loc.GetColumnNumber())
+            .build();
+  }
+
+  return Response::Success();
+}
+
+extern "C" void V8RecordReplayGetCurrentException(v8::MaybeLocal<v8::Value>* exception);
+
+Response V8DebuggerAgentImpl::getPendingException(
+    Maybe<String16> objectGroup, Maybe<RemoteObject>* out_exception) {
+  v8::MaybeLocal<v8::Value> maybe_exception;
+  V8RecordReplayGetCurrentException(&maybe_exception);
+
+  if(!maybe_exception.IsEmpty()) {
+    v8::Local<v8::Context> context = m_isolate->GetCurrentContext();
+    v8::Local<v8::Value> exception = maybe_exception.ToLocalChecked();
+    std::unique_ptr<RemoteObject> obj =
+        m_session->wrapObject(context, exception, objectGroup.fromMaybe(""), false);
+
+    *out_exception = std::move(obj);
   }
 
   return Response::Success();
@@ -1938,6 +2014,7 @@ Response V8DebuggerAgentImpl::currentCallFrames(
   *result = std::make_unique<Array<CallFrame>>();
   auto iterator = v8::debug::StackTraceIterator::Create(m_isolate);
   int frameOrdinal = 0;
+  bool noContents = noContentsRaw.isJust() && noContentsRaw.fromJust();
   for (; !iterator->Done(); iterator->Advance(), frameOrdinal++) {
     int contextId = iterator->GetContextId();
     InjectedScript* injectedScript = nullptr;
@@ -1988,6 +2065,7 @@ Response V8DebuggerAgentImpl::currentCallFrames(
                          m_isolate, iterator->GetFunctionDebugName()))
                      .setLocation(std::move(location))
                      .setUrl(String16())
+                     .setContextId(contextId)
                      .setScopeChain(std::move(scopes))
                      .setThis(std::move(protocolReceiver))
                      .setCanBeRestarted(iterator->CanBeRestarted())
@@ -2038,7 +2116,8 @@ V8DebuggerAgentImpl::currentExternalStackTrace() {
 }
 
 bool V8DebuggerAgentImpl::isPaused() const {
-  return m_debugger->isPausedInContextGroup(m_session->contextGroupId());
+  return true;
+  //return m_debugger->isPausedInContextGroup(m_session->contextGroupId());
 }
 
 static String16 getScriptLanguage(const V8DebuggerScript& script) {
@@ -2305,7 +2384,7 @@ void V8DebuggerAgentImpl::didPauseOnInstrumentation(
   std::unique_ptr<protocol::DictionaryValue> breakAuxData;
 
   std::unique_ptr<Array<CallFrame>> protocolCallFrames;
-  Response response = currentCallFrames(&protocolCallFrames);
+  Response response = currentCallFrames(Maybe<int>(), Maybe<bool>(), Maybe<String16>(), &protocolCallFrames);
   if (!response.IsSuccess()) {
     protocolCallFrames = std::make_unique<Array<CallFrame>>();
   }
@@ -2445,7 +2524,7 @@ void V8DebuggerAgentImpl::didPause(
   }
 
   std::unique_ptr<Array<CallFrame>> protocolCallFrames;
-  Response response = currentCallFrames(&protocolCallFrames);
+  Response response = currentCallFrames(Maybe<int>(), Maybe<bool>(), Maybe<String16>(), &protocolCallFrames);
   if (!response.IsSuccess()) {
     protocolCallFrames = std::make_unique<Array<CallFrame>>();
   }
@@ -2585,6 +2664,18 @@ Response V8DebuggerAgentImpl::processSkipList(
   m_skipList = std::move(skipListInit);
   return Response::Success();
 }
+
+std::unique_ptr<protocol::Runtime::RemoteObject>
+V8DebuggerAgentImpl::wrapObject(int context_id, v8::Local<v8::Value> val) {
+  InjectedScript* injectedScript = nullptr;
+  m_session->findInjectedScript(context_id, injectedScript);
+
+  std::unique_ptr<protocol::Runtime::RemoteObject> rv;
+  injectedScript->wrapObject(val, kBacktraceObjectGroup,
+                             WrapMode::kNoPreview, &rv);
+  return rv;
+}
+
 
 void V8DebuggerAgentImpl::stop() {
   disable();

--- a/src/inspector/v8-debugger-agent-impl.cc
+++ b/src/inspector/v8-debugger-agent-impl.cc
@@ -1440,6 +1440,18 @@ class DisassemblyCollectorImpl final : public v8::debug::DisassemblyCollector {
     return std::move(chunks_[reading_chunk_index_++]);
   }
 
+ private:
+  // For a large Ritz module, the average is about 50 chars per line,
+  // so (with 2-byte String16 chars) this should give approximately 20 MB
+  // per chunk.
+  static constexpr size_t kLinesPerChunk = 200'000;
+
+  size_t writing_chunk_index_ = 0;
+  size_t reading_chunk_index_ = 0;
+  size_t total_number_of_lines_ = 0;
+  std::vector<DisassemblyChunk> chunks_;
+};
+
 // [replay] Always offer `arguments`, even if not usually available.
 //   -> https://linear.app/replay/issue/RUN-1061#comment-fc1c3ee4
 v8::MaybeLocal<v8::Value> V8DebuggerAgentImpl::getArgumentsOfCallFrame(
@@ -1464,18 +1476,6 @@ v8::MaybeLocal<v8::Value> V8DebuggerAgentImpl::getArgumentsOfCallFrame(
     return it->GetFrameArguments();
   }
 }
-
- private:
-  // For a large Ritz module, the average is about 50 chars per line,
-  // so (with 2-byte String16 chars) this should give approximately 20 MB
-  // per chunk.
-  static constexpr size_t kLinesPerChunk = 200'000;
-
-  size_t writing_chunk_index_ = 0;
-  size_t reading_chunk_index_ = 0;
-  size_t total_number_of_lines_ = 0;
-  std::vector<DisassemblyChunk> chunks_;
-};
 
 Response V8DebuggerAgentImpl::disassembleWasmModule(
     const String16& in_scriptId, std::optional<String16>* out_streamId,
@@ -1653,14 +1653,16 @@ Response V8DebuggerAgentImpl::pause() {
 }
 
 Response V8DebuggerAgentImpl::getCallFrames(
-    Maybe<int> maxFrames, Maybe<bool> noContents,
-    Maybe<String16> objectGroup,
-    std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>* out_callFrames) {
+    std::optional<int> maxFrames, std::optional<bool> noContents,
+    std::optional<String16> objectGroup,
+    std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>*
+        out_callFrames) {
   return currentCallFrames(std::move(maxFrames), std::move(noContents),
                            std::move(objectGroup), out_callFrames);
 }
 
-Response V8DebuggerAgentImpl::getTopFrameLocation(Maybe<protocol::Debugger::Location>* out_location) {
+Response V8DebuggerAgentImpl::getTopFrameLocation(
+    std::unique_ptr<protocol::Debugger::Location>* out_location) {
   if (!isPaused()) {
     return Response::Success();
   }
@@ -1686,15 +1688,16 @@ Response V8DebuggerAgentImpl::getTopFrameLocation(Maybe<protocol::Debugger::Loca
 extern "C" void V8RecordReplayGetCurrentException(v8::MaybeLocal<v8::Value>* exception);
 
 Response V8DebuggerAgentImpl::getPendingException(
-    Maybe<String16> objectGroup, Maybe<RemoteObject>* out_exception) {
+    std::optional<String16> objectGroup,
+    std::unique_ptr<RemoteObject>* out_exception) {
   v8::MaybeLocal<v8::Value> maybe_exception;
   V8RecordReplayGetCurrentException(&maybe_exception);
 
   if(!maybe_exception.IsEmpty()) {
     v8::Local<v8::Context> context = m_isolate->GetCurrentContext();
     v8::Local<v8::Value> exception = maybe_exception.ToLocalChecked();
-    std::unique_ptr<RemoteObject> obj =
-        m_session->wrapObject(context, exception, objectGroup.fromMaybe(""), false);
+    std::unique_ptr<RemoteObject> obj = m_session->wrapObject(
+        context, exception, objectGroup.value_or(String16()), false);
 
     *out_exception = std::move(obj);
   }
@@ -2005,6 +2008,8 @@ Response V8DebuggerAgentImpl::setBlackboxedRanges(
 }
 
 Response V8DebuggerAgentImpl::currentCallFrames(
+    std::optional<int> maxFrames, std::optional<bool> noContents,
+    std::optional<String16> objectGroup,
     std::unique_ptr<Array<CallFrame>>* result) {
   if (!isPaused()) {
     *result = std::make_unique<Array<CallFrame>>();
@@ -2014,8 +2019,10 @@ Response V8DebuggerAgentImpl::currentCallFrames(
   *result = std::make_unique<Array<CallFrame>>();
   auto iterator = v8::debug::StackTraceIterator::Create(m_isolate);
   int frameOrdinal = 0;
-  bool noContents = noContentsRaw.isJust() && noContentsRaw.fromJust();
+  bool noContentsFlag = noContents.value_or(false);
+  String16 frameObjectGroup = objectGroup.value_or(kBacktraceObjectGroup);
   for (; !iterator->Done(); iterator->Advance(), frameOrdinal++) {
+    if (maxFrames.has_value() && frameOrdinal >= *maxFrames) break;
     int contextId = iterator->GetContextId();
     InjectedScript* injectedScript = nullptr;
     std::shared_ptr<InspectedContext> inspectedContext;
@@ -2029,16 +2036,19 @@ Response V8DebuggerAgentImpl::currentCallFrames(
     v8::debug::Location loc = iterator->GetSourceLocation();
 
     std::unique_ptr<Array<Scope>> scopes;
-    auto scopeIterator = iterator->GetScopeIterator();
-    Response res =
-        buildScopes(m_isolate, scopeIterator.get(), injectedScript, &scopes);
-    if (!res.IsSuccess()) return res;
+    Response res = Response::Success();
+    if (!noContentsFlag) {
+      auto scopeIterator = iterator->GetScopeIterator();
+      res = buildScopes(m_isolate, scopeIterator.get(), injectedScript,
+                        frameObjectGroup, &scopes);
+      if (!res.IsSuccess()) return res;
+    }
 
     std::unique_ptr<RemoteObject> protocolReceiver;
-    if (injectedScript) {
+    if (!noContentsFlag && injectedScript) {
       v8::Local<v8::Value> receiver;
       if (iterator->GetReceiver().ToLocal(&receiver)) {
-        res = injectedScript->wrapObject(receiver, kBacktraceObjectGroup,
+        res = injectedScript->wrapObject(receiver, frameObjectGroup,
                                          WrapOptions({WrapMode::kIdOnly}),
                                          &protocolReceiver);
         if (!res.IsSuccess()) return res;
@@ -2082,10 +2092,10 @@ Response V8DebuggerAgentImpl::currentCallFrames(
     }
 
     v8::Local<v8::Value> returnValue = iterator->GetReturnValue();
-    if (!returnValue.IsEmpty() && injectedScript) {
+    if (!noContentsFlag && !returnValue.IsEmpty() && injectedScript) {
       std::unique_ptr<RemoteObject> value;
       res =
-          injectedScript->wrapObject(returnValue, kBacktraceObjectGroup,
+          injectedScript->wrapObject(returnValue, frameObjectGroup,
                                      WrapOptions({WrapMode::kIdOnly}), &value);
       if (!res.IsSuccess()) return res;
       frame->setReturnValue(std::move(value));
@@ -2116,8 +2126,7 @@ V8DebuggerAgentImpl::currentExternalStackTrace() {
 }
 
 bool V8DebuggerAgentImpl::isPaused() const {
-  return true;
-  //return m_debugger->isPausedInContextGroup(m_session->contextGroupId());
+  return m_debugger->isPausedInContextGroup(m_session->contextGroupId());
 }
 
 static String16 getScriptLanguage(const V8DebuggerScript& script) {
@@ -2384,7 +2393,8 @@ void V8DebuggerAgentImpl::didPauseOnInstrumentation(
   std::unique_ptr<protocol::DictionaryValue> breakAuxData;
 
   std::unique_ptr<Array<CallFrame>> protocolCallFrames;
-  Response response = currentCallFrames(Maybe<int>(), Maybe<bool>(), Maybe<String16>(), &protocolCallFrames);
+  Response response = currentCallFrames(std::nullopt, std::nullopt,
+                                        std::nullopt, &protocolCallFrames);
   if (!response.IsSuccess()) {
     protocolCallFrames = std::make_unique<Array<CallFrame>>();
   }
@@ -2524,7 +2534,8 @@ void V8DebuggerAgentImpl::didPause(
   }
 
   std::unique_ptr<Array<CallFrame>> protocolCallFrames;
-  Response response = currentCallFrames(Maybe<int>(), Maybe<bool>(), Maybe<String16>(), &protocolCallFrames);
+  Response response = currentCallFrames(std::nullopt, std::nullopt,
+                                        std::nullopt, &protocolCallFrames);
   if (!response.IsSuccess()) {
     protocolCallFrames = std::make_unique<Array<CallFrame>>();
   }
@@ -2672,7 +2683,7 @@ V8DebuggerAgentImpl::wrapObject(int context_id, v8::Local<v8::Value> val) {
 
   std::unique_ptr<protocol::Runtime::RemoteObject> rv;
   injectedScript->wrapObject(val, kBacktraceObjectGroup,
-                             WrapMode::kNoPreview, &rv);
+                             WrapOptions({WrapMode::kIdOnly}), &rv);
   return rv;
 }
 

--- a/src/inspector/v8-debugger-agent-impl.h
+++ b/src/inspector/v8-debugger-agent-impl.h
@@ -157,13 +157,15 @@ class V8DebuggerAgentImpl : public protocol::Debugger::Backend {
       std::unique_ptr<protocol::Array<protocol::Debugger::ScriptPosition>>
           positions) override;
   Response getCallFrames(
-      Maybe<int> maxFrames, Maybe<bool> noContents,
-      Maybe<String16> objectGroup,
-      std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>* out_callFrames) override;
-  Response getTopFrameLocation(Maybe<protocol::Debugger::Location>* out_location) override;
+      std::optional<int> maxFrames, std::optional<bool> noContents,
+      std::optional<String16> objectGroup,
+      std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>*
+          out_callFrames) override;
+  Response getTopFrameLocation(
+      std::unique_ptr<protocol::Debugger::Location>* out_location) override;
   Response getPendingException(
-      Maybe<String16> objectGroup,
-      Maybe<protocol::Runtime::RemoteObject>* out_exception) override;
+      std::optional<String16> objectGroup,
+      std::unique_ptr<protocol::Runtime::RemoteObject>* out_exception) override;
 
   bool enabled() const { return m_enableState == kEnabled; }
 
@@ -204,11 +206,15 @@ class V8DebuggerAgentImpl : public protocol::Debugger::Backend {
   v8::Isolate* isolate() { return m_isolate; }
 
   Response currentCallFrames(
-      Maybe<int> maxFrames, Maybe<bool> noContents,
-      Maybe<String16> objectGroup,
+      std::optional<int> maxFrames, std::optional<bool> noContents,
+      std::optional<String16> objectGroup,
       std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>*);
   std::unique_ptr<protocol::Runtime::RemoteObject> wrapObject(int contextId,
                                                               v8::Local<v8::Value> val);
+
+  // [replay] Always offer `arguments`, even if not usually available.
+  //   -> https://linear.app/replay/issue/RUN-1061#comment-fc1c3ee4
+  v8::MaybeLocal<v8::Value> getArgumentsOfCallFrame(const String16& callFrameId);
 
   void clearBreakDetails();
 

--- a/src/inspector/v8-debugger-agent-impl.h
+++ b/src/inspector/v8-debugger-agent-impl.h
@@ -156,6 +156,14 @@ class V8DebuggerAgentImpl : public protocol::Debugger::Backend {
       const String16& scriptId,
       std::unique_ptr<protocol::Array<protocol::Debugger::ScriptPosition>>
           positions) override;
+  Response getCallFrames(
+      Maybe<int> maxFrames, Maybe<bool> noContents,
+      Maybe<String16> objectGroup,
+      std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>* out_callFrames) override;
+  Response getTopFrameLocation(Maybe<protocol::Debugger::Location>* out_location) override;
+  Response getPendingException(
+      Maybe<String16> objectGroup,
+      Maybe<protocol::Runtime::RemoteObject>* out_exception) override;
 
   bool enabled() const { return m_enableState == kEnabled; }
 
@@ -195,13 +203,18 @@ class V8DebuggerAgentImpl : public protocol::Debugger::Backend {
 
   v8::Isolate* isolate() { return m_isolate; }
 
+  Response currentCallFrames(
+      Maybe<int> maxFrames, Maybe<bool> noContents,
+      Maybe<String16> objectGroup,
+      std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>*);
+  std::unique_ptr<protocol::Runtime::RemoteObject> wrapObject(int contextId,
+                                                              v8::Local<v8::Value> val);
+
   void clearBreakDetails();
 
  private:
   void enableImpl();
 
-  Response currentCallFrames(
-      std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>*);
   std::unique_ptr<protocol::Runtime::StackTrace> currentAsyncStackTrace();
   std::unique_ptr<protocol::Runtime::StackTraceId> currentExternalStackTrace();
 

--- a/src/inspector/v8-debugger.cc
+++ b/src/inspector/v8-debugger.cc
@@ -890,18 +890,19 @@ v8::MaybeLocal<v8::Value> V8Debugger::generatorScopes(
 }
 
 v8::MaybeLocal<v8::Array> V8Debugger::collectionsEntries(
-    v8::Local<v8::Context> context, v8::Local<v8::Value> collection) {
+    v8::Local<v8::Context> context, v8::Local<v8::Value> collection,
+    const v8::KeyIterationParams* params) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Array> entries;
   bool isKeyValue = false;
   if (!collection->IsObject() || !collection.As<v8::Object>()
-                                      ->PreviewEntries(&isKeyValue)
+                                      ->PreviewEntries(&isKeyValue, params)
                                       .ToLocal(&entries)) {
     return v8::MaybeLocal<v8::Array>();
   }
 
   v8::Local<v8::Array> wrappedEntries = v8::Array::New(isolate);
-  CHECK(!isKeyValue || wrappedEntries->Length() % 2 == 0);
+  CHECK(!isKeyValue || entries->Length() % 2 == 0);  // replay: discovered v8 bug
   if (!wrappedEntries->SetPrototype(context, v8::Null(isolate))
            .FromMaybe(false)) {
     return v8::MaybeLocal<v8::Array>();
@@ -978,14 +979,15 @@ v8::MaybeLocal<v8::Array> V8Debugger::privateMethods(
 }
 
 v8::MaybeLocal<v8::Array> V8Debugger::internalProperties(
-    v8::Local<v8::Context> context, v8::Local<v8::Value> value) {
+    v8::Local<v8::Context> context, v8::Local<v8::Value> value,
+    const v8::KeyIterationParams* params) {
   v8::Local<v8::Array> properties;
   if (!v8::debug::GetInternalProperties(m_isolate, value)
            .ToLocal(&properties)) {
     return v8::MaybeLocal<v8::Array>();
   }
   v8::Local<v8::Array> entries;
-  if (collectionsEntries(context, value).ToLocal(&entries)) {
+  if (collectionsEntries(context, value, params).ToLocal(&entries)) {
     createDataProperty(context, properties, properties->Length(),
                        toV8StringInternalized(m_isolate, "[[Entries]]"));
     createDataProperty(context, properties, properties->Length(), entries);

--- a/src/inspector/v8-debugger.h
+++ b/src/inspector/v8-debugger.h
@@ -113,8 +113,9 @@ class V8Debugger : public v8::debug::DebugDelegate,
   std::unique_ptr<V8StackTraceImpl> createStackTrace(v8::Local<v8::StackTrace>);
   std::unique_ptr<V8StackTraceImpl> captureStackTrace(bool fullStack);
 
-  v8::MaybeLocal<v8::Array> internalProperties(v8::Local<v8::Context>,
-                                               v8::Local<v8::Value>);
+  v8::MaybeLocal<v8::Array> internalProperties(
+      v8::Local<v8::Context>, v8::Local<v8::Value>,
+      const v8::KeyIterationParams* params);
 
   v8::Local<v8::Array> queryObjects(v8::Local<v8::Context> context,
                                     v8::Local<v8::Object> prototype);
@@ -185,7 +186,8 @@ class V8Debugger : public v8::debug::DebugDelegate,
   v8::MaybeLocal<v8::Value> generatorScopes(v8::Local<v8::Context>,
                                             v8::Local<v8::Value>);
   v8::MaybeLocal<v8::Array> collectionsEntries(v8::Local<v8::Context> context,
-                                               v8::Local<v8::Value> value);
+                                               v8::Local<v8::Value> value,
+                                               const v8::KeyIterationParams* params);
   v8::MaybeLocal<v8::Array> privateMethods(v8::Local<v8::Context> context,
                                            v8::Local<v8::Value> value);
 

--- a/src/inspector/v8-inspector-impl.cc
+++ b/src/inspector/v8-inspector-impl.cc
@@ -55,6 +55,8 @@
 #include "src/inspector/v8-stack-trace-impl.h"
 #include "src/inspector/value-mirror.h"
 
+#include "v8.h"
+
 namespace v8_inspector {
 
 std::unique_ptr<V8Inspector> V8Inspector::create(v8::Isolate* isolate,
@@ -256,10 +258,20 @@ std::shared_ptr<InspectedContext> V8InspectorImpl::getContext(
   if (!groupId || !contextId) return nullptr;
 
   auto contextGroupIt = m_contexts.find(groupId);
-  if (contextGroupIt == m_contexts.end()) return nullptr;
+  if (contextGroupIt == m_contexts.end()) {
+    v8::recordreplay::CommandDiagnostic(
+        "[RUN-2486-2537] V8InspectorImpl::getContext A %d %d %zu", contextId,
+        groupId, m_contexts.size());
+    return nullptr;
+  }
 
   auto contextIt = contextGroupIt->second->find(contextId);
-  if (contextIt == contextGroupIt->second->end()) return nullptr;
+  if (contextIt == contextGroupIt->second->end()) {
+    v8::recordreplay::CommandDiagnostic(
+        "[RUN-2486-2537] V8InspectorImpl::getContext B %d %d %zu", contextId,
+        groupId, contextGroupIt->second->size());
+    return nullptr;
+  }
 
   return contextIt->second;
 }
@@ -306,6 +318,10 @@ void V8InspectorImpl::contextCreated(const V8ContextInfo& info) {
   }
   const auto& contextById = contextIt->second;
 
+  v8::recordreplay::Trace(
+      "[RUN-2042-2109] V8InspectorImpl::contextCreated %d %d %zu %zu", contextId,
+      info.contextGroupId, m_sessions.size(), contextById->size());
+
   DCHECK(contextById->find(contextId) == contextById->cend());
   (*contextById)[contextId].reset(context);
   forEachSession(
@@ -341,6 +357,12 @@ void V8InspectorImpl::contextCollected(int groupId, int contextId) {
 }
 
 void V8InspectorImpl::resetContextGroup(int contextGroupId) {
+  v8::recordreplay::Trace(
+      "[RUN-2042-2109] V8InspectorImpl::resetContextGroup %d %zu %zu",
+      contextGroupId, m_sessions.size(),
+      m_contexts.find(contextGroupId) != m_contexts.end()
+          ? m_contexts.find(contextGroupId)->second->size()
+          : 0);
   m_consoleStorageMap.erase(contextGroupId);
   m_muteExceptionsMap.erase(contextGroupId);
   auto contextsIt = m_contexts.find(contextGroupId);
@@ -459,6 +481,11 @@ void V8InspectorImpl::discardInspectedContext(int contextGroupId,
                                               int contextId) {
   auto context = getContext(contextGroupId, contextId);
   if (!context) return;
+  v8::recordreplay::Trace(
+      "[RUN-2042-2109] V8InspectorImpl::discardInspectedContext %d %d %zu %zu",
+      contextId, contextGroupId, m_sessions.size(),
+      m_contexts[contextGroupId]->size());
+
   m_uniqueIdToContextId.erase(context->uniqueId().pair());
   m_contexts[contextGroupId]->erase(contextId);
   if (m_contexts[contextGroupId]->empty()) m_contexts.erase(contextGroupId);

--- a/src/inspector/v8-inspector-session-impl.cc
+++ b/src/inspector/v8-inspector-session-impl.cc
@@ -4,6 +4,9 @@
 
 #include "src/inspector/v8-inspector-session-impl.h"
 
+#include <sstream>
+#include <string>
+
 #include "../../third_party/inspector_protocol/crdtp/cbor.h"
 #include "../../third_party/inspector_protocol/crdtp/dispatch.h"
 #include "../../third_party/inspector_protocol/crdtp/json.h"
@@ -26,6 +29,8 @@
 #include "src/inspector/v8-profiler-agent-impl.h"
 #include "src/inspector/v8-runtime-agent-impl.h"
 #include "src/inspector/v8-schema-agent-impl.h"
+
+#include "replayio.h"
 
 namespace v8_inspector {
 namespace {
@@ -122,6 +127,9 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(
       m_clientTrustLevel(clientTrustLevel) {
   m_state->getBoolean("use_binary_protocol", &use_binary_protocol_);
 
+  v8::recordreplay::CommandDiagnosticTrace(
+      "[RUN-2486-2577] V8InspectorSessionImpl %d %d", contextGroupId, sessionId);
+
   m_runtimeAgent.reset(new V8RuntimeAgentImpl(
       this, this, agentState(protocol::Runtime::Metainfo::domainName),
       std::move(debuggerBarrier)));
@@ -191,13 +199,64 @@ std::unique_ptr<StringBuffer> V8InspectorSessionImpl::serializeForFrontend(
   return StringBufferFrom(std::move(json));
 }
 
+extern "C" void V8RecordReplayOnAnnotation(const char* kind, const char* contents);
+
+// Add an annotation to the recording for a protocol message event.
+// The get_cbor callback will only be invoked when replaying.
+void V8InspectorSessionImpl::RecordReplayMessageAnnotation(const char* kind,
+                                                           const std::function<v8_crdtp::span<uint8_t>()>& get_cbor) {
+  if (!v8::recordreplay::IsRecordingOrReplaying() ||
+      !v8::IsMainThread() ||
+      v8::recordreplay::AreEventsDisallowed("RecordReplayMessageAnnotation") ||
+      v8::recordreplay::IsInReplayCode("RecordReplayMessageAnnotation")) {
+    return;
+  }
+
+  // OnAnnotation calls must happen at the same point when recording vs. replaying,
+  // but the contents do not need to be consistent. Avoid serialization and
+  // conversion overhead when recording.
+  std::string json;
+  if (v8::recordreplay::IsReplaying()) {
+    v8::replayio::AutoDisallowEvents disallow("RecordReplayMessageAnnotation");
+    v8_crdtp::span<uint8_t> cbor = get_cbor();
+    v8_crdtp::Status status = ConvertCBORToJSON(cbor, &json);
+    DCHECK(status.ok());
+    USE(status);
+
+    // Tack additional information about this inspector onto the annotation JSON.
+    if (json.length() && json[json.length() - 1] == '}') {
+      json.resize(json.length() - 1);
+
+      std::ostringstream oss;
+      oss << ",\"contextGroupId\":" << m_contextGroupId;
+      oss << ",\"sessionId\":" << m_sessionId;
+      oss << "}";
+
+      json += oss.str();
+    }
+  }
+  V8RecordReplayOnAnnotation(kind, json.c_str());
+}
+
 void V8InspectorSessionImpl::SendProtocolResponse(
     int callId, std::unique_ptr<protocol::Serializable> message) {
+  std::vector<uint8_t> cbor;
+  RecordReplayMessageAnnotation("inspector-protocol-response",
+                                [&]() {
+                                  cbor = message->Serialize();
+                                  return SpanFrom(cbor);
+                                });
   m_channel->sendResponse(callId, serializeForFrontend(std::move(message)));
 }
 
 void V8InspectorSessionImpl::SendProtocolNotification(
     std::unique_ptr<protocol::Serializable> message) {
+  std::vector<uint8_t> cbor;
+  RecordReplayMessageAnnotation("inspector-protocol-notification",
+                                [&]() {
+                                  cbor = message->Serialize();
+                                  return SpanFrom(cbor);
+                                });
   m_channel->sendNotification(serializeForFrontend(std::move(message)));
 }
 
@@ -227,6 +286,11 @@ Response V8InspectorSessionImpl::findInjectedScript(
   std::shared_ptr<InspectedContext> context =
       m_inspector->getContext(m_contextGroupId, contextId);
   if (!context) {
+    if (v8::recordreplay::IsInReplayCode("InjectedScript::bindRemoteObjectIfNeeded")) {
+      v8::recordreplay::Warning(
+        "[RUN-2486-2498] Cannot find context with specified id B %d %d",
+        m_contextGroupId, contextId);
+    }
     return Response::ServerError("Cannot find context with specified id");
   }
   injectedScript = context->getInjectedScript(m_sessionId);
@@ -244,6 +308,11 @@ Response V8InspectorSessionImpl::findInjectedScript(
     RemoteObjectIdBase* objectId, InjectedScript*& injectedScript,
     std::shared_ptr<InspectedContext>* inspectedContext) {
   if (objectId->isolateId() != m_inspector->isolateId()) {
+    if (v8::recordreplay::IsInReplayCode("InjectedScript::bindRemoteObjectIfNeeded")) {
+      v8::recordreplay::Warning(
+        "[RUN-2486-2498] Cannot find context with specified id C %llu %llu",
+        objectId->isolateId(), m_inspector->isolateId());
+    }
     return Response::ServerError("Cannot find context with specified id");
   }
   return findInjectedScript(objectId->contextId(), injectedScript,
@@ -306,6 +375,25 @@ V8InspectorSessionImpl::wrapObject(v8::Local<v8::Context> context,
                                    v8::Local<v8::Value> value,
                                    StringView groupName, bool generatePreview) {
   return wrapObject(context, value, toString16(groupName), generatePreview);
+}
+
+// Replay edit: Return objectId
+std::u16string V8InspectorSessionImpl::wrapObjectGetObjectId(
+    v8::Local<v8::Context> context, v8::Local<v8::Value> value,
+    StringView groupName, bool generatePreview) {
+  auto remoteObject =
+      wrapObject(context, value, toString16(groupName), generatePreview);
+
+  String16 defaultValue("");
+  const String16& objectId = remoteObject->getObjectId(defaultValue);
+  // StringView* objectIdStringView = new StringView(objectId.characters16(),
+  // objectId.length());
+
+  // create new string and assign to result
+  // NOTE: StringView does not own its memory and String16 is not part of the
+  // API, so we have to use std::*string
+  auto* chrs = reinterpret_cast<const char16_t*>(objectId.characters16());
+  return std::u16string(chrs, objectId.length());
 }
 
 std::unique_ptr<protocol::Runtime::RemoteObject>
@@ -391,6 +479,8 @@ void V8InspectorSessionImpl::dispatchProtocolMessage(
     associated_data_copy = toString16(associated_data).utf8();
     associated_data_view = associated_data_copy;
   }
+  RecordReplayMessageAnnotation("inspector-protocol-dispatch",
+                                [&]() { return cbor; });
   v8_crdtp::Dispatchable dispatchable(cbor, associated_data_view,
                                       v8_crdtp::FallthroughCallback());
   if (!dispatchable.ok()) {
@@ -496,6 +586,10 @@ void V8InspectorSessionImpl::resume(bool terminateOnResume) {
 }
 
 void V8InspectorSessionImpl::stepOver() { m_debuggerAgent->stepOver({}); }
+
+v8::MaybeLocal<v8::Value> V8InspectorSessionImpl::getArgumentsOfCallFrame(StringView callFrameId) {
+  return m_debuggerAgent->getArgumentsOfCallFrame(toString16(callFrameId));
+}
 
 std::vector<std::unique_ptr<protocol::Debugger::API::SearchMatch>>
 V8InspectorSessionImpl::searchInTextByLines(StringView text, StringView query,

--- a/src/inspector/v8-inspector-session-impl.h
+++ b/src/inspector/v8-inspector-session-impl.h
@@ -92,6 +92,9 @@ class V8InspectorSessionImpl : public V8InspectorSession,
   void setSkipAllPauses(bool) override;
   void resume(bool terminateOnResume = false) override;
   void stepOver() override;
+
+  v8::MaybeLocal<v8::Value> getArgumentsOfCallFrame(StringView callFrameId) override;
+
   std::vector<std::unique_ptr<protocol::Debugger::API::SearchMatch>>
   searchInTextByLines(StringView text, StringView query, bool caseSensitive,
                       bool isRegex) override;
@@ -102,6 +105,12 @@ class V8InspectorSessionImpl : public V8InspectorSession,
   std::unique_ptr<protocol::Runtime::API::RemoteObject> wrapObject(
       v8::Local<v8::Context>, v8::Local<v8::Value>, StringView groupName,
       bool generatePreview) override;
+
+  // Replay edit: Return objectId
+  virtual std::u16string wrapObjectGetObjectId(v8::Local<v8::Context>,
+                                               v8::Local<v8::Value>,
+                                               StringView groupName,
+                                               bool generatePreview) override;
 
   V8InspectorSession::Inspectable* inspectedObject(unsigned num);
   static const unsigned kInspectedObjectBufferSize = 5;
@@ -132,6 +141,9 @@ class V8InspectorSessionImpl : public V8InspectorSession,
   void SendProtocolNotification(
       std::unique_ptr<protocol::Serializable> message) override;
   void FlushProtocolNotifications() override;
+
+  void RecordReplayMessageAnnotation(const char* kind,
+                                     const std::function<v8_crdtp::span<uint8_t>()>& get_cbor);
 
   std::unique_ptr<StringBuffer> serializeForFrontend(
       std::unique_ptr<protocol::Serializable> message);

--- a/src/inspector/v8-runtime-agent-impl.cc
+++ b/src/inspector/v8-runtime-agent-impl.cc
@@ -56,6 +56,9 @@
 #include "src/inspector/v8-value-utils.h"
 #include "src/tracing/trace-event.h"
 
+#include "replayio.h"
+#include "src/base/replayio.h"
+
 namespace v8_inspector {
 
 namespace V8RuntimeAgentImplState {
@@ -349,7 +352,11 @@ V8RuntimeAgentImpl::V8RuntimeAgentImpl(
       m_frontend(FrontendChannel),
       m_inspector(session->inspector()),
       m_debuggerBarrier(debuggerBarrier),
-      m_enabled(false) {}
+      m_enabled(false),
+      m_replay_owned(
+          (!v8::recordreplay::FeatureEnabled("replay-only-command-handling") ||
+           v8::recordreplay::IsReplaying()) &&
+          v8::recordreplay::AreEventsDisallowed()) {}
 
 V8RuntimeAgentImpl::~V8RuntimeAgentImpl() = default;
 
@@ -603,6 +610,9 @@ Response V8RuntimeAgentImpl::getProperties(
   }
 
   v8::Local<v8::Object> object = scope.object().As<v8::Object>();
+
+  v8::KeyIterationParams params(pageSize.fromMaybe(0), pageIndex.fromMaybe(0));
+
 
   std::unique_ptr<WrapOptions> wrapOptions;
   response =
@@ -1065,6 +1075,9 @@ Response V8RuntimeAgentImpl::getExceptionDetails(
 void V8RuntimeAgentImpl::bindingCalled(const String16& name,
                                        const String16& payload,
                                        int executionContextId) {
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, "V8RuntimeAgentImpl::bindingCalled");
+
   if (!m_activeBindings.count(name)) return;
   m_frontend.bindingCalled(name, payload, executionContextId);
   m_frontend.flush();
@@ -1096,6 +1109,9 @@ void V8RuntimeAgentImpl::addBindings(InspectedContext* context) {
 }
 
 void V8RuntimeAgentImpl::restore() {
+  v8::replayio::AutoMaybeDisallowEvents disallow(m_replay_owned,
+                                               "V8RuntimeAgentImpl::restore");
+
   if (!m_state->booleanProperty(V8RuntimeAgentImplState::runtimeEnabled,
                                 false)) {
     return;
@@ -1173,6 +1189,9 @@ Response V8RuntimeAgentImpl::disable() {
 }
 
 void V8RuntimeAgentImpl::reset() {
+  v8::replayio::AutoMaybeDisallowEvents disallow(m_replay_owned,
+                                               "V8RuntimeAgentImpl::reset");
+
   m_compiledScripts.clear();
   if (m_enabled) {
     int sessionId = m_session->sessionId();
@@ -1186,6 +1205,9 @@ void V8RuntimeAgentImpl::reset() {
 
 void V8RuntimeAgentImpl::reportExecutionContextCreated(
     InspectedContext* context) {
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, "V8RuntimeAgentImpl::reportExecutionContextCreated");
+
   if (!m_enabled) return;
   context->setReported(m_session->sessionId(), true);
   std::unique_ptr<protocol::Runtime::ExecutionContextDescription> description =
@@ -1208,6 +1230,9 @@ void V8RuntimeAgentImpl::reportExecutionContextCreated(
 
 void V8RuntimeAgentImpl::reportExecutionContextDestroyed(
     InspectedContext* context) {
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, "V8RuntimeAgentImpl::reportExecutionContextDestroyed");
+
   if (m_enabled && context->isReported(m_session->sessionId())) {
     context->setReported(m_session->sessionId(), false);
     m_frontend.executionContextDestroyed(context->contextId(),
@@ -1218,6 +1243,9 @@ void V8RuntimeAgentImpl::reportExecutionContextDestroyed(
 void V8RuntimeAgentImpl::inspect(
     std::unique_ptr<protocol::Runtime::RemoteObject> objectToInspect,
     std::unique_ptr<protocol::DictionaryValue> hints, int executionContextId) {
+  v8::replayio::AutoMaybeDisallowEvents disallow(m_replay_owned,
+                                               "V8RuntimeAgentImpl::inspect");
+
   if (m_enabled) {
     m_frontend.inspectRequested(std::move(objectToInspect), std::move(hints),
                                 executionContextId);
@@ -1230,6 +1258,9 @@ void V8RuntimeAgentImpl::messageAdded(V8ConsoleMessage* message) {
 
 bool V8RuntimeAgentImpl::reportMessage(V8ConsoleMessage* message,
                                        bool generatePreview) {
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, "V8RuntimeAgentImpl::reportMessage");
+
   message->reportToFrontend(&m_frontend, m_session, generatePreview);
   m_frontend.flush();
   return m_inspector->hasConsoleMessageStorage(m_session->contextGroupId());

--- a/src/inspector/v8-runtime-agent-impl.cc
+++ b/src/inspector/v8-runtime-agent-impl.cc
@@ -585,7 +585,8 @@ Response V8RuntimeAgentImpl::getProperties(
     const String16& objectId, std::optional<bool> ownProperties,
     std::optional<bool> accessorPropertiesOnly,
     std::optional<bool> generatePreview,
-    std::optional<bool> nonIndexedPropertiesOnly,
+    std::optional<bool> nonIndexedPropertiesOnly, std::optional<int> pageSize,
+    std::optional<int> pageIndex,
     std::unique_ptr<protocol::Array<protocol::Runtime::PropertyDescriptor>>*
         result,
     std::unique_ptr<
@@ -611,8 +612,7 @@ Response V8RuntimeAgentImpl::getProperties(
 
   v8::Local<v8::Object> object = scope.object().As<v8::Object>();
 
-  v8::KeyIterationParams params(pageSize.fromMaybe(0), pageIndex.fromMaybe(0));
-
+  v8::KeyIterationParams params(pageSize.value_or(0), pageIndex.value_or(0));
 
   std::unique_ptr<WrapOptions> wrapOptions;
   response =
@@ -623,7 +623,7 @@ Response V8RuntimeAgentImpl::getProperties(
   response = scope.injectedScript()->getProperties(
       object, scope.objectGroupName(), ownProperties.value_or(false),
       accessorPropertiesOnly.value_or(false),
-      nonIndexedPropertiesOnly.value_or(false), *wrapOptions, result,
+      nonIndexedPropertiesOnly.value_or(false), *wrapOptions, &params, result,
       exceptionDetails);
   if (!response.IsSuccess()) return response;
   if (*exceptionDetails) return Response::Success();
@@ -633,7 +633,8 @@ Response V8RuntimeAgentImpl::getProperties(
       privatePropertiesProtocolArray;
   response = scope.injectedScript()->getInternalAndPrivateProperties(
       object, scope.objectGroupName(), accessorPropertiesOnly.value_or(false),
-      &internalPropertiesProtocolArray, &privatePropertiesProtocolArray);
+      &params, &internalPropertiesProtocolArray,
+      &privatePropertiesProtocolArray);
   if (!response.IsSuccess()) return response;
   if (!internalPropertiesProtocolArray->empty()) {
     *internalProperties = std::move(internalPropertiesProtocolArray);

--- a/src/inspector/v8-runtime-agent-impl.h
+++ b/src/inspector/v8-runtime-agent-impl.h
@@ -180,6 +180,9 @@ class V8RuntimeAgentImpl : public protocol::Runtime::Backend {
       m_compiledScripts;
   // Binding name -> executionContextIds mapping.
   std::unordered_map<String16, std::unordered_set<int>> m_activeBindings;
+
+  // Whether this agent is replaying specific, and should not interact with the recording.
+  bool m_replay_owned;
 };
 
 }  // namespace v8_inspector

--- a/src/inspector/v8-runtime-agent-impl.h
+++ b/src/inspector/v8-runtime-agent-impl.h
@@ -104,6 +104,7 @@ class V8RuntimeAgentImpl : public protocol::Runtime::Backend {
       std::optional<bool> accessorPropertiesOnly,
       std::optional<bool> generatePreview,
       std::optional<bool> nonIndexedPropertiesOnly,
+      std::optional<int> pageSize, std::optional<int> pageIndex,
       std::unique_ptr<protocol::Array<protocol::Runtime::PropertyDescriptor>>*
           result,
       std::unique_ptr<

--- a/src/inspector/value-mirror.cc
+++ b/src/inspector/value-mirror.cc
@@ -24,6 +24,10 @@
 #include "src/inspector/v8-serialization-duplicate-tracker.h"
 #include "src/inspector/v8-value-utils.h"
 
+#include "v8.h"
+
+#include "src/inspector/string-util.h"
+
 namespace v8_inspector {
 
 using protocol::Response;
@@ -1445,6 +1449,38 @@ std::unique_ptr<ValueMirror> createNativeGetter(v8::Local<v8::Context> context,
   return ValueMirror::create(context, function);
 }
 
+static const char* allowed_getters[] = {
+    "type",
+    "fromElement",
+    "target",
+    "isTrusted",
+    "key",
+    "clientX",
+    "clientY",
+    "altKey",
+    "button",
+    "buttons",
+    "ctrlKey",
+    "currentTarget",
+    "defaultPrevented",
+    "eventPhase",
+    "metaKey",
+    "movementX",
+    "movementY",
+    "offsetX",
+    "offsetY",
+    "pageX",
+    "pageY",
+    "screenX",
+    "screenY",
+    "shiftKey",
+    "srcElement",
+    "timeStamp",
+    "which",
+    "x",
+    "y",
+};
+
 void nativeSetterCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
   if (info.Length() < 1) return;
   v8::Isolate* isolate = info.GetIsolate();
@@ -1527,7 +1563,8 @@ bool ValueMirror::getProperties(v8::Local<v8::Context> context,
                                 v8::Local<v8::Object> object,
                                 bool ownProperties, bool accessorPropertiesOnly,
                                 bool nonIndexedPropertiesOnly,
-                                PropertyAccumulator* accumulator) {
+                                PropertyAccumulator* accumulator,
+                                const v8::KeyIterationParams* params) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::TryCatch tryCatch(isolate);
   v8::Local<v8::Set> set = v8::Set::New(isolate);
@@ -1551,8 +1588,25 @@ bool ValueMirror::getProperties(v8::Local<v8::Context> context,
     }
   }
 
+  // [RUN-3149] we're only interested in a subset of the properties on this
+  // object. In order to make sure we get enough own properties to satisfy
+  // expected behavior for objects, always request a much larger set of keys
+  // we will later prune returned properties down to the originally requested
+  // size.
+  const int SubsetPageSize = 100000;
+
+  v8::KeyIterationParams subsetIterationParams(SubsetPageSize, 0);
+  const v8::KeyIterationParams *keyIterationParams;
+  if (*params) {
+    // we're grabbing a subset.  use the larger subset params.
+    keyIterationParams = &subsetIterationParams;
+  } else {
+    // we're grabbing everything.  use the passed-in params.
+    keyIterationParams = params;
+  }
   auto iterator = v8::debug::PropertyIterator::Create(context, object,
-                                                      nonIndexedPropertiesOnly);
+                                                      nonIndexedPropertiesOnly,
+                                                      keyIterationParams);
   if (!iterator) {
     CHECK(tryCatch.HasCaught());
     return false;
@@ -1680,7 +1734,8 @@ bool ValueMirror::getProperties(v8::Local<v8::Context> context,
 // static
 void ValueMirror::getInternalProperties(
     v8::Local<v8::Context> context, v8::Local<v8::Object> object,
-    std::vector<InternalPropertyMirror>* mirrors) {
+    std::vector<InternalPropertyMirror>* mirrors,
+    const v8::KeyIterationParams* params) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::MicrotasksScope microtasksScope(context,
                                       v8::MicrotasksScope::kDoNotRunMicrotasks);
@@ -1709,7 +1764,7 @@ void ValueMirror::getInternalProperties(
       static_cast<V8InspectorImpl*>(v8::debug::GetInspector(isolate))
           ->debugger();
   v8::Local<v8::Array> properties;
-  if (debugger->internalProperties(context, object).ToLocal(&properties)) {
+  if (debugger->internalProperties(context, object, params).ToLocal(&properties)) {
     for (uint32_t i = 0; i < properties->Length(); i += 2) {
       v8::Local<v8::Value> name;
       if (!properties->Get(context, i).ToLocal(&name) || !name->IsString()) {

--- a/src/inspector/value-mirror.cc
+++ b/src/inspector/value-mirror.cc
@@ -1449,38 +1449,6 @@ std::unique_ptr<ValueMirror> createNativeGetter(v8::Local<v8::Context> context,
   return ValueMirror::create(context, function);
 }
 
-static const char* allowed_getters[] = {
-    "type",
-    "fromElement",
-    "target",
-    "isTrusted",
-    "key",
-    "clientX",
-    "clientY",
-    "altKey",
-    "button",
-    "buttons",
-    "ctrlKey",
-    "currentTarget",
-    "defaultPrevented",
-    "eventPhase",
-    "metaKey",
-    "movementX",
-    "movementY",
-    "offsetX",
-    "offsetY",
-    "pageX",
-    "pageY",
-    "screenX",
-    "screenY",
-    "shiftKey",
-    "srcElement",
-    "timeStamp",
-    "which",
-    "x",
-    "y",
-};
-
 void nativeSetterCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
   if (info.Length() < 1) return;
   v8::Isolate* isolate = info.GetIsolate();

--- a/src/inspector/value-mirror.h
+++ b/src/inspector/value-mirror.h
@@ -83,10 +83,12 @@ class ValueMirror {
                             v8::Local<v8::Object> object, bool ownProperties,
                             bool accessorPropertiesOnly,
                             bool nonIndexedPropertiesOnly,
-                            PropertyAccumulator* accumulator);
+                            PropertyAccumulator* accumulator,
+                            const v8::KeyIterationParams* params = v8::KeyIterationParams::Default());
   static void getInternalProperties(
       v8::Local<v8::Context> context, v8::Local<v8::Object> object,
-      std::vector<InternalPropertyMirror>* mirrors);
+      std::vector<InternalPropertyMirror>* mirrors,
+      const v8::KeyIterationParams* params = v8::KeyIterationParams::Default());
   static std::vector<PrivatePropertyMirror> getPrivateProperties(
       v8::Local<v8::Context> context, v8::Local<v8::Object> object,
       bool accessorPropertiesOnly);

--- a/src/interpreter/bytecode-array-builder.cc
+++ b/src/interpreter/bytecode-array-builder.cc
@@ -22,6 +22,15 @@
 
 namespace v8 {
 namespace internal {
+
+extern int RegisterAssertValueSite(const std::string& desc, int source_position);
+extern int RegisterInstrumentationSite(const char* kind, int source_position,
+                                       int bytecode_offset);
+extern bool RecordReplayHasDefaultContext();
+extern bool gRecordReplayAssertTrackedObjects;
+
+extern size_t NumRunningBackgroundCompileTasks();
+
 namespace interpreter {
 
 class RegisterTransferWriter final
@@ -46,6 +55,8 @@ class RegisterTransferWriter final
 
 BytecodeArrayBuilder::BytecodeArrayBuilder(
     Zone* zone, int parameter_count, int locals_count,
+    bool record_replay_ignore,
+    bool record_replay_assert_values,
     FeedbackVectorSpec* feedback_vector_spec,
     SourcePositionTableBuilder::RecordingMode source_position_mode)
     : zone_(zone),
@@ -69,6 +80,20 @@ BytecodeArrayBuilder::BytecodeArrayBuilder(
     register_optimizer_ = zone->New<BytecodeRegisterOptimizer>(
         zone, &register_allocator_, fixed_register_count(), parameter_count,
         zone->New<RegisterTransferWriter>(this));
+  }
+
+  if (recordreplay::IsRecordingOrReplaying("emit-opcodes") &&
+      RecordReplayHasDefaultContext() &&
+      !record_replay_ignore) {
+    emit_record_replay_opcodes_ = true;
+    emit_record_replay_assert_values_ = record_replay_assert_values;
+
+    // Record/replay opcodes can only be emitted for scripts that run on the
+    // main thread. If we aren't on the main thread, this must have been
+    // triggered by a background compile task.
+    if (!IsMainThread()) {
+      CHECK(NumRunningBackgroundCompileTasks() != 0);
+    }
   }
 }
 
@@ -192,6 +217,7 @@ void BytecodeArrayBuilder::WriteJump(BytecodeNode* node, BytecodeLabel* label) {
 
 void BytecodeArrayBuilder::WriteJumpLoop(BytecodeNode* node,
                                          BytecodeLoopHeader* loop_header) {
+  RecordReplayOnProgress();
   AttachOrEmitDeferredSourceInfo(node);
   // JumpLoop can throw due to interrupt checks (stack overflow, termination).
   potentially_throwing_bytecode_count_++;
@@ -800,6 +826,7 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::LoadGlobal(const AstRawString* name,
       OutputLdaGlobal(name_index, feedback_slot);
       break;
   }
+  RecordReplayAssertValue(std::string("LoadGlobal " + name->to_string()));
   return *this;
 }
 
@@ -872,6 +899,7 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::LoadLookupSlot(
       OutputLdaLookupSlot(name_index);
       break;
   }
+  RecordReplayAssertValue(std::string("LoadLookupSlot " + name->to_string()));
   return *this;
 }
 
@@ -928,6 +956,7 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::LoadNamedProperty(
     Register object, const AstRawString* name, int feedback_slot) {
   size_t name_index = GetConstantPoolEntry(name);
   OutputGetNamedProperty(object, name_index, feedback_slot);
+  RecordReplayAssertValue(std::string("GetNamedProperty ") + name->to_string());
   return *this;
 }
 
@@ -941,6 +970,7 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::LoadNamedPropertyFromSuper(
 BytecodeArrayBuilder& BytecodeArrayBuilder::LoadKeyedProperty(
     Register object, int feedback_slot) {
   OutputGetKeyedProperty(object, feedback_slot);
+  RecordReplayAssertValue("LoadKeyedProperty");
   return *this;
 }
 
@@ -1018,12 +1048,15 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::SetNamedProperty(
 BytecodeArrayBuilder& BytecodeArrayBuilder::SetNamedProperty(
     Register object, const AstRawString* name, int feedback_slot,
     LanguageMode language_mode) {
+  RecordReplayAssertValue(std::string("SetNamedProperty " + name->to_string()));
+
   size_t name_index = GetConstantPoolEntry(name);
   return SetNamedProperty(object, name_index, feedback_slot, language_mode);
 }
 
 BytecodeArrayBuilder& BytecodeArrayBuilder::DefineNamedOwnProperty(
     Register object, const AstRawString* name, int feedback_slot) {
+  RecordReplayAssertValue(std::string("DefineNamedOwnProperty " + name->to_string()));
   size_t name_index = GetConstantPoolEntry(name);
   // Ensure that the store operation is in sync with the IC slot kind.
   DCHECK_EQ(
@@ -1036,6 +1069,7 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::DefineNamedOwnProperty(
 BytecodeArrayBuilder& BytecodeArrayBuilder::SetKeyedProperty(
     Register object, Register key, int feedback_slot,
     LanguageMode language_mode) {
+  RecordReplayAssertValue("SetKeyedProperty");
   // Ensure that language mode is in sync with the IC slot kind.
   DCHECK_EQ(GetLanguageModeFromSlotKind(feedback_vector_spec()->GetKind(
                 FeedbackVector::ToSlot(feedback_slot))),
@@ -1509,6 +1543,90 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::IncBlockCounter(
   return *this;
 }
 
+BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayOnProgress() {
+  if (emit_record_replay_opcodes_) {
+    OutputRecordReplayIncExecutionProgressCounter();
+  } else if (recordreplay::IsReplaying()) {
+    OutputRecordReplayNotifyActivity();
+  }
+  return *this;
+}
+
+BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayAssertValue(const std::string& desc) {
+  if (emit_record_replay_assert_values_) {
+    CHECK(emit_record_replay_opcodes_);
+    int index = RegisterAssertValueSite(desc, most_recent_source_position_);
+    OutputRecordReplayAssertValue(index);
+  }
+  return *this;
+}
+
+int BytecodeArrayBuilder::RecordReplayRegisterInstrumentationSite(
+    const char* kind, int source_position) {
+  if (!strcmp(kind, "breakpoint") && source_position != kNoSourcePosition &&
+      record_replay_instrumentation_site_locations_.find(source_position) !=
+          record_replay_instrumentation_site_locations_.end()) {
+    // Don't insert a breakpoint at the same location more than once.
+    return -1;
+  }
+  record_replay_instrumentation_site_locations_.insert(source_position);
+
+  // some of the instrumentations bypass the above location-based deduplication mechanism (mainly the ones added with kNoSourcePosition)
+  // so to ensure unique function indices to be used for all registered instrumentation sites
+  // we use a dedicated counter for this
+  int function_index = ++record_replay_instrumentation_site_counter_;
+  return RegisterInstrumentationSite(kind, source_position, function_index);
+}
+
+bool BytecodeArrayBuilder::EmitRecordReplayInstrumentationOpcodes() const {
+  // Instrumentation opcodes aren't needed when recording, except when we are asserting
+  // encountered values and need consistent IDs for these objects when recording.
+  // Generator instrumentation will create persistent object IDs.
+  return emit_record_replay_opcodes_ && (recordreplay::IsReplaying() || gRecordReplayAssertTrackedObjects);
+}
+
+BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayInstrumentation(
+    const char* kind, int source_position) {
+  if (EmitRecordReplayInstrumentationOpcodes()) {
+    int index = RecordReplayRegisterInstrumentationSite(kind, source_position);
+    if (index >= 0) {
+      OutputRecordReplayInstrumentation(index);
+    }
+  }
+  return *this;
+}
+
+BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayInstrumentationGenerator(
+    const char* kind, Register generator_object) {
+  if (EmitRecordReplayInstrumentationOpcodes()) {
+    int index =
+        RecordReplayRegisterInstrumentationSite(kind, kNoSourcePosition);
+    if (index >= 0) {
+      OutputRecordReplayInstrumentationGenerator(index, generator_object);
+    }
+  }
+  return *this;
+}
+
+BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayInstrumentationReturn(
+    const char* kind, Register return_value, int source_position) {
+  if (EmitRecordReplayInstrumentationOpcodes()) {
+    int index =
+        RecordReplayRegisterInstrumentationSite(kind, source_position);
+    if (index >= 0) {
+      OutputRecordReplayInstrumentationReturn(index, return_value);
+    }
+  }
+  return *this;
+}
+
+BytecodeArrayBuilder& BytecodeArrayBuilder::RecordReplayTrackObjectId(Register object) {
+  if (emit_record_replay_opcodes_) {
+    OutputRecordReplayTrackObjectId(object);
+  }
+  return *this;
+}
+
 BytecodeArrayBuilder& BytecodeArrayBuilder::ForInEnumerate(Register receiver) {
   OutputForInEnumerate(receiver);
   return *this;
@@ -1580,6 +1698,7 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::CallProperty(Register callable,
   } else {
     OutputCallProperty(callable, args, args.register_count(), feedback_slot);
   }
+  RecordReplayAssertValue("CallProperty");
   return *this;
 }
 
@@ -1595,6 +1714,7 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::CallUndefinedReceiver(
     OutputCallUndefinedReceiver(callable, args, args.register_count(),
                                 feedback_slot);
   }
+  RecordReplayAssertValue("CallUndefinedReceiver");
   return *this;
 }
 
@@ -1602,6 +1722,7 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::CallAnyReceiver(Register callable,
                                                             RegisterList args,
                                                             int feedback_slot) {
   OutputCallAnyReceiver(callable, args, args.register_count(), feedback_slot);
+  RecordReplayAssertValue("CallAnyReceiver");
   return *this;
 }
 
@@ -1609,6 +1730,7 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::CallWithSpread(Register callable,
                                                            RegisterList args,
                                                            int feedback_slot) {
   OutputCallWithSpread(callable, args, args.register_count(), feedback_slot);
+  RecordReplayAssertValue("CallWithSpread");
   return *this;
 }
 
@@ -1616,6 +1738,7 @@ BytecodeArrayBuilder& BytecodeArrayBuilder::Construct(Register constructor,
                                                       RegisterList args,
                                                       int feedback_slot_id) {
   OutputConstruct(constructor, args, args.register_count(), feedback_slot_id);
+  RecordReplayAssertValue("Construct");
   return *this;
 }
 

--- a/src/interpreter/bytecode-array-builder.h
+++ b/src/interpreter/bytecode-array-builder.h
@@ -40,6 +40,8 @@ class V8_EXPORT_PRIVATE BytecodeArrayBuilder final {
  public:
   BytecodeArrayBuilder(
       Zone* zone, int parameter_count, int locals_count,
+      bool record_replay_ignore,
+      bool record_replay_assert_values,
       FeedbackVectorSpec* feedback_vector_spec = nullptr,
       SourcePositionTableBuilder::RecordingMode source_position_mode =
           SourcePositionTableBuilder::RECORD_SOURCE_POSITIONS);
@@ -502,6 +504,22 @@ class V8_EXPORT_PRIVATE BytecodeArrayBuilder final {
   // Increment the block counter at the given slot (block code coverage).
   BytecodeArrayBuilder& IncBlockCounter(int slot);
 
+  BytecodeArrayBuilder& RecordReplayOnProgress();
+  BytecodeArrayBuilder& RecordReplayAssertValue(const std::string& desc);
+
+  int RecordReplayRegisterInstrumentationSite(const char* kind,
+                                              int source_position);
+  BytecodeArrayBuilder& RecordReplayInstrumentation(const char* kind,
+                                                    int source_position = kNoSourcePosition);
+  BytecodeArrayBuilder& RecordReplayInstrumentationGenerator(const char* kind,
+                                                             Register generator_object);
+  BytecodeArrayBuilder& RecordReplayInstrumentationReturn(const char* kind,
+                                                          Register return_value,
+                                                          int source_position = kNoSourcePosition);
+  BytecodeArrayBuilder& RecordReplayTrackObjectId(Register object);
+
+  bool EmitRecordReplayInstrumentationOpcodes() const;
+
   // Complex flow control.
   BytecodeArrayBuilder& ForInEnumerate(Register receiver);
   BytecodeArrayBuilder& ForInPrepare(RegisterList cache_info_triple,
@@ -583,6 +601,7 @@ class V8_EXPORT_PRIVATE BytecodeArrayBuilder final {
 
   void SetExpressionPosition(int position) {
     if (position == kNoSourcePosition) return;
+    most_recent_source_position_ = position;
     if (!latest_source_info_.is_statement()) {
       // Ensure the current expression position is overwritten with the
       // latest value.
@@ -704,6 +723,12 @@ class V8_EXPORT_PRIVATE BytecodeArrayBuilder final {
   BytecodeRegisterOptimizer* register_optimizer_;
   BytecodeSourceInfo latest_source_info_;
   BytecodeSourceInfo deferred_source_info_;
+  int most_recent_source_position_ = -1;
+  bool emit_record_replay_opcodes_ = false;
+  bool emit_record_replay_assert_values_ = false;
+  std::unordered_set<int> record_replay_instrumentation_site_locations_;
+ public:
+  int record_replay_instrumentation_site_counter_ = 0;
   int potentially_throwing_bytecode_count_;
 };
 

--- a/src/interpreter/bytecode-array-writer.h
+++ b/src/interpreter/bytecode-array-writer.h
@@ -74,6 +74,8 @@ class V8_EXPORT_PRIVATE BytecodeArrayWriter final {
 
   bool RemainderOfBlockIsDead() const { return exit_seen_in_block_; }
 
+  int size() const { return (int)bytecodes_.size(); }
+
   size_t current_bytecode_size() const { return bytecodes_.size(); }
 
  private:

--- a/src/interpreter/bytecode-generator.cc
+++ b/src/interpreter/bytecode-generator.cc
@@ -51,6 +51,9 @@
 
 namespace v8 {
 namespace internal {
+
+extern bool RecordReplayTrackThisObjectAssignment(const std::string& property);
+
 namespace interpreter {
 
 // Scoped class tracking context objects created by the visitor. Represents
@@ -1438,7 +1441,10 @@ BytecodeGenerator::BytecodeGenerator(
     : local_isolate_(local_isolate),
       zone_(compile_zone),
       builder_(zone(), info->num_parameters_including_this(),
-               info->scope()->num_stack_slots(), info->feedback_vector_spec(),
+               info->scope()->num_stack_slots(),
+               info->flags().record_replay_ignore(),
+               info->flags().record_replay_assert_values(),
+               info->feedback_vector_spec(),
                info->SourcePositionRecordingMode()),
       info_(info),
       ast_string_constants_(ast_string_constants),
@@ -1748,6 +1754,26 @@ void BytecodeGenerator::GenerateBytecode(uintptr_t stack_limit) {
   }
 }
 
+void BytecodeGenerator::ReplayExpressionShiftedSetStatementPosition(Statement* stmt, Expression* expr) {
+  builder()->SetStatementPosition(stmt, /* record_replay_breakpoint */ false);
+  if (expr->position() < 0) {
+    // expression is empty, so the breakpoint gets added at the statement itself
+    builder()->RecordReplayInstrumentation("breakpoint", stmt->position());
+  } else if (expr->IsBinaryOperation()) {
+    // given the breakpoint gets shifted to the expression (if that's available) by default
+    // we first check if it's not a binary operation, in which case we need to make sure the breakpoint is added at the position of the left operand
+    // this targets the case in which the binary operation's position is set to its right operand, see:
+    // https://github.com/v8/v8/commit/5bf9e470f8290dde983797e695e5156374d81962
+    // without this the pre-call-post-args breakpoint added by `VisitCall` would not be added as it would be treated as duplicate.
+    // without this specialcase the breakpoints would be added like this (3 would be skipped):
+    //
+    // return /*2*/foo(), /*1*//*3*/bar();
+    builder()->RecordReplayInstrumentation("breakpoint", expr->AsBinaryOperation()->left()->position());
+  } else {
+    builder()->RecordReplayInstrumentation("breakpoint", expr->position());
+  }
+}
+
 void BytecodeGenerator::GenerateBytecodeBody() {
   GenerateBodyPrologue();
 
@@ -1794,6 +1820,19 @@ void BytecodeGenerator::GenerateBodyPrologue() {
   FunctionLiteral* literal = info()->literal();
   // Emit tracing call if requested to do so.
   if (v8_flags.trace) builder()->CallRuntime(Runtime::kTraceEnter);
+
+  if (recordreplay::IsRecordingOrReplaying("emit-opcodes")) {
+    builder()->RecordReplayOnProgress();
+
+    if (IsResumableFunction(literal->kind())) {
+      builder()->RecordReplayInstrumentationGenerator("generator", generator_object());
+    } else {
+      builder()->RecordReplayInstrumentation("main");
+    }
+
+    // Reset for each function.
+    record_replay_has_track_this_ = false;
+  }
 
   // Increment the function-scope block coverage counter.
   BuildIncrementBlockCoverageCounterIfEnabled(literal, SourceRangeKind::kBody);
@@ -2259,6 +2298,10 @@ void BytecodeGenerator::BuildDeclareCall(Runtime::FunctionId id) {
   top_level_builder()->mark_processed();
 }
 
+  // See BuildTryCatch for why we increment the progress counter here.
+  builder()->RecordReplayOnProgress();
+  builder()->RecordReplayAssertValue("BeginFinally");
+
 void BytecodeGenerator::VisitModuleDeclarations(Declaration::List* decls) {
   RegisterAllocationScope register_scope(this);
   for (Declaration* decl : *decls) {
@@ -2560,7 +2603,7 @@ void BytecodeGenerator::VisitBreakStatement(BreakStatement* stmt) {
 
 void BytecodeGenerator::VisitReturnStatement(ReturnStatement* stmt) {
   AllocateBlockCoverageSlotIfEnabled(stmt, SourceRangeKind::kContinuation);
-  builder()->SetStatementPosition(stmt);
+  ReplayExpressionShiftedSetStatementPosition(stmt, stmt->expression());
   VisitForAccumulatorValue(stmt->expression());
   int return_position = stmt->end_position();
   if (return_position == ReturnStatement::kFunctionLiteralReturnPosition) {
@@ -3033,6 +3076,13 @@ void BytecodeGenerator::BuildTryFinally(
     try_body_func();
   }
   try_control_builder.EndTry();
+
+  // Unlike in gecko, we need to increment the progress counter at catch
+  // blocks so we can detect when exceptions are initially thrown vs. being
+  // rethrown. See Runtime_UnwindAndFindExceptionHandler.
+  builder()->RecordReplayOnProgress();
+
+  builder()->RecordReplayAssertValue("BeginCatch");
 
   // Record fall-through and exception cases.
   if (!builder()->RemainderOfBlockIsDead()) {
@@ -4248,6 +4298,24 @@ void BytecodeGenerator::VisitObjectLiteral(ObjectLiteral* expr) {
       object_literals_.push_back(std::make_pair(expr->builder(), entry));
     }
     BuildCreateObjectLiteral(literal, flags, entry);
+
+    // Check if any constant properties indicate the object should be tracked.
+    if (recordreplay::IsRecordingOrReplaying("emit-opcodes")) {
+      for (int i = 0; i < expr->properties()->length(); i++) {
+        ObjectLiteral::Property* prop = expr->properties()->at(i);
+        if (prop->is_computed_name()) break;
+        if (prop->kind() == ObjectLiteral::Property::CONSTANT &&
+            prop->IsCompileTimeValue()) {
+          Literal* key_lit = prop->key()->AsLiteral();
+          if (key_lit && key_lit->IsStringLiteral() &&
+              RecordReplayTrackThisObjectAssignment(
+                  key_lit->AsRawPropertyName()->to_string())) {
+            builder()->RecordReplayTrackObjectId(literal);
+            break;
+          }
+        }
+      }
+    }
   }
 
   // Store computed values into the literal.
@@ -4849,7 +4917,14 @@ void BytecodeGenerator::BuildReturn(int source_position) {
     builder()->StoreAccumulatorInRegister(result).CallRuntime(
         Runtime::kTraceExit, result);
   }
-  builder()->SetStatementPosition(source_position);
+  builder()->SetStatementPosition(source_position,
+                                  /* record_replay_breakpoint */ false);
+  if (builder()->EmitRecordReplayInstrumentationOpcodes()) {
+    RegisterAllocationScope register_scope(this);
+    Register return_value = register_allocator()->NewRegister();
+    builder()->StoreAccumulatorInRegister(return_value);
+    builder()->RecordReplayInstrumentationReturn("exit", return_value);
+  }
   builder()->Return();
 }
 
@@ -5149,6 +5224,14 @@ void BytecodeGenerator::BuildLoadNamedProperty(const Expression* object_expr,
 void BytecodeGenerator::BuildSetNamedProperty(const Expression* object_expr,
                                               Register object,
                                               const AstRawString* name) {
+  if (recordreplay::IsRecordingOrReplaying("emit-opcodes") &&
+      !record_replay_has_track_this_ &&
+      object_expr->IsThisExpression() &&
+      RecordReplayTrackThisObjectAssignment(name->to_string())) {
+    builder()->RecordReplayTrackObjectId(object);
+    record_replay_has_track_this_ = true;
+  }
+
   Register value;
   if (!execution_result()->IsEffect()) {
     value = register_allocator()->NewRegister();
@@ -6042,6 +6125,8 @@ void BytecodeGenerator::BuildSuspendPoint(int position) {
 
   RegisterList registers = register_allocator()->AllLiveRegisters();
 
+  builder()->RecordReplayInstrumentation("exit");
+
   // Save context, registers, and state. This bytecode then returns the value
   // in the accumulator.
   builder()->SetExpressionPosition(position);
@@ -6053,6 +6138,9 @@ void BytecodeGenerator::BuildSuspendPoint(int position) {
   // Clobbers all registers and sets the accumulator to the
   // [[input_or_debug_pos]] slot of the generator object.
   builder()->ResumeGenerator(generator_object(), registers);
+
+  builder()->RecordReplayOnProgress();
+  builder()->RecordReplayInstrumentationGenerator("entry", generator_object());
 }
 
 void BytecodeGenerator::VisitYield(Yield* expr) {
@@ -6818,6 +6906,8 @@ void BytecodeGenerator::VisitCall(Call* expr) {
     return VisitCallSuper(expr);
   }
 
+  int start_instrumentation_count = builder()->record_replay_instrumentation_site_counter_;
+
   // We compile the call differently depending on the presence of spreads and
   // their positions.
   //
@@ -7019,6 +7109,35 @@ void BytecodeGenerator::VisitCall(Call* expr) {
   }
 
   builder()->SetExpressionPosition(expr);
+
+  // Emit a breakpoint for all call expressions
+  // after arguments have already been evaluated.
+  // This might duplicate the call's parent's position,
+  // so we should try to have it get deduplicated
+  // by inserting it before the call, *if* there are no arguments.
+  //
+  // Example1 (potentially deduped breakpoint):
+  // `/*BREAK1*/func();
+  //
+  // Example2 (extra breakpoint after arguments evaluation):
+  // `/*BREAK1*/func/*BREAK3*/(/*BREAK2*/g());`
+
+  // TODO: Deduplicate property call locations
+  //       NOTE: In this case, `expr->position()` is different from the
+  //             `ExpressionStatement`'s position.
+  //       Example: `/*BREAK1*/o.func/*BREAK2*/();`
+
+  if (expr->call_head_token_position() && start_instrumentation_count != builder()->record_replay_instrumentation_site_counter_) {
+    // Has arguments and visiting them added breakpoints.
+    // Move this to a position that is assured not to conflict with any other
+    // AST node.
+    builder()->RecordReplayInstrumentation("breakpoint", expr->call_head_token_position());
+  } else {
+    // Might have arguments but visiting them didn't add breakpoints.
+    // Add this to a potentially conflicting position, letting it to be deduplicated in such case.
+    // If there is no conflict, a breakpoint will be added.
+    builder()->RecordReplayInstrumentation("breakpoint", expr->position());
+  }
 
   if (use_reflect_apply) {
     builder()->CallJSRuntime(Context::REFLECT_APPLY_INDEX, args);

--- a/src/interpreter/bytecode-generator.cc
+++ b/src/interpreter/bytecode-generator.cc
@@ -2298,10 +2298,6 @@ void BytecodeGenerator::BuildDeclareCall(Runtime::FunctionId id) {
   top_level_builder()->mark_processed();
 }
 
-  // See BuildTryCatch for why we increment the progress counter here.
-  builder()->RecordReplayOnProgress();
-  builder()->RecordReplayAssertValue("BeginFinally");
-
 void BytecodeGenerator::VisitModuleDeclarations(Declaration::List* decls) {
   RegisterAllocationScope register_scope(this);
   for (Declaration* decl : *decls) {
@@ -3091,6 +3087,10 @@ void BytecodeGenerator::BuildTryFinally(
   try_control_builder.LeaveTry();
   try_control_builder.BeginHandler();
   commands.RecordHandlerReThrowPath();
+
+  // See BuildTryCatch for why we increment the progress counter here.
+  builder()->RecordReplayOnProgress();
+  builder()->RecordReplayAssertValue("BeginFinally");
 
   try_control_builder.BeginFinally();
 

--- a/src/interpreter/bytecode-generator.h
+++ b/src/interpreter/bytecode-generator.h
@@ -61,6 +61,9 @@ class BytecodeGenerator final : public AstVisitor<BytecodeGenerator> {
   template <typename IsolateT>
   DirectHandle<TrustedByteArray> FinalizeSourcePositionTable(IsolateT* isolate);
 
+  // [RUN-3317] Shift breakpoint from |stmt| to |expr|, if |expr| exists.
+  void ReplayExpressionShiftedSetStatementPosition(Statement* stmt, Expression* expr);
+
   // Check if hint2 is same or the subtype of hint1.
   static bool IsSameOrSubTypeHint(TypeHint hint1, TypeHint hint2) {
     return hint1 == (hint1 | hint2);
@@ -684,6 +687,11 @@ class BytecodeGenerator final : public AstVisitor<BytecodeGenerator> {
   int suspend_count_;
   // TODO(solanes): assess if we can move loop_depth_ into LoopScope.
   int loop_depth_;
+
+  // Whether we've emitted an opcode to track the 'this' object after
+  // seeing an assignment to one of its properties. This is emitted at
+  // most once per function.
+  bool record_replay_has_track_this_ = false;
 
   // Variables for which hole checks have been emitted in the current basic
   // block. Managed by HoleCheckElisionScope and HoleCheckElisionMergeScope.

--- a/src/interpreter/bytecodes.h
+++ b/src/interpreter/bytecodes.h
@@ -506,6 +506,19 @@ namespace interpreter {
   /* Block Coverage */                                                         \
   V(IncBlockCounter, ImplicitRegisterUse::kNone, OperandType::kCoverageSlot)   \
                                                                                \
+  /* Record Replay */                                                          \
+  V(RecordReplayIncExecutionProgressCounter, ImplicitRegisterUse::kNone)       \
+  V(RecordReplayNotifyActivity, ImplicitRegisterUse::kNone)                    \
+  V(RecordReplayInstrumentation, ImplicitRegisterUse::kNone,                   \
+    OperandType::kIdx)                                                         \
+  V(RecordReplayInstrumentationGenerator, ImplicitRegisterUse::kNone,          \
+    OperandType::kIdx, OperandType::kReg)                                      \
+  V(RecordReplayInstrumentationReturn, ImplicitRegisterUse::kNone,             \
+    OperandType::kIdx, OperandType::kReg)                                      \
+  V(RecordReplayAssertValue, ImplicitRegisterUse::kReadWriteAccumulator,       \
+    OperandType::kIdx)                                                         \
+  V(RecordReplayTrackObjectId, ImplicitRegisterUse::kNone, OperandType::kReg)  \
+                                                                               \
   /* Execution Abort (internal error) */                                       \
   V(Abort, ImplicitRegisterUse::kNone, OperandType::kAbortReason)
 

--- a/src/interpreter/bytecodes.h
+++ b/src/interpreter/bytecodes.h
@@ -510,13 +510,13 @@ namespace interpreter {
   V(RecordReplayIncExecutionProgressCounter, ImplicitRegisterUse::kNone)       \
   V(RecordReplayNotifyActivity, ImplicitRegisterUse::kNone)                    \
   V(RecordReplayInstrumentation, ImplicitRegisterUse::kNone,                   \
-    OperandType::kIdx)                                                         \
+    OperandType::kUImm)                                                         \
   V(RecordReplayInstrumentationGenerator, ImplicitRegisterUse::kNone,          \
-    OperandType::kIdx, OperandType::kReg)                                      \
+    OperandType::kUImm, OperandType::kReg)                                      \
   V(RecordReplayInstrumentationReturn, ImplicitRegisterUse::kNone,             \
-    OperandType::kIdx, OperandType::kReg)                                      \
+    OperandType::kUImm, OperandType::kReg)                                      \
   V(RecordReplayAssertValue, ImplicitRegisterUse::kReadWriteAccumulator,       \
-    OperandType::kIdx)                                                         \
+    OperandType::kUImm)                                                         \
   V(RecordReplayTrackObjectId, ImplicitRegisterUse::kNone, OperandType::kReg)  \
                                                                                \
   /* Execution Abort (internal error) */                                       \

--- a/src/interpreter/interpreter-generator.cc
+++ b/src/interpreter/interpreter-generator.cc
@@ -3239,6 +3239,66 @@ IGNITION_HANDLER(IncBlockCounter, InterpreterAssembler) {
   Dispatch();
 }
 
+IGNITION_HANDLER(RecordReplayIncExecutionProgressCounter, InterpreterAssembler) {
+  TNode<Context> context = GetContext();
+  TNode<Object> closure = LoadRegister(Register::function_closure());
+  CallRuntime(Runtime::kRecordReplayAssertExecutionProgress, context, closure);
+  Dispatch();
+}
+
+IGNITION_HANDLER(RecordReplayNotifyActivity, InterpreterAssembler) {
+  TNode<Context> context = GetContext();
+  CallRuntime(Runtime::kRecordReplayNotifyActivity, context);
+  Dispatch();
+}
+
+IGNITION_HANDLER(RecordReplayInstrumentation, InterpreterAssembler) {
+  TNode<Context> context = GetContext();
+  TNode<Object> closure = LoadRegister(Register::function_closure());
+  TNode<Smi> index = BytecodeOperandIdxSmi(0);
+  CallRuntime(Runtime::kRecordReplayInstrumentation, context, closure, index);
+  Dispatch();
+}
+
+IGNITION_HANDLER(RecordReplayInstrumentationGenerator, InterpreterAssembler) {
+  TNode<Context> context = GetContext();
+  TNode<Object> closure = LoadRegister(Register::function_closure());
+  TNode<Smi> index = BytecodeOperandIdxSmi(0);
+  TNode<Object> generator = LoadRegisterAtOperandIndex(1);
+  CallRuntime(Runtime::kRecordReplayInstrumentationGenerator,
+              context, closure, index, generator);
+  Dispatch();
+}
+
+IGNITION_HANDLER(RecordReplayInstrumentationReturn, InterpreterAssembler) {
+  TNode<Context> context = GetContext();
+  TNode<Object> closure = LoadRegister(Register::function_closure());
+  TNode<Smi> index = BytecodeOperandIdxSmi(0);
+  TNode<Object> return_value = LoadRegisterAtOperandIndex(1);
+  CallRuntime(Runtime::kRecordReplayInstrumentationReturn,
+              context, closure, index, return_value);
+  Dispatch();
+}
+
+IGNITION_HANDLER(RecordReplayAssertValue, InterpreterAssembler) {
+  TNode<Context> context = GetContext();
+  TNode<Object> closure = LoadRegister(Register::function_closure());
+  TNode<Smi> index = BytecodeOperandIdxSmi(0);
+  TNode<Object> value = GetAccumulator();
+  TNode<Object> result = CallRuntime(Runtime::kRecordReplayAssertValue,
+                                     context, closure, index, value);
+  SetAccumulator(result);
+  Dispatch();
+}
+
+IGNITION_HANDLER(RecordReplayTrackObjectId, InterpreterAssembler) {
+  TNode<Context> context = GetContext();
+  TNode<Object> object = LoadRegisterAtOperandIndex(0);
+  CallRuntime(Runtime::kRecordReplayTrackObjectId,
+              context, object);
+  Dispatch();
+}
+
 // ForInEnumerate <receiver>
 //
 // Enumerates the enumerable keys of the |receiver| and either returns the

--- a/src/interpreter/interpreter.cc
+++ b/src/interpreter/interpreter.cc
@@ -305,8 +305,10 @@ InterpreterCompilationJob::Status InterpreterCompilationJob::DoFinalizeJobImpl(
     parse_info()->literal()->set_shared_function_info(
         indirect_handle(shared_info, isolate));
   }
-  CheckAndPrintBytecodeMismatch(
-      isolate, handle(Cast<Script>(shared_info->script()), isolate), bytecodes);
+  // Record/replay instrumentation site indexes will differ when scripts
+  // are recompiled.
+  //CheckAndPrintBytecodeMismatch(
+  //    isolate, handle(Cast<Script>(shared_info->script()), isolate), bytecodes);
 #endif
 
   return SUCCEEDED;

--- a/src/libplatform/tracing/tracing-controller.cc
+++ b/src/libplatform/tracing/tracing-controller.cc
@@ -29,6 +29,8 @@
 #include "src/libplatform/tracing/trace-event-listener.h"
 #endif  // V8_USE_PERFETTO
 
+#include "v8.h"
+
 #ifdef V8_USE_PERFETTO_JSON_EXPORT
 class JsonOutputWriter : public perfetto::trace_processor::json::OutputWriter {
  public:
@@ -139,6 +141,10 @@ uint64_t TracingController::AddTraceEventWithTimestamp(
     const uint64_t* arg_values,
     std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
     unsigned int flags, int64_t timestamp) {
+  // For now we don't support tracing when recording/replaying,
+  // due to non-deterministic behavior it can introduce.
+  recordreplay::InvalidateRecording("Event tracing enabled");
+
   int64_t cpu_now_us = CurrentCpuTimestampMicroseconds();
 
   uint64_t handle = 0;

--- a/src/logging/counters-scopes.h
+++ b/src/logging/counters-scopes.h
@@ -9,6 +9,8 @@
 #include "src/logging/counters.h"
 #include "src/logging/log.h"
 
+#include "replayio.h"
+
 namespace v8 {
 namespace internal {
 
@@ -153,6 +155,8 @@ class V8_NODISCARD NestedTimedHistogramScope : public BaseTimedHistogramScope {
   friend PauseNestedTimedHistogramScope;
 
   void StartInteral() {
+    replayio::AutoPassThroughEvents pt;
+
     previous_scope_ = timed_histogram()->Enter(this);
     base::TimeTicks now = base::TimeTicks::Now();
     if (previous_scope_) previous_scope_->Pause(now);
@@ -160,6 +164,8 @@ class V8_NODISCARD NestedTimedHistogramScope : public BaseTimedHistogramScope {
   }
 
   void StopInternal() {
+    replayio::AutoPassThroughEvents pt;
+
     timed_histogram()->Leave(previous_scope_);
     base::TimeTicks now = base::TimeTicks::Now();
     base::TimeDelta elapsed = timer_.Elapsed(now);

--- a/src/logging/metrics.h
+++ b/src/logging/metrics.h
@@ -13,6 +13,8 @@
 #include "src/base/platform/time.h"
 #include "src/init/v8.h"
 
+#include "replayio.h"
+
 namespace v8 {
 class TaskRunner;
 }  // namespace v8

--- a/src/maglev/maglev-graph-builder.cc
+++ b/src/maglev/maglev-graph-builder.cc
@@ -3383,6 +3383,49 @@ MaybeReduceResult MaglevGraphBuilder::TryReduceTypeOf(
                      RootIndex::kundefined_string);
   }
 
+void MaglevGraphBuilder::VisitRecordReplayIncExecutionProgressCounter() {
+  ValueNode* closure = GetClosure();
+  BuildCallRuntime(Runtime::kRecordReplayAssertExecutionProgress, {closure});
+}
+
+void MaglevGraphBuilder::VisitRecordReplayNotifyActivity() {
+  BuildCallRuntime(Runtime::kRecordReplayNotifyActivity, {});
+}
+
+void MaglevGraphBuilder::VisitRecordReplayInstrumentation() {
+  ValueNode* closure = GetClosure();
+  ValueNode* index = GetSmiConstant(iterator_.GetIndexOperand(0));
+  BuildCallRuntime(Runtime::kRecordReplayInstrumentation, {closure, index});
+}
+
+void MaglevGraphBuilder::VisitRecordReplayInstrumentationGenerator() {
+  ValueNode* closure = GetClosure();
+  ValueNode* index = GetSmiConstant(iterator_.GetIndexOperand(0));
+  ValueNode* generator_object = LoadRegisterTagged(1);
+  BuildCallRuntime(Runtime::kRecordReplayInstrumentationGenerator,
+                   {closure, index, generator_object});
+}
+
+void MaglevGraphBuilder::VisitRecordReplayInstrumentationReturn() {
+  ValueNode* closure = GetClosure();
+  ValueNode* index = GetSmiConstant(iterator_.GetIndexOperand(0));
+  ValueNode* return_value = LoadRegisterTagged(1);
+  BuildCallRuntime(Runtime::kRecordReplayInstrumentationReturn,
+                   {closure, index, return_value});
+}
+
+void MaglevGraphBuilder::VisitRecordReplayAssertValue() {
+  ValueNode* closure = GetClosure();
+  ValueNode* index = GetSmiConstant(iterator_.GetIndexOperand(0));
+  ValueNode* value = GetAccumulatorTagged();
+  BuildCallRuntime(Runtime::kRecordReplayAssertValue, {closure, index, value});
+}
+
+void MaglevGraphBuilder::VisitRecordReplayTrackObjectId() {
+  ValueNode* object = LoadRegisterTagged(0);
+  BuildCallRuntime(Runtime::kRecordReplayTrackObjectId, {object});
+}
+
   return {};
 }
 

--- a/src/maglev/maglev-graph-builder.cc
+++ b/src/maglev/maglev-graph-builder.cc
@@ -3383,49 +3383,6 @@ MaybeReduceResult MaglevGraphBuilder::TryReduceTypeOf(
                      RootIndex::kundefined_string);
   }
 
-void MaglevGraphBuilder::VisitRecordReplayIncExecutionProgressCounter() {
-  ValueNode* closure = GetClosure();
-  BuildCallRuntime(Runtime::kRecordReplayAssertExecutionProgress, {closure});
-}
-
-void MaglevGraphBuilder::VisitRecordReplayNotifyActivity() {
-  BuildCallRuntime(Runtime::kRecordReplayNotifyActivity, {});
-}
-
-void MaglevGraphBuilder::VisitRecordReplayInstrumentation() {
-  ValueNode* closure = GetClosure();
-  ValueNode* index = GetSmiConstant(iterator_.GetIndexOperand(0));
-  BuildCallRuntime(Runtime::kRecordReplayInstrumentation, {closure, index});
-}
-
-void MaglevGraphBuilder::VisitRecordReplayInstrumentationGenerator() {
-  ValueNode* closure = GetClosure();
-  ValueNode* index = GetSmiConstant(iterator_.GetIndexOperand(0));
-  ValueNode* generator_object = LoadRegisterTagged(1);
-  BuildCallRuntime(Runtime::kRecordReplayInstrumentationGenerator,
-                   {closure, index, generator_object});
-}
-
-void MaglevGraphBuilder::VisitRecordReplayInstrumentationReturn() {
-  ValueNode* closure = GetClosure();
-  ValueNode* index = GetSmiConstant(iterator_.GetIndexOperand(0));
-  ValueNode* return_value = LoadRegisterTagged(1);
-  BuildCallRuntime(Runtime::kRecordReplayInstrumentationReturn,
-                   {closure, index, return_value});
-}
-
-void MaglevGraphBuilder::VisitRecordReplayAssertValue() {
-  ValueNode* closure = GetClosure();
-  ValueNode* index = GetSmiConstant(iterator_.GetIndexOperand(0));
-  ValueNode* value = GetAccumulatorTagged();
-  BuildCallRuntime(Runtime::kRecordReplayAssertValue, {closure, index, value});
-}
-
-void MaglevGraphBuilder::VisitRecordReplayTrackObjectId() {
-  ValueNode* object = LoadRegisterTagged(0);
-  BuildCallRuntime(Runtime::kRecordReplayTrackObjectId, {object});
-}
-
   return {};
 }
 
@@ -3434,6 +3391,62 @@ MaybeReduceResult MaglevGraphBuilder::TryReduceTypeOf(ValueNode* value) {
                          [&](TypeOfLiteralFlag _, RootIndex idx) -> ValueNode* {
                            return GetRootConstant(idx);
                          });
+}
+
+ReduceResult MaglevGraphBuilder::VisitRecordReplayIncExecutionProgressCounter() {
+  ValueNode* closure = GetClosure();
+  RETURN_IF_ABORT(
+      BuildCallRuntime(Runtime::kRecordReplayAssertExecutionProgress,
+                       {closure}));
+  return ReduceResult::Done();
+}
+
+ReduceResult MaglevGraphBuilder::VisitRecordReplayNotifyActivity() {
+  RETURN_IF_ABORT(BuildCallRuntime(Runtime::kRecordReplayNotifyActivity, {}));
+  return ReduceResult::Done();
+}
+
+ReduceResult MaglevGraphBuilder::VisitRecordReplayInstrumentation() {
+  ValueNode* closure = GetClosure();
+  ValueNode* index = GetSmiConstant(iterator_.GetUnsignedImmediateOperand(0));
+  RETURN_IF_ABORT(BuildCallRuntime(Runtime::kRecordReplayInstrumentation,
+                                   {closure, index}));
+  return ReduceResult::Done();
+}
+
+ReduceResult MaglevGraphBuilder::VisitRecordReplayInstrumentationGenerator() {
+  ValueNode* closure = GetClosure();
+  ValueNode* index = GetSmiConstant(iterator_.GetUnsignedImmediateOperand(0));
+  ValueNode* generator_object = LoadRegister(1);
+  RETURN_IF_ABORT(
+      BuildCallRuntime(Runtime::kRecordReplayInstrumentationGenerator,
+                       {closure, index, generator_object}));
+  return ReduceResult::Done();
+}
+
+ReduceResult MaglevGraphBuilder::VisitRecordReplayInstrumentationReturn() {
+  ValueNode* closure = GetClosure();
+  ValueNode* index = GetSmiConstant(iterator_.GetUnsignedImmediateOperand(0));
+  ValueNode* return_value = LoadRegister(1);
+  RETURN_IF_ABORT(
+      BuildCallRuntime(Runtime::kRecordReplayInstrumentationReturn,
+                       {closure, index, return_value}));
+  return ReduceResult::Done();
+}
+
+ReduceResult MaglevGraphBuilder::VisitRecordReplayAssertValue() {
+  ValueNode* closure = GetClosure();
+  ValueNode* index = GetSmiConstant(iterator_.GetUnsignedImmediateOperand(0));
+  ValueNode* value = GetAccumulator();
+  return SetAccumulator(BuildCallRuntime(Runtime::kRecordReplayAssertValue,
+                                         {closure, index, value}));
+}
+
+ReduceResult MaglevGraphBuilder::VisitRecordReplayTrackObjectId() {
+  ValueNode* object = LoadRegister(0);
+  RETURN_IF_ABORT(
+      BuildCallRuntime(Runtime::kRecordReplayTrackObjectId, {object}));
+  return ReduceResult::Done();
 }
 
 ReduceResult MaglevGraphBuilder::VisitTestTypeOf() {

--- a/src/numbers/math-random.cc
+++ b/src/numbers/math-random.cc
@@ -4,6 +4,7 @@
 
 #include "src/numbers/math-random.h"
 
+#include "include/v8.h"
 #include "src/base/utils/random-number-generator.h"
 #include "src/common/assert-scope.h"
 #include "src/execution/isolate.h"
@@ -77,7 +78,14 @@ Address MathRandom::InitializeAndMaybeRefillCache(Isolate* isolate,
     // Generate random numbers using xorshift128+.
     uint64_t random =
         base::RandomNumberGenerator::XorShift128(&state.s0, &state.s1);
-    cache->set(i, base::RandomNumberGenerator::ToDouble(random));
+    double v = base::RandomNumberGenerator::ToDouble(random);
+
+    // The RNG can be used at non-deterministic points within the VM,
+    // so we ensure that we're getting the same values whenever refilling
+    // the cache used for Math.random().
+    recordreplay::RecordReplayBytes("MathRandom", &v, sizeof(v));
+
+    cache->set(i, v);
   }
   pod->set(0, state);
 

--- a/src/objects/elements-inl.h
+++ b/src/objects/elements-inl.h
@@ -25,10 +25,10 @@ ElementsAccessor::CollectElementIndices(DirectHandle<JSObject> object,
 inline MaybeHandle<FixedArray> ElementsAccessor::PrependElementIndices(
     Isolate* isolate, DirectHandle<JSObject> object,
     DirectHandle<FixedArray> keys, GetKeysConversion convert,
-    PropertyFilter filter) {
+    PropertyFilter filter, const KeyIterationParams* params) {
   return PrependElementIndices(isolate, object,
                                direct_handle(object->elements(), isolate), keys,
-                               convert, filter);
+                               convert, filter, params);
 }
 
 inline bool ElementsAccessor::HasElement(Isolate* isolate,

--- a/src/objects/elements.cc
+++ b/src/objects/elements.cc
@@ -1453,7 +1453,7 @@ class ElementsAccessorBase : public InternalElementsAccessor {
       // No space for indices.
       // NOTE: We can return |keys| here because it was a temp allocated object
       // when it was passed in.
-      return keys;
+      return indirect_handle(keys, isolate);  // DirectHandle -> MaybeHandle
     }
     // The page size may cap how many element indices fit alongside the property
     // keys; never collect more indices than there is room for.

--- a/src/objects/elements.cc
+++ b/src/objects/elements.cc
@@ -1254,6 +1254,13 @@ class ElementsAccessorBase : public InternalElementsAccessor {
     UNREACHABLE();
   }
 
+    initial_list_length = (size_t)params->PageSize((KeyIterationIndex)initial_list_length);
+    if (*params && initial_list_length <= nof_property_keys) {
+      // No space for indices.
+      // NOTE: We can return |keys| here because it was a temp allocated object when it was passed in.
+      return keys;
+    }
+
   Tagged<Object> CopyElements(Isolate* isolate, DirectHandle<JSAny> source,
                               DirectHandle<JSObject> destination, size_t length,
                               size_t offset) final {
@@ -1375,6 +1382,8 @@ class ElementsAccessorBase : public InternalElementsAccessor {
     PropertyFilter filter = keys->filter();
     Isolate* isolate = keys->isolate();
     Factory* factory = isolate->factory();
+    auto* params = keys->key_iteration_params();
+    auto pageSize = (size_t)params->PageSize((KeyIterationIndex)length);
     for (size_t i = 0; i < length; i++) {
       if (Subclass::HasElementImpl(isolate, *object, i, *backing_store,
                                    filter)) {
@@ -1412,6 +1421,8 @@ class ElementsAccessorBase : public InternalElementsAccessor {
           list->set(insertion_index, *number);
         }
         insertion_index++;
+
+        if (insertion_index == pageSize) break;
       }
     }
     *nof_indices = insertion_index;
@@ -1933,6 +1944,8 @@ class DictionaryElementsAccessor
       }
       elements->set(insertion_index, raw_key);
       insertion_index++;
+
+      if (insertion_index == pageSize) break;
     }
     SortIndices(isolate, elements, insertion_index);
     for (uint32_t i = 0; i < insertion_index; i++) {
@@ -5755,6 +5768,9 @@ class StringWrapperElementsAccessor
       KeyAccumulator* keys) {
     uint32_t length = GetString(*object)->length();
     Factory* factory = keys->isolate()->factory();
+
+    auto* params = keys->key_iteration_params();
+    auto pageSize = (uint32_t)params->PageSize((KeyIterationIndex)length);
     for (uint32_t i = 0; i < length; i++) {
       RETURN_FAILURE_IF_NOT_SUCCESSFUL(
           keys->AddKey(factory->NewNumberFromUint(i)));

--- a/src/objects/elements.cc
+++ b/src/objects/elements.cc
@@ -1254,13 +1254,6 @@ class ElementsAccessorBase : public InternalElementsAccessor {
     UNREACHABLE();
   }
 
-    initial_list_length = (size_t)params->PageSize((KeyIterationIndex)initial_list_length);
-    if (*params && initial_list_length <= nof_property_keys) {
-      // No space for indices.
-      // NOTE: We can return |keys| here because it was a temp allocated object when it was passed in.
-      return keys;
-    }
-
   Tagged<Object> CopyElements(Isolate* isolate, DirectHandle<JSAny> source,
                               DirectHandle<JSObject> destination, size_t length,
                               size_t offset) final {
@@ -1385,6 +1378,7 @@ class ElementsAccessorBase : public InternalElementsAccessor {
     auto* params = keys->key_iteration_params();
     auto pageSize = (size_t)params->PageSize((KeyIterationIndex)length);
     for (size_t i = 0; i < length; i++) {
+      if (i == pageSize) break;
       if (Subclass::HasElementImpl(isolate, *object, i, *backing_store,
                                    filter)) {
         RETURN_FAILURE_IF_NOT_SUCCESSFUL(
@@ -1421,8 +1415,6 @@ class ElementsAccessorBase : public InternalElementsAccessor {
           list->set(insertion_index, *number);
         }
         insertion_index++;
-
-        if (insertion_index == pageSize) break;
       }
     }
     *nof_indices = insertion_index;
@@ -1433,15 +1425,17 @@ class ElementsAccessorBase : public InternalElementsAccessor {
   MaybeHandle<FixedArray> PrependElementIndices(
       Isolate* isolate, DirectHandle<JSObject> object,
       DirectHandle<FixedArrayBase> backing_store, DirectHandle<FixedArray> keys,
-      GetKeysConversion convert, PropertyFilter filter) final {
+      GetKeysConversion convert, PropertyFilter filter,
+      const KeyIterationParams* params) final {
     return Subclass::PrependElementIndicesImpl(isolate, object, backing_store,
-                                               keys, convert, filter);
+                                               keys, convert, filter, params);
   }
 
   static MaybeHandle<FixedArray> PrependElementIndicesImpl(
       Isolate* isolate, DirectHandle<JSObject> object,
       DirectHandle<FixedArrayBase> backing_store, DirectHandle<FixedArray> keys,
-      GetKeysConversion convert, PropertyFilter filter) {
+      GetKeysConversion convert, PropertyFilter filter,
+      const KeyIterationParams* params = KeyIterationParams::Default()) {
     uint32_t nof_property_keys = keys->ulength().value();
     size_t nof_elements_szt =
         Subclass::GetMaxNumberOfEntries(isolate, *object, *backing_store);
@@ -1452,6 +1446,20 @@ class ElementsAccessorBase : public InternalElementsAccessor {
     }
     uint32_t nof_elements = static_cast<uint32_t>(nof_elements_szt);
     uint32_t initial_list_length = nof_elements + nof_property_keys;
+
+    initial_list_length =
+        (uint32_t)params->PageSize((KeyIterationIndex)initial_list_length);
+    if (*params && initial_list_length <= nof_property_keys) {
+      // No space for indices.
+      // NOTE: We can return |keys| here because it was a temp allocated object
+      // when it was passed in.
+      return keys;
+    }
+    // The page size may cap how many element indices fit alongside the property
+    // keys; never collect more indices than there is room for.
+    if (initial_list_length - nof_property_keys < nof_elements) {
+      nof_elements = initial_list_length - nof_property_keys;
+    }
 
     // Collect the element indices into a new list.
     DCHECK_LE(initial_list_length, std::numeric_limits<int>::max());
@@ -1932,6 +1940,9 @@ class DictionaryElementsAccessor
     uint32_t insertion_index = 0;
     PropertyFilter filter = keys->filter();
     ReadOnlyRoots roots(isolate);
+    auto* params = keys->key_iteration_params();
+    auto pageSize = (uint32_t)params->PageSize((KeyIterationIndex)
+        GetMaxNumberOfEntries(isolate, *object, *backing_store));
     for (InternalIndex i : dictionary->IterateEntries()) {
       AllowGarbageCollection allow_gc;
       Tagged<Object> raw_key = dictionary->KeyAt(i);
@@ -5772,6 +5783,7 @@ class StringWrapperElementsAccessor
     auto* params = keys->key_iteration_params();
     auto pageSize = (uint32_t)params->PageSize((KeyIterationIndex)length);
     for (uint32_t i = 0; i < length; i++) {
+      if (i == pageSize) break;
       RETURN_FAILURE_IF_NOT_SUCCESSFUL(
           keys->AddKey(factory->NewNumberFromUint(i)));
     }

--- a/src/objects/elements.h
+++ b/src/objects/elements.h
@@ -99,12 +99,14 @@ class ElementsAccessor {
   virtual MaybeHandle<FixedArray> PrependElementIndices(
       Isolate* isolate, DirectHandle<JSObject> object,
       DirectHandle<FixedArrayBase> backing_store, DirectHandle<FixedArray> keys,
-      GetKeysConversion convert, PropertyFilter filter = ALL_PROPERTIES) = 0;
+      GetKeysConversion convert, PropertyFilter filter = ALL_PROPERTIES,
+      const KeyIterationParams* params = KeyIterationParams::Default()) = 0;
 
   inline MaybeHandle<FixedArray> PrependElementIndices(
       Isolate* isolate, DirectHandle<JSObject> object,
       DirectHandle<FixedArray> keys, GetKeysConversion convert,
-      PropertyFilter filter = ALL_PROPERTIES);
+      PropertyFilter filter = ALL_PROPERTIES,
+      const KeyIterationParams* params = KeyIterationParams::Default());
 
   V8_WARN_UNUSED_RESULT virtual ExceptionStatus AddElementsToKeyAccumulator(
       DirectHandle<JSObject> receiver, KeyAccumulator* accumulator,

--- a/src/objects/js-objects-inl.h
+++ b/src/objects/js-objects-inl.h
@@ -857,6 +857,13 @@ void JSMessageObject::set_raw_type(int value) {
   message_type_.store(this, Smi::FromInt(value));
 }
 
+int JSMessageObject::record_replay_bookmark() const {
+  return record_replay_bookmark_.load().value();
+}
+void JSMessageObject::set_record_replay_bookmark(int value) {
+  record_replay_bookmark_.store(this, Smi::FromInt(value));
+}
+
 Tagged<Object> JSMessageObject::argument() const { return argument_.load(); }
 void JSMessageObject::set_argument(Tagged<Object> value,
                                    WriteBarrierMode mode) {

--- a/src/objects/js-objects.cc
+++ b/src/objects/js-objects.cc
@@ -815,7 +815,6 @@ Maybe<PropertyAttributes> JSReceiver::GetPropertyAttributes(
     UNREACHABLE();
   }
 }
-
 namespace {
 
 Tagged<JSReceiver::PropertiesOrHash> SetHashAndUpdateProperties(
@@ -5528,6 +5527,8 @@ static bool ShouldConvertToFastElements(Tagged<JSObject> object,
 
   // Adding a property with this index will require slow elements.
   if (index >= static_cast<uint32_t>(Smi::kMaxValue)) return false;
+
+  recordreplay::Assert("[RUN-1675-1826] JSDate::CurrentTimeValue");
 
   if (IsJSArray(object)) {
     Tagged<Object> length = Cast<JSArray>(object)->length();

--- a/src/objects/js-objects.h
+++ b/src/objects/js-objects.h
@@ -1473,6 +1473,10 @@ V8_OBJECT class JSMessageObject : public JSObject {
 
   class BodyDescriptor;
 
+  // when recording/replaying, a bookmark for the point where the message's
+  // exception was thrown.
+  DECL_INT_ACCESSORS(record_replay_bookmark)
+
  private:
   friend class Factory;
 

--- a/src/objects/js-objects.h
+++ b/src/objects/js-objects.h
@@ -1517,6 +1517,10 @@ V8_OBJECT class JSMessageObject : public JSObject {
   TaggedMember<Smi> start_position_;
   TaggedMember<Smi> end_position_;
   TaggedMember<Smi> error_level_;
+  // record/replay: matches js-objects.tq's trailing `record_replay_bookmark: Smi`
+  // field (JSMessageObject is a @cppObjectLayoutDefinition, so the backing member
+  // must be declared by hand). Backs DECL_INT_ACCESSORS(record_replay_bookmark).
+  TaggedMember<Smi> record_replay_bookmark_;
 } V8_OBJECT_END;
 
 // The [Async-from-Sync Iterator] object

--- a/src/objects/js-objects.tq
+++ b/src/objects/js-objects.tq
@@ -174,6 +174,7 @@ extern class JSMessageObject extends JSObject {
   start_position: Smi;
   end_position: Smi;
   error_level: Smi;
+  record_replay_bookmark: Smi;
 }
 
 @cppObjectLayoutDefinition

--- a/src/objects/keys.cc
+++ b/src/objects/keys.cc
@@ -98,9 +98,10 @@ static Handle<FixedArray> CombineKeys(Isolate* isolate,
 MaybeHandle<FixedArray> KeyAccumulator::GetKeys(
     Isolate* isolate, DirectHandle<JSReceiver> object, KeyCollectionMode mode,
     PropertyFilter filter, GetKeysConversion keys_conversion, bool is_for_in,
-    bool skip_indices) {
+    bool skip_indices,
+    const KeyIterationParams* params) {
   FastKeyAccumulator accumulator(isolate, object, mode, filter, is_for_in,
-                                 skip_indices);
+                                 skip_indices, params);
   return accumulator.GetKeys(keys_conversion);
 }
 
@@ -401,7 +402,8 @@ Handle<FixedArray> GetFastEnumPropertyKeys(Isolate* isolate,
   // Check if the {map} has a valid enum length, which implies that it
   // must have a valid enum cache as well.
   int enum_length = map->EnumLength();
-  if (enum_length != kInvalidEnumCacheSentinel) {
+  // Ignore cache in case of custom params.
+  if (enum_length != kInvalidEnumCacheSentinel && !*params) {
     DCHECK(map->OnlyHasSimpleProperties());
     DCHECK_GE(enum_length, 0);
     DCHECK_LE(static_cast<uint32_t>(enum_length), keys->ulength().value());
@@ -446,7 +448,7 @@ MaybeHandle<FixedArray> GetOwnKeysWithElements(Isolate* isolate,
   } else {
     ElementsAccessor* accessor = object->GetElementsAccessor();
     result = accessor->PrependElementIndices(isolate, object, keys, convert,
-                                             ONLY_ENUMERABLE);
+                                             ONLY_ENUMERABLE, params);
   }
 
   if (v8_flags.trace_for_in_enumerate) {
@@ -518,7 +520,6 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysFast(
   if (!own_only || IsCustomElementsReceiverMap(map)) {
     return MaybeHandle<FixedArray>();
   }
-
   // From this point on we are certain to only collect own keys.
   DCHECK(IsJSObject(*receiver_));
   DirectHandle<JSObject> object = Cast<JSObject>(receiver_);
@@ -545,7 +546,7 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysFast(
   // The properties-only case failed because there were probably elements on the
   // receiver.
   return GetOwnKeysWithElements<true>(isolate_, object, keys_conversion,
-                                      skip_indices_);
+                                      skip_indices_, key_iteration_params_);
 }
 
 // static
@@ -630,7 +631,8 @@ FastKeyAccumulator::GetOwnKeysWithUninitializedEnumLength() {
   }
   // We have no elements but possibly enumerable property keys, hence we can
   // directly initialize the enum cache.
-  Handle<FixedArray> keys = GetFastEnumPropertyKeys(isolate_, object);
+  Handle<FixedArray> keys =
+      GetFastEnumPropertyKeys(isolate_, object, key_iteration_params_);
   if (is_for_in_) return keys;
   // Do not leak the enum cache as it might end up as an elements backing store.
   return isolate_->factory()->CopyFixedArray(keys);
@@ -645,6 +647,7 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysSlow(
   accumulator.set_may_have_elements(may_have_elements_);
   accumulator.set_first_prototype_map(first_prototype_map_);
   accumulator.set_try_prototype_info_cache(try_prototype_info_cache_);
+  accumulator.set_key_iteration_params(key_iteration_params_);
 
   MAYBE_RETURN(accumulator.CollectKeys(receiver_, receiver_),
                MaybeHandle<FixedArray>());
@@ -684,6 +687,7 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysWithPrototypeInfoCache(
     accumulator.set_receiver(receiver_);
     accumulator.set_first_prototype_map(first_prototype_map_);
     accumulator.set_try_prototype_info_cache(try_prototype_info_cache_);
+    accumulator.set_key_iteration_params(key_iteration_params_);
     MAYBE_RETURN(accumulator.CollectKeys(first_prototype_, first_prototype_),
                  MaybeHandle<FixedArray>());
     prototype_chain_keys = accumulator.GetKeys(keys_conversion);
@@ -698,7 +702,6 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysWithPrototypeInfoCache(
   }
   return result;
 }
-
 bool FastKeyAccumulator::MayHaveElements(Tagged<JSReceiver> receiver) {
   if (!IsJSObject(receiver)) {
 #if V8_ENABLE_WEBASSEMBLY
@@ -927,6 +930,9 @@ void CommonCopyEnumKeysTo(Isolate* isolate, DirectHandle<Dictionary> dictionary,
     }
     properties++;
     if (mode == KeyCollectionMode::kOwnOnly && properties == length) break;
+
+    // NOTE: length has been capped by pageSize up the stack.
+    if (properties == length) break;
   }
 
   CHECK_EQ(length, properties);
@@ -938,11 +944,12 @@ void CommonCopyEnumKeysTo(Isolate* isolate, DirectHandle<Dictionary> dictionary,
 template <typename Dictionary>
 void CopyEnumKeysTo(Isolate* isolate, DirectHandle<Dictionary> dictionary,
                     DirectHandle<FixedArray> storage, KeyCollectionMode mode,
-                    KeyAccumulator* accumulator) {
+                    KeyAccumulator* accumulator,
+                    const KeyIterationParams* params) {
   static_assert(!Dictionary::kIsOrderedDictionaryType);
 
   CommonCopyEnumKeysTo<Dictionary>(isolate, dictionary, storage, mode,
-                                   accumulator);
+                                   accumulator, params);
 
   const uint32_t length = storage->ulength().value();
 
@@ -964,9 +971,10 @@ template <>
 void CopyEnumKeysTo(Isolate* isolate,
                     DirectHandle<SwissNameDictionary> dictionary,
                     DirectHandle<FixedArray> storage, KeyCollectionMode mode,
-                    KeyAccumulator* accumulator) {
+                    KeyAccumulator* accumulator,
+                    const KeyIterationParams* params) {
   CommonCopyEnumKeysTo<SwissNameDictionary>(isolate, dictionary, storage, mode,
-                                            accumulator);
+                                            accumulator, params);
 
   // No need to sort, as CommonCopyEnumKeysTo on OrderedNameDictionary
   // adds entries to |storage| in the dict's insertion order
@@ -1019,6 +1027,8 @@ ExceptionStatus CollectKeysFromDictionary(DirectHandle<Dictionary> dictionary,
       // TODO(emrich): consider storing keys instead of indices into the array
       // in case of ordered dictionary type.
       array->set(array_size++, Smi::FromInt(i.as_int()));
+
+      if (array_size == numberOfElements) break;
     }
     if (!Dictionary::kIsOrderedDictionaryType) {
       // Sorting only needed if it's an unordered dictionary,
@@ -1062,7 +1072,8 @@ Maybe<bool> KeyAccumulator::CollectOwnPropertyNames(
   if (filter_ == ENUMERABLE_STRINGS) {
     DirectHandle<FixedArray> enum_keys;
     if (object->HasFastProperties()) {
-      enum_keys = KeyAccumulator::GetOwnEnumPropertyKeys(isolate_, object);
+      enum_keys = KeyAccumulator::GetOwnEnumPropertyKeys(isolate_, object,
+                                                         key_iteration_params_);
       // If the number of properties equals the length of enumerable properties
       // we do not have to filter out non-enumerable ones
       Tagged<Map> map = object->map();

--- a/src/objects/keys.cc
+++ b/src/objects/keys.cc
@@ -393,8 +393,9 @@ Handle<FixedArray> ReduceFixedArrayTo(Isolate* isolate,
 
 // Initializes and directly returns the enum cache. Users of this function
 // have to make sure to never directly leak the enum cache.
-Handle<FixedArray> GetFastEnumPropertyKeys(Isolate* isolate,
-                                           DirectHandle<JSObject> object) {
+Handle<FixedArray> GetFastEnumPropertyKeys(
+    Isolate* isolate, DirectHandle<JSObject> object,
+    const KeyIterationParams* params = KeyIterationParams::Default()) {
   DirectHandle<Map> map(object->map(), isolate);
   Handle<FixedArray> keys(map->instance_descriptors()->enum_cache()->keys(),
                           isolate);
@@ -430,16 +431,16 @@ Handle<FixedArray> GetFastEnumPropertyKeys(Isolate* isolate,
 }
 
 template <bool fast_properties>
-MaybeHandle<FixedArray> GetOwnKeysWithElements(Isolate* isolate,
-                                               DirectHandle<JSObject> object,
-                                               GetKeysConversion convert,
-                                               bool skip_indices) {
+MaybeHandle<FixedArray> GetOwnKeysWithElements(
+    Isolate* isolate, DirectHandle<JSObject> object, GetKeysConversion convert,
+    bool skip_indices,
+    const KeyIterationParams* params = KeyIterationParams::Default()) {
   Handle<FixedArray> keys;
   if (fast_properties) {
-    keys = GetFastEnumPropertyKeys(isolate, object);
+    keys = GetFastEnumPropertyKeys(isolate, object, params);
   } else {
     // TODO(cbruni): preallocate big enough array to also hold elements.
-    keys = KeyAccumulator::GetOwnEnumPropertyKeys(isolate, object);
+    keys = KeyAccumulator::GetOwnEnumPropertyKeys(isolate, object, params);
   }
 
   MaybeHandle<FixedArray> result;
@@ -527,7 +528,7 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysFast(
   // Do not try to use the enum-cache for dict-mode objects.
   if (map->is_dictionary_map()) {
     return GetOwnKeysWithElements<false>(isolate_, object, keys_conversion,
-                                         skip_indices_);
+                                         skip_indices_, key_iteration_params_);
   }
   int enum_length = receiver_->map()->EnumLength();
   if (enum_length == kInvalidEnumCacheSentinel) {
@@ -661,15 +662,17 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysWithPrototypeInfoCache(
     MaybeHandle<FixedArray> maybe_own_keys;
     if (receiver_->map()->is_dictionary_map()) {
       maybe_own_keys = GetOwnKeysWithElements<false>(
-          isolate_, Cast<JSObject>(receiver_), keys_conversion, skip_indices_);
+          isolate_, Cast<JSObject>(receiver_), keys_conversion, skip_indices_,
+          key_iteration_params_);
     } else {
       maybe_own_keys = GetOwnKeysWithElements<true>(
-          isolate_, Cast<JSObject>(receiver_), keys_conversion, skip_indices_);
+          isolate_, Cast<JSObject>(receiver_), keys_conversion, skip_indices_,
+          key_iteration_params_);
     }
     ASSIGN_RETURN_ON_EXCEPTION(isolate_, own_keys, maybe_own_keys);
   } else {
     own_keys = KeyAccumulator::GetOwnEnumPropertyKeys(
-        isolate_, Cast<JSObject>(receiver_));
+        isolate_, Cast<JSObject>(receiver_), key_iteration_params_);
   }
   Handle<FixedArray> prototype_chain_keys;
   if (has_prototype_info_cache_) {
@@ -893,7 +896,8 @@ std::optional<int> CollectOwnPropertyNamesInternal(
 template <typename Dictionary>
 void CommonCopyEnumKeysTo(Isolate* isolate, DirectHandle<Dictionary> dictionary,
                           DirectHandle<FixedArray> storage,
-                          KeyCollectionMode mode, KeyAccumulator* accumulator) {
+                          KeyCollectionMode mode, KeyAccumulator* accumulator,
+                          const KeyIterationParams* params) {
   DCHECK_IMPLIES(mode != KeyCollectionMode::kOwnOnly, accumulator != nullptr);
   const uint32_t length = storage->ulength().value();
   uint32_t properties = 0;
@@ -985,14 +989,15 @@ void CopyEnumKeysTo(Isolate* isolate,
 template <class T>
 Handle<FixedArray> GetOwnEnumPropertyDictionaryKeys(
     Isolate* isolate, KeyCollectionMode mode, KeyAccumulator* accumulator,
-    DirectHandle<JSObject> object, Tagged<T> raw_dictionary) {
+    DirectHandle<JSObject> object, Tagged<T> raw_dictionary,
+    const KeyIterationParams* params = KeyIterationParams::Default()) {
   DirectHandle<T> dictionary(raw_dictionary, isolate);
   if (dictionary->NumberOfElements() == 0) {
     return isolate->factory()->empty_fixed_array();
   }
   int length = dictionary->NumberOfEnumerableProperties();
   Handle<FixedArray> storage = isolate->factory()->NewFixedArray(length);
-  CopyEnumKeysTo(isolate, dictionary, storage, mode, accumulator);
+  CopyEnumKeysTo(isolate, dictionary, storage, mode, accumulator, params);
   return storage;
 }
 
@@ -1004,8 +1009,9 @@ ExceptionStatus CollectKeysFromDictionary(DirectHandle<Dictionary> dictionary,
   Isolate* isolate = keys->isolate();
   ReadOnlyRoots roots(isolate);
   // TODO(jkummerow): Consider using a std::unique_ptr<InternalIndex[]> instead.
+  int number_of_elements = dictionary->NumberOfElements();
   DirectHandle<FixedArray> array =
-      isolate->factory()->NewFixedArray(dictionary->NumberOfElements());
+      isolate->factory()->NewFixedArray(number_of_elements);
   int array_size = 0;
   PropertyFilter filter = keys->filter();
   // Handle enumerable strings in CopyEnumKeysTo.
@@ -1028,7 +1034,7 @@ ExceptionStatus CollectKeysFromDictionary(DirectHandle<Dictionary> dictionary,
       // in case of ordered dictionary type.
       array->set(array_size++, Smi::FromInt(i.as_int()));
 
-      if (array_size == numberOfElements) break;
+      if (array_size == number_of_elements) break;
     }
     if (!Dictionary::kIsOrderedDictionaryType) {
       // Sorting only needed if it's an unordered dictionary,
@@ -1094,13 +1100,16 @@ Maybe<bool> KeyAccumulator::CollectOwnPropertyNames(
     } else if (IsJSGlobalObject(*object)) {
       enum_keys = GetOwnEnumPropertyDictionaryKeys(
           isolate_, mode_, this, object,
-          Cast<JSGlobalObject>(*object)->global_dictionary(kAcquireLoad));
+          Cast<JSGlobalObject>(*object)->global_dictionary(kAcquireLoad),
+          key_iteration_params_);
     } else if (V8_ENABLE_SWISS_NAME_DICTIONARY_BOOL) {
       enum_keys = GetOwnEnumPropertyDictionaryKeys(
-          isolate_, mode_, this, object, object->property_dictionary_swiss());
+          isolate_, mode_, this, object, object->property_dictionary_swiss(),
+          key_iteration_params_);
     } else {
       enum_keys = GetOwnEnumPropertyDictionaryKeys(
-          isolate_, mode_, this, object, object->property_dictionary());
+          isolate_, mode_, this, object, object->property_dictionary(),
+          key_iteration_params_);
     }
     if (IsJSModuleNamespace(*object)) {
       // Simulate [[GetOwnProperty]] for establishing enumerability, which
@@ -1247,21 +1256,22 @@ Maybe<bool> KeyAccumulator::CollectOwnKeys(DirectHandle<JSObject> object) {
 
 // static
 Handle<FixedArray> KeyAccumulator::GetOwnEnumPropertyKeys(
-    Isolate* isolate, DirectHandle<JSObject> object) {
+    Isolate* isolate, DirectHandle<JSObject> object,
+    const KeyIterationParams* params) {
   if (object->HasFastProperties()) {
-    return GetFastEnumPropertyKeys(isolate, object);
+    return GetFastEnumPropertyKeys(isolate, object, params);
   } else if (IsJSGlobalObject(*object)) {
     return GetOwnEnumPropertyDictionaryKeys(
         isolate, KeyCollectionMode::kOwnOnly, nullptr, object,
-        Cast<JSGlobalObject>(*object)->global_dictionary(kAcquireLoad));
+        Cast<JSGlobalObject>(*object)->global_dictionary(kAcquireLoad), params);
   } else if (V8_ENABLE_SWISS_NAME_DICTIONARY_BOOL) {
     return GetOwnEnumPropertyDictionaryKeys(
         isolate, KeyCollectionMode::kOwnOnly, nullptr, object,
-        object->property_dictionary_swiss());
+        object->property_dictionary_swiss(), params);
   } else {
     return GetOwnEnumPropertyDictionaryKeys(
         isolate, KeyCollectionMode::kOwnOnly, nullptr, object,
-        object->property_dictionary());
+        object->property_dictionary(), params);
   }
 }
 

--- a/src/objects/keys.h
+++ b/src/objects/keys.h
@@ -74,7 +74,8 @@ class KeyAccumulator final {
   // Does not throw for uninitialized exports in module namespace objects, so
   // this has to be checked separately.
   static Handle<FixedArray> GetOwnEnumPropertyKeys(
-      Isolate* isolate, DirectHandle<JSObject> object);
+      Isolate* isolate, DirectHandle<JSObject> object,
+      const KeyIterationParams* params = KeyIterationParams::Default());
 
   V8_WARN_UNUSED_RESULT ExceptionStatus
   AddKey(Tagged<Object> key, AddKeyConversion convert = DO_NOT_CONVERT);
@@ -189,13 +190,16 @@ class FastKeyAccumulator {
  public:
   FastKeyAccumulator(Isolate* isolate, DirectHandle<JSReceiver> receiver,
                      KeyCollectionMode mode, PropertyFilter filter,
-                     bool is_for_in = false, bool skip_indices = false)
+                     bool is_for_in = false, bool skip_indices = false,
+                     const KeyIterationParams* params =
+                         KeyIterationParams::Default())
       : isolate_(isolate),
         receiver_(receiver),
         mode_(mode),
         filter_(filter),
         is_for_in_(is_for_in),
-        skip_indices_(skip_indices) {
+        skip_indices_(skip_indices),
+        key_iteration_params_(params) {
     Prepare();
   }
   FastKeyAccumulator(const FastKeyAccumulator&) = delete;

--- a/src/objects/keys.h
+++ b/src/objects/keys.h
@@ -61,7 +61,8 @@ class KeyAccumulator final {
       Isolate* isolate, DirectHandle<JSReceiver> object, KeyCollectionMode mode,
       PropertyFilter filter,
       GetKeysConversion keys_conversion = GetKeysConversion::kKeepNumbers,
-      bool is_for_in = false, bool skip_indices = false);
+      bool is_for_in = false, bool skip_indices = false,
+      const KeyIterationParams* params = KeyIterationParams::Default());
 
   Handle<FixedArray> GetKeys(
       GetKeysConversion convert = GetKeysConversion::kKeepNumbers);
@@ -88,6 +89,11 @@ class KeyAccumulator final {
   // The collection mode defines whether we collect the keys from the prototype
   // chain or only look at the receiver.
   KeyCollectionMode mode() { return mode_; }
+
+  const KeyIterationParams* key_iteration_params() const {
+    return key_iteration_params_;
+  }
+
   void set_skip_indices(bool value) { skip_indices_ = value; }
   // Shadowing keys are used to filter keys. This happens when non-enumerable
   // keys appear again on the prototype chain.
@@ -151,6 +157,9 @@ class KeyAccumulator final {
     last_non_empty_prototype_ = object;
   }
   void set_may_have_elements(bool value) { may_have_elements_ = value; }
+  void set_key_iteration_params(const KeyIterationParams* params) {
+    key_iteration_params_ = params;
+  }
 
   Isolate* isolate_;
   Handle<OrderedHashSet> keys_;
@@ -167,6 +176,7 @@ class KeyAccumulator final {
   bool skip_shadow_check_ = true;
   bool may_have_elements_ = true;
   bool try_prototype_info_cache_ = false;
+  const KeyIterationParams* key_iteration_params_ = KeyIterationParams::Default();
 
   friend FastKeyAccumulator;
 };
@@ -212,10 +222,11 @@ class FastKeyAccumulator {
       Isolate* isolate, DirectHandle<Map> map, int enum_length,
       AllocationType allocation = AllocationType::kOld);
 
+  MaybeHandle<FixedArray> GetKeysSlow(GetKeysConversion convert);
+
  private:
   void Prepare();
   MaybeHandle<FixedArray> GetKeysFast(GetKeysConversion convert);
-  MaybeHandle<FixedArray> GetKeysSlow(GetKeysConversion convert);
   MaybeHandle<FixedArray> GetKeysWithPrototypeInfoCache(
       GetKeysConversion convert);
 
@@ -239,6 +250,8 @@ class FastKeyAccumulator {
   bool has_prototype_info_cache_ = false;
   bool try_prototype_info_cache_ = false;
   bool only_own_has_simple_elements_ = false;
+  const KeyIterationParams* key_iteration_params_ =
+      KeyIterationParams::Default();
 };
 
 }  // namespace internal

--- a/src/objects/objects.cc
+++ b/src/objects/objects.cc
@@ -4775,6 +4775,13 @@ Handle<Object> JSPromise::Reject(DirectHandle<JSPromise> promise,
                                  PromiseReaction::kReject);
 }
 
+// record/replay: defined in debug.cc; declared here so the promise-adoption hook
+// relocated into JSPromise::Resolve below can see them (the original decls are
+// later in this file, after the use).
+extern bool RecordReplayShouldCallOnPromiseHook();
+void AddPromiseDependencyGraphAdoption(Isolate* isolate, Handle<Object> promise,
+                                       Handle<Object> adoption);
+
 // https://tc39.es/ecma262/#sec-promise-resolve-functions
 // static
 MaybeHandle<Object> JSPromise::Resolve(DirectHandle<JSPromise> promise,

--- a/src/objects/objects.cc
+++ b/src/objects/objects.cc
@@ -4863,6 +4863,13 @@ MaybeHandle<Object> JSPromise::Resolve(DirectHandle<JSPromise> promise,
       isolate->factory()->NewPromiseResolveThenableJobTask(
           promise, resolution_recv, Cast<JSReceiver>(then_action),
           then_context);
+  if (RecordReplayShouldCallOnPromiseHook()) {
+    // Fulfillment of this promise is delayed by adopted resolution.
+    // Ref: Promise/A+ 2.3.2
+    AddPromiseDependencyGraphAdoption(
+        isolate, indirect_handle(Cast<Object>(promise), isolate),
+        indirect_handle(Cast<Object>(resolution_recv), isolate));
+  }
   if (isolate->debug()->is_active() && IsJSPromise(*resolution_recv)) {
     // Mark the dependency of the new {promise} on the {resolution}.
     Object::SetProperty(isolate, resolution_recv,
@@ -5642,12 +5649,6 @@ HandleType<Derived>::MaybeType BaseNameDictionary<Derived, Shape>::Add(
   dictionary->set_next_enumeration_index(index + 1);
   return dictionary;
 }
-
-  if (RecordReplayShouldCallOnPromiseHook()) {
-    // Fulfillment of this promise is delayed by adopted resolution.
-    // Ref: Promise/A+ 2.3.2
-    AddPromiseDependencyGraphAdoption(isolate, Handle<Object>::cast(promise), resolution);
-  }
 
 template <typename Derived, typename Shape>
 template <typename IsolateT, template <typename> typename HandleType,

--- a/src/objects/objects.cc
+++ b/src/objects/objects.cc
@@ -98,6 +98,8 @@
 #include "src/wasm/wasm-objects-inl.h"
 #endif  // V8_ENABLE_WEBASSEMBLY
 
+#include "src/base/replayio.h"
+
 #ifdef V8_INTL_SUPPORT
 #include "src/objects/js-break-iterator.h"
 #include "src/objects/js-collator.h"
@@ -4764,7 +4766,8 @@ Handle<Object> JSPromise::Reject(DirectHandle<JSPromise> promise,
   // 7. If promise.[[PromiseIsHandled]] is false, perform
   //    HostPromiseRejectionTracker(promise, "reject").
   if (!promise->has_handler()) {
-    isolate->ReportPromiseReject(promise, reason, kPromiseRejectWithNoHandler);
+    isolate->ReportPromiseReject(promise, reason,
+                                 kPromiseRejectWithNoHandler);
   }
 
   // 8. Return TriggerPromiseReactions(reactions, reason).
@@ -5473,6 +5476,10 @@ Handle<RegisteredSymbolTable> RegisteredSymbolTable::Add(
   return table;
 }
 
+
+extern bool RecordReplayShouldCallOnPromiseHook();
+void AddPromiseDependencyGraphAdoption(Isolate* isolate, Handle<Object> promise, Handle<Object> adoption);
+
 template <typename Derived, typename Shape>
 template <typename IsolateT>
 Handle<Derived> BaseNameDictionary<Derived, Shape>::New(
@@ -5635,6 +5642,12 @@ HandleType<Derived>::MaybeType BaseNameDictionary<Derived, Shape>::Add(
   dictionary->set_next_enumeration_index(index + 1);
   return dictionary;
 }
+
+  if (RecordReplayShouldCallOnPromiseHook()) {
+    // Fulfillment of this promise is delayed by adopted resolution.
+    // Ref: Promise/A+ 2.3.2
+    AddPromiseDependencyGraphAdoption(isolate, Handle<Object>::cast(promise), resolution);
+  }
 
 template <typename Derived, typename Shape>
 template <typename IsolateT, template <typename> typename HandleType,

--- a/src/objects/value-serializer.cc
+++ b/src/objects/value-serializer.cc
@@ -586,15 +586,16 @@ void ValueSerializer::WriteString(DirectHandle<String> string) {
     // replaying due to JIT and other VM behavior. Only write out strings
     // as two bytes to ensure serialized buffers have a consistent size.
     if (recordreplay::IsRecordingOrReplaying("values", "ValueSerializer::WriteString")) {
-      base::ScopedVector<base::uc16> new_chars(chars.length());
+      base::OwnedVector<base::uc16> new_chars =
+          base::OwnedVector<base::uc16>::New(chars.length());
       for (int i = 0; i < chars.length(); i++)
         new_chars[i] = chars[i];
-      uint32_t byte_length = new_chars.length() * sizeof(base::uc16);
+      uint32_t byte_length = new_chars.size() * sizeof(base::uc16);
       // The existing reading code expects 16-byte strings to be aligned.
       if ((buffer_size_ + 1 + BytesNeededForVarint(byte_length)) & 1)
         WriteTag(SerializationTag::kPadding);
       WriteTag(SerializationTag::kTwoByteString);
-      WriteTwoByteString(new_chars);
+      WriteTwoByteString(new_chars.as_vector());
     } else {
       WriteTag(SerializationTag::kOneByteString);
       WriteOneByteString(chars);

--- a/src/objects/value-serializer.cc
+++ b/src/objects/value-serializer.cc
@@ -1144,6 +1144,16 @@ Maybe<bool> ValueSerializer::WriteJSArrayBufferView(
   return ThrowIfOutOfMemory();
 }
 
+// FIXME surely there is a utility somewhere we can use instead?
+inline int HashBytes(const void* aPtr, size_t aSize) {
+  int hash = 0;
+  uint8_t* ptr = (uint8_t*)aPtr;
+  for (size_t i = 0; i < aSize; i++) {
+    hash = (((hash << 5) - hash) + ptr[i]) | 0;
+  }
+  return hash;
+}
+
 Maybe<bool> ValueSerializer::WriteJSError(DirectHandle<JSObject> error) {
   DirectHandle<Object> stack;
   PropertyDescriptor message_desc;
@@ -1165,16 +1175,6 @@ Maybe<bool> ValueSerializer::WriteJSError(DirectHandle<JSObject> error) {
   if (!Object::ToString(isolate_, name_object).ToHandle(&name)) {
     return Nothing<bool>();
   }
-
-// FIXME surely there is a utility somewhere we can use instead?
-inline int HashBytes(const void* aPtr, size_t aSize) {
-  int hash = 0;
-  uint8_t* ptr = (uint8_t*)aPtr;
-  for (size_t i = 0; i < aSize; i++) {
-    hash = (((hash << 5) - hash) + ptr[i]) | 0;
-  }
-  return hash;
-}
 
   if (name->IsOneByteEqualTo(base::CStrVector("EvalError"))) {
     WriteVarint(static_cast<uint8_t>(ErrorTag::kEvalErrorPrototype));

--- a/src/objects/value-serializer.cc
+++ b/src/objects/value-serializer.cc
@@ -405,6 +405,16 @@ void ValueSerializer::WriteRawBytes(const void* source, size_t length) {
 }
 
 Maybe<uint8_t*> ValueSerializer::ReserveRawBytes(size_t bytes) {
+  if (recordreplay::HasAsserts()) {
+    recordreplay::AssertBufferAllocationState* bufferAssertsState =
+      recordreplay::AutoAssertBufferAllocations::GetState();
+    if (bufferAssertsState) {
+      recordreplay::Diagnostic("ValueSerializer::ReserveRawBytes");
+      recordreplay::Assert("[%s] ValueSerializer::ReserveRawBytes %zu",
+        bufferAssertsState->issueLabel.c_str(),
+        bytes);
+    }
+  }
   size_t old_size = buffer_size_;
   size_t new_size = old_size + bytes;
   if (V8_UNLIKELY(new_size > buffer_capacity_)) {
@@ -457,6 +467,8 @@ void ValueSerializer::WriteUint64(uint64_t value) {
 }
 
 std::pair<uint8_t*, size_t> ValueSerializer::Release() {
+  REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
+    "[TT-1403] V8ScriptValueSerializer::Serialize %zu", buffer_size_);
   auto result = std::make_pair(buffer_, buffer_size_);
   buffer_ = nullptr;
   buffer_size_ = 0;
@@ -569,8 +581,24 @@ void ValueSerializer::WriteString(DirectHandle<String> string) {
   DCHECK(flat.IsFlat());
   if (flat.IsOneByte()) {
     base::Vector<const uint8_t> chars = flat.ToOneByteVector();
-    WriteTag(SerializationTag::kOneByteString);
-    WriteOneByteString(chars);
+
+    // Whether a string has a one or two byte representation can vary when
+    // replaying due to JIT and other VM behavior. Only write out strings
+    // as two bytes to ensure serialized buffers have a consistent size.
+    if (recordreplay::IsRecordingOrReplaying("values", "ValueSerializer::WriteString")) {
+      base::ScopedVector<base::uc16> new_chars(chars.length());
+      for (int i = 0; i < chars.length(); i++)
+        new_chars[i] = chars[i];
+      uint32_t byte_length = new_chars.length() * sizeof(base::uc16);
+      // The existing reading code expects 16-byte strings to be aligned.
+      if ((buffer_size_ + 1 + BytesNeededForVarint(byte_length)) & 1)
+        WriteTag(SerializationTag::kPadding);
+      WriteTag(SerializationTag::kTwoByteString);
+      WriteTwoByteString(new_chars);
+    } else {
+      WriteTag(SerializationTag::kOneByteString);
+      WriteOneByteString(chars);
+    }
   } else if (flat.IsTwoByte()) {
     base::Vector<const base::uc16> chars = flat.ToUC16Vector();
     uint32_t byte_length = chars.length() * sizeof(base::uc16);
@@ -704,6 +732,8 @@ Maybe<bool> ValueSerializer::WriteJSReceiver(
 Maybe<bool> ValueSerializer::WriteJSObject(DirectHandle<JSObject> object) {
   DCHECK(!IsCustomElementsReceiverMap(object->map()));
   const bool can_serialize_fast =
+    // [TT-492] Slow path all serialization so we're guaranteed to always match.
+    !recordreplay::IsRecordingOrReplaying("ValueSerializer") &&
       object->HasFastProperties() && object->elements()->ulength().value() == 0;
   if (!can_serialize_fast) return WriteJSObjectSlow(object);
 
@@ -1136,6 +1166,16 @@ Maybe<bool> ValueSerializer::WriteJSError(DirectHandle<JSObject> error) {
     return Nothing<bool>();
   }
 
+// FIXME surely there is a utility somewhere we can use instead?
+inline int HashBytes(const void* aPtr, size_t aSize) {
+  int hash = 0;
+  uint8_t* ptr = (uint8_t*)aPtr;
+  for (size_t i = 0; i < aSize; i++) {
+    hash = (((hash << 5) - hash) + ptr[i]) | 0;
+  }
+  return hash;
+}
+
   if (name->IsOneByteEqualTo(base::CStrVector("EvalError"))) {
     WriteVarint(static_cast<uint8_t>(ErrorTag::kEvalErrorPrototype));
   } else if (name->IsOneByteEqualTo(base::CStrVector("RangeError"))) {
@@ -1357,7 +1397,12 @@ ValueDeserializer::ValueDeserializer(Isolate* isolate,
       position_(data.begin()),
       end_(data.end()),
       id_map_(isolate->global_handles()->Create(
-          ReadOnlyRoots(isolate_).empty_fixed_array())) {}
+          ReadOnlyRoots(isolate_).empty_fixed_array())) {
+  REPLAY_ASSERT(
+    "[TT-492] ValueDeserializer::ValueDeserializer A %u %d",
+    data.size(), HashBytes(&data[0], data.size())
+  );
+}
 
 ValueDeserializer::ValueDeserializer(Isolate* isolate, const uint8_t* data,
                                      size_t size)
@@ -1366,7 +1411,12 @@ ValueDeserializer::ValueDeserializer(Isolate* isolate, const uint8_t* data,
       position_(data),
       end_(data + size),
       id_map_(isolate->global_handles()->Create(
-          ReadOnlyRoots(isolate_).empty_fixed_array())) {}
+          ReadOnlyRoots(isolate_).empty_fixed_array())) {
+  REPLAY_ASSERT(
+    "[TT-492] ValueDeserializer::ValueDeserializer B %u %d", size,
+    HashBytes(data, size)
+  );
+}
 
 ValueDeserializer::~ValueDeserializer() {
   DCHECK_LE(position_, end_);

--- a/src/parsing/parse-info.cc
+++ b/src/parsing/parse-info.cc
@@ -22,6 +22,9 @@
 namespace v8 {
 namespace internal {
 
+extern bool RecordReplayHasRegisteredScript(Script script);
+extern bool RecordReplayAssertValues(const std::string& url);
+
 UnoptimizedCompileFlags::UnoptimizedCompileFlags(Isolate* isolate,
                                                  int script_id)
     : flags_(0),
@@ -86,8 +89,11 @@ UnoptimizedCompileFlags UnoptimizedCompileFlags::ForScriptCompile(
 // static
 UnoptimizedCompileFlags UnoptimizedCompileFlags::ForToplevelCompile(
     Isolate* isolate, bool is_user_javascript, LanguageMode language_mode,
-    REPLMode repl_mode, ScriptType type, bool lazy) {
-  UnoptimizedCompileFlags flags(isolate, isolate->GetNextScriptId());
+    REPLMode repl_mode, ScriptType type, bool lazy,
+    int script_id) {
+  if (script_id == UnboundScript::kNoScriptId)
+    script_id = isolate->GetNextScriptId();
+  UnoptimizedCompileFlags flags(isolate, script_id);
   flags.SetFlagsForToplevelCompile(is_user_javascript, language_mode, repl_mode,
                                    type, lazy);
   LOG(isolate, ScriptEvent(ScriptEventType::kReserveId, flags.script_id()));

--- a/src/parsing/parse-info.h
+++ b/src/parsing/parse-info.h
@@ -44,6 +44,8 @@ class Zone;
   V(is_toplevel, bool, 1, _)                                    \
   V(is_eager, bool, 1, _)                                       \
   V(is_eval, bool, 1, _)                                        \
+  V(record_replay_ignore, bool, 1, _)                           \
+  V(record_replay_assert_values, bool, 1, _)                    \
   V(is_reparse, bool, 1, _)                                     \
   V(outer_language_mode, LanguageMode, 1, _)                    \
   V(parse_restriction, ParseRestriction, 1, _)                  \
@@ -75,7 +77,8 @@ class V8_EXPORT_PRIVATE UnoptimizedCompileFlags {
                                                     bool is_user_javascript,
                                                     LanguageMode language_mode,
                                                     REPLMode repl_mode,
-                                                    ScriptType type, bool lazy);
+                                                    ScriptType type, bool lazy,
+                                                    int script_id = UnboundScript::kNoScriptId);
 
   // Set-up flags for a compiling a particular function (either a lazy compile
   // or a recompile).

--- a/src/parsing/parser-base.h
+++ b/src/parsing/parser-base.h
@@ -3957,6 +3957,7 @@ ParserBase<Impl>::ParseLeftHandSideContinuation(ExpressionT result) {
 
     ExpressionListT args(pointer_buffer());
     bool has_spread;
+    int call_head_token_position = peek_position();
     ParseArguments(&args, &has_spread, kMaybeArrowHead);
     if (V8_LIKELY(peek() == Token::kArrow)) {
       fni_.RemoveAsyncKeywordFromEnd();
@@ -3972,7 +3973,7 @@ ParserBase<Impl>::ParseLeftHandSideContinuation(ExpressionT result) {
       return result;
     }
 
-    result = factory()->NewCall(result, args, pos, has_spread);
+    result = factory()->NewCall(result, args, pos, has_spread, call_head_token_position);
 
     maybe_arrow.ValidateExpression();
 
@@ -4049,6 +4050,7 @@ ParserBase<Impl>::ParseLeftHandSideContinuation(ExpressionT result) {
         }
         bool has_spread;
         ExpressionListT args(pointer_buffer());
+        int call_head_token_position = peek_position();
         ParseArguments(&args, &has_spread);
 
         // Keep track of eval() calls since they disable all local variable
@@ -4068,7 +4070,7 @@ ParserBase<Impl>::ParseLeftHandSideContinuation(ExpressionT result) {
           }
         }
 
-        result = factory()->NewCall(result, args, pos, has_spread,
+        result = factory()->NewCall(result, args, pos, has_spread, call_head_token_position,
                                     eval_scope_info_index, is_optional);
 
         fni_.RemoveLastFunction();
@@ -4155,9 +4157,10 @@ ParserBase<Impl>::ParseMemberWithPresentNewPrefixesExpression() {
     {
       ExpressionListT args(pointer_buffer());
       bool has_spread;
+      int call_head_token_position = peek_position();
       ParseArguments(&args, &has_spread);
-
-      result = factory()->NewCallNew(result, args, new_pos, has_spread);
+      result = factory()->NewCallNew(result, args, new_pos, has_spread,
+                                     call_head_token_position);
     }
     // The expression can still continue with . or [ after the arguments.
     return ParseMemberExpressionContinuation(result);
@@ -4903,6 +4906,7 @@ ParserBase<Impl>::ParseAsyncFunctionDeclaration(
     impl()->ReportUnexpectedToken(Token::kEscapedKeyword);
   }
   int pos = position();
+  int call_head_token_position = pos;
   DCHECK(!scanner()->HasLineTerminatorBeforeNext());
   Consume(Token::kFunction);
   ParseFunctionFlags flags = ParseFunctionFlag::kIsAsync;
@@ -5567,7 +5571,7 @@ typename ParserBase<Impl>::ExpressionT ParserBase<Impl>::ParseTemplateLiteral(
     typename Impl::TemplateLiteralState ts = impl()->OpenTemplateLiteral(pos);
     bool is_valid = CheckTemplateEscapes(forbid_illegal_escapes);
     impl()->AddTemplateSpan(&ts, is_valid, true);
-    return impl()->CloseTemplateLiteral(&ts, start, tag);
+  return impl()->CloseTemplateLiteral(&ts, start, tag, call_head_token_position);
   }
 
   Consume(Token::kTemplateSpan);

--- a/src/parsing/parser-base.h
+++ b/src/parsing/parser-base.h
@@ -4174,7 +4174,7 @@ ParserBase<Impl>::ParseMemberWithPresentNewPrefixesExpression() {
 
   // NewExpression without arguments.
   ExpressionListT args(pointer_buffer());
-  return factory()->NewCallNew(result, args, new_pos, false);
+  return factory()->NewCallNew(result, args, new_pos, false, new_pos);
 }
 
 template <typename Impl>
@@ -4906,7 +4906,6 @@ ParserBase<Impl>::ParseAsyncFunctionDeclaration(
     impl()->ReportUnexpectedToken(Token::kEscapedKeyword);
   }
   int pos = position();
-  int call_head_token_position = pos;
   DCHECK(!scanner()->HasLineTerminatorBeforeNext());
   Consume(Token::kFunction);
   ParseFunctionFlags flags = ParseFunctionFlag::kIsAsync;
@@ -5571,7 +5570,7 @@ typename ParserBase<Impl>::ExpressionT ParserBase<Impl>::ParseTemplateLiteral(
     typename Impl::TemplateLiteralState ts = impl()->OpenTemplateLiteral(pos);
     bool is_valid = CheckTemplateEscapes(forbid_illegal_escapes);
     impl()->AddTemplateSpan(&ts, is_valid, true);
-  return impl()->CloseTemplateLiteral(&ts, start, tag, call_head_token_position);
+    return impl()->CloseTemplateLiteral(&ts, start, tag, start);
   }
 
   Consume(Token::kTemplateSpan);
@@ -5620,7 +5619,7 @@ typename ParserBase<Impl>::ExpressionT ParserBase<Impl>::ParseTemplateLiteral(
 
   DCHECK_IMPLIES(!has_error(), next == Token::kTemplateTail);
   // Once we've reached a kTemplateTail, we can close the TemplateLiteral.
-  return impl()->CloseTemplateLiteral(&ts, start, tag);
+  return impl()->CloseTemplateLiteral(&ts, start, tag, start);
 }
 
 template <typename Impl>

--- a/src/parsing/parser.cc
+++ b/src/parsing/parser.cc
@@ -3758,7 +3758,7 @@ void Parser::AddTemplateExpression(TemplateLiteralState* state,
 }
 
 Expression* Parser::CloseTemplateLiteral(TemplateLiteralState* state, int start,
-                                         Expression* tag) {
+                                         Expression* tag, int call_head_token_position) {
   TemplateLiteral* lit = *state;
   int pos = lit->position();
   const ZonePtrList<const AstRawString>* cooked_strings = lit->cooked();
@@ -3781,7 +3781,7 @@ Expression* Parser::CloseTemplateLiteral(TemplateLiteralState* state, int start,
     ScopedPtrList<Expression> call_args(pointer_buffer());
     call_args.Add(template_object);
     call_args.AddAll(expressions->ToConstVector());
-    return factory()->NewTaggedTemplate(tag, call_args, pos);
+    return factory()->NewTaggedTemplate(tag, call_args, pos, call_head_token_position);
   }
 }
 

--- a/src/parsing/parser.h
+++ b/src/parsing/parser.h
@@ -515,7 +515,7 @@ class V8_EXPORT_PRIVATE Parser : public NON_EXPORTED_BASE(ParserBase<Parser>) {
   void AddTemplateExpression(TemplateLiteralState* state,
                              Expression* expression);
   Expression* CloseTemplateLiteral(TemplateLiteralState* state, int start,
-                                   Expression* tag);
+                                   Expression* tag, int call_head_token_position = 0);
 
   Expression* RewriteSuperCall(Expression* call_expression);
 

--- a/src/parsing/pending-compilation-error-handler.cc
+++ b/src/parsing/pending-compilation-error-handler.cc
@@ -205,6 +205,17 @@ void PendingCompilationErrorHandler::ThrowPendingError(
   }
   isolate->debug()->OnCompileError(script);
 
+  if (recordreplay::IsReplaying()) {
+    std::string url;
+    if (!script->name().IsUndefined()) {
+      std::unique_ptr<char[]> name = String::cast(script->name()).ToCString();
+      url = name.get();
+    }
+
+    Script::PositionInfo position_info;
+    Script::GetPositionInfo(script, location.start_pos(), &position_info, Script::WITH_OFFSET);
+  }
+
   Factory* factory = isolate->factory();
   DirectHandle<JSObject> error = factory->NewSyntaxError(
       error_details_.message(), base::VectorOf(args, num_args));

--- a/src/parsing/pending-compilation-error-handler.cc
+++ b/src/parsing/pending-compilation-error-handler.cc
@@ -213,7 +213,7 @@ void PendingCompilationErrorHandler::ThrowPendingError(
     }
 
     Script::PositionInfo position_info;
-    Script::GetPositionInfo(script, location.start_pos(), &position_info, Script::WITH_OFFSET);
+    Script::GetPositionInfo(script, location.start_pos(), &position_info, Script::OffsetFlag::kWithOffset);
   }
 
   Factory* factory = isolate->factory();

--- a/src/parsing/preparser.h
+++ b/src/parsing/preparser.h
@@ -592,7 +592,8 @@ class PreParserFactory {
   }
   PreParserExpression NewCall(PreParserExpression expression,
                               const PreParserExpressionList& arguments, int pos,
-                              bool has_spread, int eval_scope_info_index = 0,
+                              bool has_spread, int call_head_token_position,
+                              int eval_scope_info_index = 0,
                               bool optional_chain = false) {
     if (eval_scope_info_index > 0) {
       DCHECK(expression.IsIdentifier() && expression.AsIdentifier().IsEval());
@@ -603,7 +604,8 @@ class PreParserFactory {
   }
   PreParserExpression NewCallNew(const PreParserExpression& expression,
                                  const PreParserExpressionList& arguments,
-                                 int pos, bool has_spread) {
+                                 int pos, bool has_spread,
+                                 int call_head_token_position) {
     return PreParserExpression::Default();
   }
   PreParserStatement NewReturnStatement(

--- a/src/parsing/preparser.h
+++ b/src/parsing/preparser.h
@@ -982,7 +982,7 @@ class PreParser : public ParserBase<PreParser> {
   V8_INLINE void AddTemplateSpan(TemplateLiteralState* state, bool should_cook,
                                  bool tail) {}
   V8_INLINE PreParserExpression CloseTemplateLiteral(
-      TemplateLiteralState* state, int start, const PreParserExpression& tag) {
+      TemplateLiteralState* state, int start, const PreParserExpression& tag, int call_head_token_position = 0) {
     return PreParserExpression::Default();
   }
   V8_INLINE bool IsPrivateReference(const PreParserExpression& expression) {

--- a/src/profiler/heap-snapshot-generator.cc
+++ b/src/profiler/heap-snapshot-generator.cc
@@ -3753,6 +3753,15 @@ void HeapSnapshotJSONSerializer::Serialize(v8::OutputStream* stream) {
 
 void HeapSnapshotJSONSerializer::SerializeImpl() {
   DCHECK_EQ(0, snapshot_->root()->index());
+
+  // Heap contents can vary when recording vs. replaying, and we don't want
+  // these variances to affect behavior when replaying. We could record/replay
+  // the snapshot itself, but it is simpler to just disable this functionality.
+  if (recordreplay::IsRecordingOrReplaying("gc-changes", "HeapSnapshotJSONSerializer::SerializeImpl")) {
+    writer_->AddString("{}");
+    return;
+  }
+
   writer_->AddCharacter('{');
   writer_->AddString("\"snapshot\":{");
   SerializeSnapshot();

--- a/src/replay/replay-isolate-data.cc
+++ b/src/replay/replay-isolate-data.cc
@@ -1,0 +1,7 @@
+#include "src/replay/replay-isolate-data.h"
+
+namespace v8 {
+namespace replayio {
+
+}  // namespace replayio
+}  // namespace v8

--- a/src/replay/replay-isolate-data.h
+++ b/src/replay/replay-isolate-data.h
@@ -1,0 +1,29 @@
+#ifndef V8_REPLAY_REPLAY_ISOLATE_DATA_H_
+#define V8_REPLAY_REPLAY_ISOLATE_DATA_H_
+
+#include <vector>
+
+#include "include/v8-persistent-handle.h"
+
+namespace v8 {
+namespace replayio {
+
+// General-purpose per-Isolate data for recording and replaying.
+class ReplayIsolateData {
+ public:
+  ReplayIsolateData() = default;
+  ~ReplayIsolateData() = default;
+
+  ReplayIsolateData(const ReplayIsolateData&) = delete;
+  ReplayIsolateData& operator=(const ReplayIsolateData&) = delete;
+
+  std::vector<v8::Global<v8::Value>>& weak_ref_pins() { return weak_ref_pins_; }
+
+ private:
+  std::vector<v8::Global<v8::Value>> weak_ref_pins_;
+};
+
+}  // namespace replayio
+}  // namespace v8
+
+#endif  // V8_REPLAY_REPLAY_ISOLATE_DATA_H_

--- a/src/replay/replay-runtime-weak-refs.cc
+++ b/src/replay/replay-runtime-weak-refs.cc
@@ -1,0 +1,47 @@
+#include "include/replayio.h"
+#include "src/execution/arguments-inl.h"
+#include "src/objects/js-weak-refs-inl.h"
+#include "src/replay/weak-refs.h"
+#include "src/runtime/runtime-utils.h"
+
+namespace v8 {
+namespace internal {
+
+// Called from WeakRef constructor. During replay, pin the target so the GC
+// cannot collect it earlier than it was collected during recording.
+RUNTIME_FUNCTION(Runtime_JSReplayWeakRefConstruct) {
+  HandleScope scope(isolate);
+  DCHECK_EQ(1, args.length());
+  Handle<HeapObject> object = args.at<HeapObject>(0);
+
+  if (recordreplay::IsReplaying()) {
+    replayio::ReplayWeakRefPins::Pin(isolate, *object);
+  }
+
+  return ReadOnlyRoots(isolate).undefined_value();
+}
+
+// Called from WeakRef.prototype.deref(). Records/replays target liveness so
+// the result is deterministic. Unpins the target once it is observed dead.
+RUNTIME_FUNCTION(Runtime_JSReplayWeakRefDeref) {
+  HandleScope scope(isolate);
+  DCHECK_EQ(1, args.length());
+  Handle<JSWeakRef> weak_ref = args.at<JSWeakRef>(0);
+
+  Object target = weak_ref->target();
+  const bool had_target = !target.IsUndefined(isolate);
+  uintptr_t alive = had_target ? 1 : 0;
+  uintptr_t recorded_alive = recordreplay::RecordReplayValue("JSWeakRef.deref", alive);
+
+  if (!recorded_alive && alive) {
+    // Can only happen during replay: The target is still alive but at recording time it was dead.
+    DCHECK(recordreplay::IsReplaying());
+    replayio::ReplayWeakRefPins::Unpin(isolate, HeapObject::cast(target));
+    return ReadOnlyRoots(isolate).undefined_value();
+  }
+
+  return target;
+}
+
+}  // namespace internal
+}  // namespace v8

--- a/src/replay/replayio.cc
+++ b/src/replay/replayio.cc
@@ -1,0 +1,30 @@
+#include "src/execution/isolate-inl.h"
+#include "src/objects/string.h"
+#include "include/replayio.h"
+#include "src/replay/replayio.h"
+
+namespace v8 {
+namespace replayio {
+
+v8::internal::Handle<v8::internal::String> RecordReplayStringHandle(
+    const char* why, v8::internal::Isolate* isolate,
+    v8::internal::Handle<v8::internal::String> input) {
+  if (!v8::recordreplay::IsRecordingOrReplaying(why)) {
+    return input;
+  }
+  std::string str = input->ToCString().get();
+  v8::recordreplay::RecordReplayString(why, str);
+  return isolate->factory()->NewStringFromUtf8(base::CStrVector(str.c_str())).ToHandleChecked();
+}
+
+v8::internal::MaybeHandle<v8::internal::String> RecordReplayStringHandle(
+    const char* why, v8::internal::Isolate* isolate,
+    v8::internal::MaybeHandle<v8::internal::String> input) {
+  if (input.is_null()) {
+    return input;
+  }
+  return RecordReplayStringHandle(why, isolate, input.ToHandleChecked());
+}
+
+}  // namespace replayio
+}  // namespace v8

--- a/src/replay/replayio.h
+++ b/src/replay/replayio.h
@@ -1,0 +1,26 @@
+#ifndef V8_REPLAY_REPLAYIO_H_
+#define V8_REPLAY_REPLAYIO_H_
+
+#include "src/handles/handles.h"
+#include "src/handles/maybe-handles.h"
+
+namespace v8 {
+namespace internal {
+class Isolate;
+class String;
+}  // namespace internal
+
+namespace replayio {
+
+v8::internal::Handle<v8::internal::String> RecordReplayStringHandle(
+    const char* why, v8::internal::Isolate* isolate,
+    v8::internal::Handle<v8::internal::String> input);
+
+v8::internal::MaybeHandle<v8::internal::String> RecordReplayStringHandle(
+    const char* why, v8::internal::Isolate* isolate,
+    v8::internal::MaybeHandle<v8::internal::String> input);
+
+}  // namespace replayio
+}  // namespace v8
+
+#endif  // V8_REPLAY_REPLAYIO_H_

--- a/src/replay/weak-refs.cc
+++ b/src/replay/weak-refs.cc
@@ -1,0 +1,38 @@
+#include "src/replay/weak-refs.h"
+
+#include "include/replayio.h"
+#include "src/api/api-inl.h"
+#include "src/execution/isolate.h"
+#include "src/objects/heap-object.h"
+#include "src/replay/replay-isolate-data.h"
+
+namespace v8 {
+namespace replayio {
+
+void ReplayWeakRefPins::Pin(internal::Isolate* isolate,
+                            internal::HeapObject target) {
+  DCHECK(!recordreplay::IsReplaying());
+  auto& entries = isolate->EnsureReplayData()->weak_ref_pins();
+  auto local = Utils::ToLocal(internal::Handle<internal::Object>(target, isolate));
+  for (auto& entry : entries) {
+    if (entry == local) return;
+  }
+  entries.emplace_back(reinterpret_cast<v8::Isolate*>(isolate), local);
+}
+
+void ReplayWeakRefPins::Unpin(internal::Isolate* isolate,
+                              internal::HeapObject target) {
+  ReplayIsolateData* data = isolate->replay_data();
+  if (!data) return;
+  auto& entries = data->weak_ref_pins();
+  auto local = Utils::ToLocal(internal::Handle<internal::Object>(target, isolate));
+  for (auto it = entries.begin(); it != entries.end(); ++it) {
+    if (*it == local) {
+      entries.erase(it);
+      return;
+    }
+  }
+}
+
+}  // namespace replayio
+}  // namespace v8

--- a/src/replay/weak-refs.h
+++ b/src/replay/weak-refs.h
@@ -1,0 +1,22 @@
+#ifndef V8_REPLAY_WEAK_REFS_H_
+#define V8_REPLAY_WEAK_REFS_H_
+
+#include "src/objects/objects.h"
+
+namespace v8 {
+namespace internal {
+class Isolate;
+}  // namespace internal
+
+namespace replayio {
+
+class ReplayWeakRefPins {
+ public:
+  static void Pin(internal::Isolate* isolate, internal::HeapObject target);
+  static void Unpin(internal::Isolate* isolate, internal::HeapObject target);
+};
+
+}  // namespace replayio
+}  // namespace v8
+
+#endif  // V8_REPLAY_WEAK_REFS_H_

--- a/src/runtime/runtime-compiler.cc
+++ b/src/runtime/runtime-compiler.cc
@@ -146,8 +146,6 @@ RUNTIME_FUNCTION(Runtime_CompileLazy) {
     return isolate->StackOverflow();
   }
 
-  CHECK(isolate == function->GetIsolate());
-
   DirectHandle<SharedFunctionInfo> sfi(function->shared(), isolate);
 
   DCHECK(!function->is_compiled(isolate));

--- a/src/runtime/runtime-compiler.cc
+++ b/src/runtime/runtime-compiler.cc
@@ -146,6 +146,8 @@ RUNTIME_FUNCTION(Runtime_CompileLazy) {
     return isolate->StackOverflow();
   }
 
+  CHECK(isolate == function->GetIsolate());
+
   DirectHandle<SharedFunctionInfo> sfi(function->shared(), isolate);
 
   DCHECK(!function->is_compiled(isolate));

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -980,7 +980,8 @@ std::string GetScriptLocationString(int script_id, int start_position) {
   std::string script_name = GetScriptName(script);
 
   Script::PositionInfo info;
-  Script::GetPositionInfo(script, start_position, &info, Script::WITH_OFFSET);
+  Script::GetPositionInfo(script, start_position, &info,
+                          Script::OffsetFlag::kWithOffset);
 
   std::ostringstream os;
   os << script_id << ":" << script_name << ":" << info.line + 1 << ":" << info.column;
@@ -1180,7 +1181,8 @@ static std::string GetStackLocation(Isolate* isolate) {
 
     int source_position = js.SourcePosition();
     Script::PositionInfo info;
-    Script::GetPositionInfo(script, source_position, &info, Script::WITH_OFFSET);
+    Script::GetPositionInfo(script, source_position, &info,
+                            Script::OffsetFlag::kWithOffset);
 
     if (script->name().IsUndefined()) {
       snprintf(location, sizeof(location), "<none>:%d:%d", info.line + 1, info.column);
@@ -1247,7 +1249,8 @@ RUNTIME_FUNCTION(Runtime_RecordReplayAssertValue) {
 
   if (!site.location_.length()) {
     Script::PositionInfo info;
-    Script::GetPositionInfo(script, site.source_position_, &info, Script::WITH_OFFSET);
+    Script::GetPositionInfo(script, site.source_position_, &info,
+                            Script::OffsetFlag::kWithOffset);
 
     char buf[1024];
     if (script->name().IsUndefined()) {
@@ -1393,7 +1396,8 @@ std::string GetRecordReplayFunctionId(Handle<SharedFunctionInfo> shared) {
 
     Script::PositionInfo info;
     Handle<Script> handleScript(script, Isolate::Current());
-    Script::GetPositionInfo(handleScript, shared->StartPosition(), &info, Script::WITH_OFFSET);
+    Script::GetPositionInfo(handleScript, shared->StartPosition(), &info,
+                            Script::OffsetFlag::kWithOffset);
     recordreplay::Print("FunctionId %s -> %s:%d:%d",
                         os.str().c_str(), url.get() ? url.get() : "<none>",
                         info.line + 1, info.column);

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -28,6 +28,14 @@
 #include "src/wasm/wasm-objects-inl.h"
 #endif  // V8_ENABLE_WEBASSEMBLY
 
+#if !V8_OS_WIN
+#include <sys/time.h>
+#include <unistd.h>
+#endif
+
+#include "src/api/api-inl.h"
+#include "src/base/replayio.h"
+
 #include "src/builtins/builtins-iterator-inl.h"
 
 namespace v8 {
@@ -200,6 +208,8 @@ RUNTIME_FUNCTION(Runtime_ScheduleBreak) {
       nullptr);
   return ReadOnlyRoots(isolate).undefined_value();
 }
+
+extern "C" void V8RecordReplayOnDebuggerStatement();
 
 namespace {
 
@@ -907,6 +917,606 @@ RUNTIME_FUNCTION(Runtime_DebugToggleBlockCoverage) {
   bool enable = Cast<Boolean>(args[0])->ToBool(isolate);
   Coverage::SelectMode(isolate, enable ? debug::CoverageMode::kBlockCount
                                        : debug::CoverageMode::kBestEffort);
+  return ReadOnlyRoots(isolate).undefined_value();
+}
+
+extern uint64_t* gProgressCounter;
+extern uint64_t gTargetProgress;
+extern bool gRecordReplayAssertProgress;
+extern int gRecordReplayCheckProgress;
+
+// Define this to check preconditions for using record/replay opcodes.
+//#define RECORD_REPLAY_CHECK_OPCODES
+
+#ifdef RECORD_REPLAY_CHECK_OPCODES
+
+extern bool RecordReplayHasRegisteredScript(Script script);
+
+static inline bool RecordReplayBytecodeAllowed() {
+  return IsMainThread()
+      && (!recordreplay::AreEventsDisallowed() || recordreplay::HasDivergedFromRecording());
+}
+
+#else // !RECORD_REPLAY_CHECK_OPCODES
+
+static inline bool RecordReplayHasRegisteredScript(Script script) {
+  return true;
+}
+
+static inline bool RecordReplayBytecodeAllowed() {
+  return true;
+}
+
+#endif // !RECORD_REPLAY_CHECK_OPCODES
+
+// When gRecordReplayAssertProgress is set we keep track of all the progress
+// made on the main thread and associate it with main-thread assertions using
+// the recorder's assert data callbacks API. Each progress advancement is
+// associated with a single 64 bit value encoding the script ID and location
+// within that script of the function which executed.
+static std::vector<uint64_t>* gProgressData;
+
+// Buffer holding data most recently reported to the recorder.
+static std::vector<uint64_t>* gReportedProgressData;
+
+static inline uint64_t BuildScriptProgressEntry(Handle<JSFunction> fun) {
+  int script_id = Script::cast(fun->shared().script()).id();
+  int start_position = fun->shared().StartPosition();
+  return (static_cast<uint64_t>(script_id) << 32) | static_cast<uint64_t>(start_position);
+}
+
+extern Handle<Script> GetScript(Isolate* isolate, int script_id);
+
+static inline std::string GetScriptName(Handle<Script> script) {
+  return script->name().IsString()
+    ? String::cast(script->name()).ToCString().get()
+    : "(anonymous script)";
+}
+
+std::string GetScriptLocationString(int script_id, int start_position) {
+  Isolate* isolate = Isolate::Current();
+  HandleScope scope(isolate);
+  Handle<Script> script = GetScript(isolate, script_id);
+  std::string script_name = GetScriptName(script);
+
+  Script::PositionInfo info;
+  Script::GetPositionInfo(script, start_position, &info, Script::WITH_OFFSET);
+
+  std::ostringstream os;
+  os << script_id << ":" << script_name << ":" << info.line + 1 << ":" << info.column;
+  return os.str();
+}
+
+static std::string GetScriptProgressEntryString(uint64_t v) {
+  int script_id = static_cast<int>(v >> 32);
+  int start_position = static_cast<int>(v);
+
+  return GetScriptLocationString(script_id, start_position);
+}
+
+// Produce a string explaining a JS mismatch during an Assert call when a C++
+// mismatch was detected. It includes the first mismatching replayed PC (if
+// there is any). That PC is the current PC minus the index of the mismatching
+// replayed entry, since every PC update before the current Assert added one
+// JS mismatch entry.
+// See https://linear.app/replay/issue/RUN-2096#comment-a334b15f
+static char* GetProgressMismatchMessage(size_t replayedIndex, uint64_t recordedEntry,
+                                        uint64_t replayedEntry) {
+  std::string recorded_text = recordedEntry
+                                  ? GetScriptProgressEntryString(recordedEntry)
+                                  : "<assertion>";
+  std::string replayed_text = replayedEntry
+                                  ? GetScriptProgressEntryString(replayedEntry)
+                                  : "<assertion>";
+  std::ostringstream os;
+  os << "{ \"recorded\": \"" << recorded_text 
+     << "\", \"replayed\": \"" << replayed_text
+     << "\", \"progress\": " << (*gProgressCounter - replayedIndex);
+  os << "\" }";
+  
+  return strdup(os.str().c_str());
+}
+
+void RecordReplayCallbackAssertGetData(void** pbuf, size_t* psize) {
+  if (!IsMainThread() || !gProgressData) {
+    *psize = 0;
+    return;
+  }
+
+  if (gReportedProgressData) {
+    delete gReportedProgressData;
+  }
+  gReportedProgressData = gProgressData;
+  gProgressData = nullptr;
+  *pbuf = &(*gReportedProgressData)[0];
+  *psize = gReportedProgressData->size() * sizeof(uint64_t);
+}
+
+extern void RecordReplayDescribeAssertData(const char* text);
+
+char* RecordReplayCallbackAssertOnDataMismatch(void* recorded_buf, size_t recorded_buf_size,
+                                               void* replayed_buf, size_t replayed_buf_size) {
+  const uint64_t* recorded = reinterpret_cast<const uint64_t*>(recorded_buf);
+  size_t recorded_size = recorded_buf_size / sizeof(uint64_t);
+
+  const uint64_t* replayed = reinterpret_cast<const uint64_t*>(replayed_buf);
+  size_t replayed_size = replayed_buf_size / sizeof(uint64_t);
+
+  for (size_t i = 0; i < std::min<size_t>(recorded_size, replayed_size); i++) {
+    if (recorded[i] == replayed[i]) {
+      std::string text = GetScriptProgressEntryString(recorded[i]);
+      RecordReplayDescribeAssertData(text.c_str());
+    } else {
+      return GetProgressMismatchMessage(replayed_size - i - 1, recorded[i], replayed[i]);
+    }
+  }
+
+  if (recorded_size < replayed_size) {
+    // We are missing recorded entries. Report the first extra replayed entry.
+    return GetProgressMismatchMessage(
+      replayed_size - recorded_size - 1, 0, replayed[recorded_size]);
+  }
+
+  if (replayed_size < recorded_size) {
+    // We are missing replayed entries. Report the first extra recorded entry.
+    return GetProgressMismatchMessage(
+      0, recorded[replayed_size], 0);
+  }
+
+  // Everything is equal.
+  return GetProgressMismatchMessage(0, 0, 0);
+}
+
+void RecordReplayCallbackAssertDescribeData(void* buf, size_t buf_size) {
+  const uint64_t* entries = reinterpret_cast<const uint64_t*>(buf);
+  size_t size = buf_size / sizeof(uint64_t);
+
+  for (size_t i = 0; i < size; i++) {
+    std::string text = GetScriptProgressEntryString(entries[i]);
+    RecordReplayDescribeAssertData(text.c_str());
+  }
+}
+
+extern bool gRecordReplayHasCheckpoint;
+
+extern void RecordReplayOnTargetProgressReached();
+extern bool RecordReplayIsDivergentUserJSWithoutPause(
+    const SharedFunctionInfo& shared);
+
+static bool gHasPrintedStack = false;
+
+RUNTIME_FUNCTION(Runtime_RecordReplayAssertExecutionProgress) {
+  if (++*gProgressCounter == gTargetProgress) {
+    RecordReplayOnTargetProgressReached();
+  }
+
+  if (gRecordReplayAssertProgress) {
+    Handle<JSFunction> function = args.at<JSFunction>(0);
+
+    if (!gProgressData) {
+      gProgressData = new std::vector<uint64_t>();
+    }
+    gProgressData->push_back(BuildScriptProgressEntry(function));
+  }
+
+  if (gRecordReplayCheckProgress) {
+    Handle<JSFunction> function = args.at<JSFunction>(0);
+
+    Handle<SharedFunctionInfo> shared(function->shared(), isolate);
+    Handle<Script> script(Script::cast(shared->script()), isolate);
+
+    CHECK(RecordReplayBytecodeAllowed());
+    CHECK(gRecordReplayHasCheckpoint);
+    CHECK(RecordReplayHasRegisteredScript(*script));
+
+    if (recordreplay::AreEventsDisallowed() && !recordreplay::HasDivergedFromRecording()) {
+      // Print JS stack if user JS was executed non-deterministically
+      // and we were not paused.
+      if (!gHasPrintedStack) {  // Prevent flood.
+        gHasPrintedStack = true;
+        HandleScope scope(isolate);
+        std::stringstream stack;
+        isolate->PrintCurrentStackTrace(stack);
+
+        recordreplay::Warning(
+            "[RUN-1919] JS ExecutionProgress in non-deterministic user JS PC=%zu "
+            "scriptId=%d @%s stack=%s",
+            *gProgressCounter, script->id(),
+            GetScriptLocationString(script->id(), shared->StartPosition())
+                .c_str(),
+            stack.str().c_str());
+      }
+    }
+  }
+
+  return ReadOnlyRoots(isolate).undefined_value();
+}
+
+RUNTIME_FUNCTION(Runtime_RecordReplayTargetProgressReached) {
+  CHECK(*gProgressCounter == gTargetProgress);
+  RecordReplayOnTargetProgressReached();
+  return ReadOnlyRoots(isolate).undefined_value();
+}
+
+extern "C" void V8RecordReplayNotifyActivity();
+
+RUNTIME_FUNCTION(Runtime_RecordReplayNotifyActivity) {
+  V8RecordReplayNotifyActivity();
+  return ReadOnlyRoots(isolate).undefined_value();
+}
+
+static std::string GetStackLocation(Isolate* isolate) {
+  HandleScope scope(isolate);
+  char location[1024];
+  strcpy(location, "<no frame>");
+  for (StackFrameIterator it(isolate); !it.done(); it.Advance()) {
+    StackFrame* frame = it.frame();
+    if (!frame->is_java_script()) {
+      continue;
+    }
+    std::vector<FrameSummary> frames;
+    CommonFrame::cast(frame)->Summarize(&frames);
+    if (!frames.size()) {
+      continue;
+    }
+    auto& summary = frames.back();
+    CHECK(summary.IsJavaScript());
+    auto const& js = summary.AsJavaScript();
+
+    Handle<SharedFunctionInfo> shared(js.function()->shared(), isolate);
+
+    // Sometimes the SharedFunctionInfo has what appears to be a bogus
+    // script for an unknown reason. We check the positions of the function
+    // to watch for this.
+    if (!shared->StartPosition() && !shared->EndPosition()) {
+      continue;
+    }
+
+    Handle<Script> script(Script::cast(shared->script()), isolate);
+
+    if (script->id() == 0) {
+      continue;
+    }
+
+    int source_position = js.SourcePosition();
+    Script::PositionInfo info;
+    Script::GetPositionInfo(script, source_position, &info, Script::WITH_OFFSET);
+
+    if (script->name().IsUndefined()) {
+      snprintf(location, sizeof(location), "<none>:%d:%d", info.line + 1, info.column);
+    } else {
+      std::unique_ptr<char[]> name = String::cast(script->name()).ToCString();
+      snprintf(location, sizeof(location), "%s:%d:%d", name.get(), info.line + 1, info.column);
+    }
+    location[sizeof(location) - 1] = 0;
+    break;
+  }
+
+  return std::string(location);
+}
+
+// Assertion and instrumentation site indexes embedded in bytecodes are offset
+// by this value. This forces the bytecode emitter to always use four bytes to
+// encode the index, so that bytecode offsets will be stable between recording
+// and replaying (or different replays) even if the indexes themselves aren't.
+static const int BytecodeSiteOffset = 1 << 16;
+
+// Locations for each assertion site, filled in lazily.
+struct AssertionSite {
+  std::string desc_;
+  int source_position_;
+  std::string location_;
+};
+typedef std::vector<AssertionSite*> AssertionSiteVector;
+static AssertionSiteVector* gAssertionSites;
+static base::Mutex* gAssertionSitesMutex;
+
+int RegisterAssertValueSite(const std::string& desc, int source_position) {
+  base::MutexGuard lock(gAssertionSitesMutex);
+
+  int index = (int)gAssertionSites->size();
+  gAssertionSites->push_back(new AssertionSite({ desc, source_position, "" }));
+  return index + BytecodeSiteOffset;
+}
+
+static inline AssertionSite& GetAssertValueSite(int32_t index) {
+  index -= BytecodeSiteOffset;
+
+  base::MutexGuard lock(gAssertionSitesMutex);
+
+  CHECK(gAssertionSites && (size_t)index < gAssertionSites->size());
+  AssertionSite* site = (*gAssertionSites)[index];
+  return *site;
+}
+
+extern std::string RecordReplayBasicValueContents(Handle<Object> value);
+
+RUNTIME_FUNCTION(Runtime_RecordReplayAssertValue) {
+  CHECK(RecordReplayBytecodeAllowed());
+
+  HandleScope scope(isolate);
+  DCHECK_EQ(3, args.length());
+  Handle<JSFunction> function = args.at<JSFunction>(0);
+  int32_t index = NumberToInt32(args[1]);
+  Handle<Object> value = args.at(2);
+
+  Handle<Script> script(Script::cast(function->shared().script()), isolate);
+  CHECK(RecordReplayHasRegisteredScript(*script));
+
+  AssertionSite& site = GetAssertValueSite(index);
+
+  if (!site.location_.length()) {
+    Script::PositionInfo info;
+    Script::GetPositionInfo(script, site.source_position_, &info, Script::WITH_OFFSET);
+
+    char buf[1024];
+    if (script->name().IsUndefined()) {
+      snprintf(buf, sizeof(buf), "<none>:%d:%d", info.line + 1, info.column);
+    } else {
+      std::unique_ptr<char[]> name = String::cast(script->name()).ToCString();
+      snprintf(buf, sizeof(buf), "%s:%d:%d", name.get(), info.line + 1, info.column);
+    }
+    buf[sizeof(buf) - 1] = 0;
+
+    site.location_ = buf;
+  }
+
+  std::string contents = RecordReplayBasicValueContents(value);
+
+  REPLAY_ASSERT(
+      "JS %s Value=%s PC=%zu scriptId=%d @%s", site.desc_.c_str(),
+      contents.c_str(), *gProgressCounter, script->id(),
+      site.location_.c_str());
+
+  if ((RecordReplayIsDivergentUserJSWithoutPause(function->shared())) ||
+      (recordreplay::IsReplaying() && recordreplay::HadMismatch())) {
+    // Print JS stack if user JS was executed non-deterministically
+    // and we were not paused, or if we had a mismatch.
+    if (!gHasPrintedStack) {  // Prevent flood.
+      gHasPrintedStack = true;
+      std::stringstream stack;
+      isolate->PrintCurrentStackTrace(stack);
+
+      recordreplay::Warning(
+          "JS-Stack %s%s PC=%zu scriptId=%d @%s stack=%s", site.desc_.c_str(),
+          RecordReplayIsDivergentUserJSWithoutPause(function->shared())
+              ? " in non-deterministic user JS"
+              : "",
+          *gProgressCounter, script->id(), site.location_.c_str(),
+          stack.str().c_str());
+    }
+  }
+
+  return *value;
+}
+
+struct InstrumentationSite {
+  const char* kind_ = nullptr;
+  int source_position_ = 0;
+  // The index of this site within its function.
+  int function_index_ = 0;
+
+  // Set on the first use of the instrumentation site.
+  std::string function_id_;
+};
+
+typedef std::vector<InstrumentationSite> InstrumentationSiteVector;
+
+// All instrumentation sites that have been registered, possibly on a non-main
+// thread during background compilation tasks. Protected by gInstrumentationSitesMutex.
+static InstrumentationSiteVector* gInstrumentationSites;
+static base::Mutex* gInstrumentationSitesMutex;
+
+// Prefix of gInstrumentationSites, main thread only. Used to avoid locking.
+static InstrumentationSiteVector* gMainThreadInstrumentationSites;
+
+// On the main thread, copy over any instrumentation sites that haven't
+// been added to gMainThreadInstrumentationSites.
+static void CopyMainThreadInstrumentationSites() {
+  base::MutexGuard lock(gInstrumentationSitesMutex);
+  for (size_t i = gMainThreadInstrumentationSites->size();
+       i < gInstrumentationSites->size();
+       i++) {
+    gMainThreadInstrumentationSites->push_back((*gInstrumentationSites)[i]);
+  }
+}
+
+int RegisterInstrumentationSite(const char* kind, int source_position,
+                                int function_index) {
+  InstrumentationSite site;
+  site.kind_ = kind;
+  site.source_position_ = source_position;
+  site.function_index_ = function_index;
+
+  base::MutexGuard lock(gInstrumentationSitesMutex);
+
+  int index = (int)gInstrumentationSites->size();
+  gInstrumentationSites->push_back(site);
+
+  return index + BytecodeSiteOffset;
+}
+
+static InstrumentationSite& GetInstrumentationSite(const char* why, int index) {
+  CHECK(IsMainThread());
+  index -= BytecodeSiteOffset;
+  if ((size_t)index >= gMainThreadInstrumentationSites->size()) {
+    CopyMainThreadInstrumentationSites();
+    if ((size_t)index >= gMainThreadInstrumentationSites->size()) {
+      recordreplay::Diagnostic("BadInstrumentationSite %s %d %d",
+                               why, index, gMainThreadInstrumentationSites->size());
+      CHECK((size_t)index < gMainThreadInstrumentationSites->size());
+    }
+  }
+  return (*gMainThreadInstrumentationSites)[index];
+}
+
+const char* InstrumentationSiteKind(int index) {
+  return GetInstrumentationSite("Kind", index).kind_;
+}
+
+int InstrumentationSiteSourcePosition(int index) {
+  return GetInstrumentationSite("SourcePosition", index).source_position_;
+}
+
+int InstrumentationSiteFunctionIndex(int index) {
+  return GetInstrumentationSite("Rank", index).function_index_;
+}
+
+void RecordReplayInitInstrumentationState() {
+  // These can't have static ctors/dtors...
+  gAssertionSites = new AssertionSiteVector();
+  gAssertionSitesMutex = new base::Mutex();
+  gInstrumentationSites = new InstrumentationSiteVector();
+  gInstrumentationSitesMutex = new base::Mutex();
+  gMainThreadInstrumentationSites = new InstrumentationSiteVector();
+}
+
+extern void RecordReplayInstrument(const char* kind, const char* function, int function_index);
+
+// Enable to dump locations of each function to stderr.
+static bool gDumpFunctionLocations;
+
+std::string GetRecordReplayFunctionId(Handle<SharedFunctionInfo> shared) {
+  Script script = Script::cast(shared->script());
+
+  std::ostringstream os;
+
+  // When recording/replaying we use a function ID we can parse to a script
+  // and source location later.
+  os << script.id() << ":" << shared->StartPosition();
+
+  if (gDumpFunctionLocations) {
+    std::unique_ptr<char[]> url;
+    if (!script.name().IsUndefined()) {
+      url = String::cast(script.name()).ToCString();
+    }
+
+    Script::PositionInfo info;
+    Handle<Script> handleScript(script, Isolate::Current());
+    Script::GetPositionInfo(handleScript, shared->StartPosition(), &info, Script::WITH_OFFSET);
+    recordreplay::Print("FunctionId %s -> %s:%d:%d",
+                        os.str().c_str(), url.get() ? url.get() : "<none>",
+                        info.line + 1, info.column);
+  }
+
+  return os.str();
+}
+
+void ParseRecordReplayFunctionId(const std::string& function_id,
+                                 int* script_id, int* source_position) {
+  const char* raw = function_id.c_str();
+  *script_id = atoi(raw);
+  *source_position = atoi(strchr(raw, ':') + 1);
+}
+
+static inline void OnInstrumentation(Isolate* isolate,
+                                     Handle<JSFunction> function, int32_t index) {
+  CHECK(RecordReplayBytecodeAllowed());
+
+  Handle<Script> script(Script::cast(function->shared().script()), isolate);
+  CHECK(RecordReplayHasRegisteredScript(*script));
+
+  InstrumentationSite& site = GetInstrumentationSite("Callback", index);
+
+  if (!site.function_id_.length()) {
+    Handle<SharedFunctionInfo> shared(function->shared(), isolate);
+    site.function_id_ = GetRecordReplayFunctionId(shared);
+  }
+
+  RecordReplayInstrument(site.kind_, site.function_id_.c_str(),
+                         site.function_index_);
+}
+
+extern bool gRecordReplayInstrumentationEnabled;
+
+RUNTIME_FUNCTION(Runtime_RecordReplayInstrumentation) {
+  if (!gRecordReplayInstrumentationEnabled) {
+    return ReadOnlyRoots(isolate).undefined_value();
+  }
+
+  HandleScope scope(isolate);
+  DCHECK_EQ(2, args.length());
+  Handle<JSFunction> function = args.at<JSFunction>(0);
+  int32_t index = NumberToInt32(args[1]);
+
+  OnInstrumentation(isolate, function, index);
+
+  return ReadOnlyRoots(isolate).undefined_value();
+}
+
+extern int RecordReplayObjectId(v8::Isolate* isolate, Local<v8::Context> cx,
+                                v8::Local<v8::Value> object, bool allow_create);
+
+static int gCurrentGeneratorId;
+
+int RecordReplayCurrentGeneratorIdRaw() {
+  return gCurrentGeneratorId;
+}
+
+RUNTIME_FUNCTION(Runtime_RecordReplayInstrumentationGenerator) {
+  HandleScope scope(isolate);
+  DCHECK_EQ(3, args.length());
+  Handle<JSFunction> function = args.at<JSFunction>(0);
+  int32_t index = NumberToInt32(args[1]);
+  Handle<Object> generator_object = args.at(2);
+
+  // Note: RecordReplayObjectId calls have to occur in the same places when
+  // replaying (regardless of whether instrumentation is enabled) so that objects
+  // will be assigned consistent IDs.
+  CHECK(!gCurrentGeneratorId);
+  v8::Isolate* v8_isolate = (v8::Isolate*) isolate;
+  gCurrentGeneratorId = RecordReplayObjectId(v8_isolate, v8_isolate->GetCurrentContext(),
+                                             v8::Utils::ToLocal(generator_object),
+                                             /* allow_create */ true);
+
+  if (gRecordReplayInstrumentationEnabled) {
+    OnInstrumentation(isolate, function, index);
+  }
+
+  gCurrentGeneratorId = 0;
+
+  return ReadOnlyRoots(isolate).undefined_value();
+}
+
+static Handle<Object>* gCurrentReturnValue;
+
+RUNTIME_FUNCTION(Runtime_RecordReplayInstrumentationReturn) {
+  if (!gRecordReplayInstrumentationEnabled) {
+    return ReadOnlyRoots(isolate).undefined_value();
+  }
+
+  HandleScope scope(isolate);
+  DCHECK_EQ(3, args.length());
+  Handle<JSFunction> function = args.at<JSFunction>(0);
+  int32_t index = NumberToInt32(args[1]);
+  Handle<Object> return_value = args.at(2);
+
+  gCurrentReturnValue = &return_value;
+
+  OnInstrumentation(isolate, function, index);
+
+  gCurrentReturnValue = nullptr;
+
+  return ReadOnlyRoots(isolate).undefined_value();
+}
+
+extern "C" bool V8RecordReplayCurrentReturnValue(v8::Local<v8::Value>* object) {
+  if (gCurrentReturnValue) {
+    *object = v8::Utils::ToLocal(*gCurrentReturnValue);
+    return true;
+  }
+  return false;
+}
+
+RUNTIME_FUNCTION(Runtime_RecordReplayTrackObjectId) {
+  DCHECK_EQ(1, args.length());
+  Handle<Object> value = args.at(0);
+
+  v8::Isolate* v8_isolate = (v8::Isolate*) isolate;
+  RecordReplayObjectId(v8_isolate, v8_isolate->GetCurrentContext(),
+                       v8::Utils::ToLocal(value),
+                       /* allow_create */ true);
+
   return ReadOnlyRoots(isolate).undefined_value();
 }
 

--- a/src/runtime/runtime-internal.cc
+++ b/src/runtime/runtime-internal.cc
@@ -230,9 +230,32 @@ RUNTIME_FUNCTION(Runtime_ThrowInvalidTypedArrayAlignment) {
                              problem_string, type, element_size));
 }
 
+extern void RecordReplayOnExceptionUnwind(Isolate* isolate);
+
+extern uint64_t* gProgressCounter;
+
+static uint64_t gLastExceptionUnwindProgress;
+
 RUNTIME_FUNCTION(Runtime_UnwindAndFindExceptionHandler) {
   SealHandleScope shs(isolate);
   DCHECK_EQ(0, args.length());
+
+  // The number of calls made when unwinding a given exception can vary when
+  // recording vs. replaying, presumably due to different JIT behavior.
+  // We only need to notify the record/replay driver the first time an
+  // exception is thrown, and not on subsequent frame unwinds. We detect this
+  // by looking at the progress counter, which is incremented whenever entering
+  // a script, try/catch block, or try/finally block. If the progress counter
+  // when unwinding is the same as the last time when unwinding, this is a
+  // frame unwind instead of an initial throw and we can ignore it.
+  if (recordreplay::IsRecordingOrReplaying() &&
+      !recordreplay::AreEventsDisallowed() &&
+      IsMainThread() &&
+      *gProgressCounter != gLastExceptionUnwindProgress) {
+    RecordReplayOnExceptionUnwind(isolate);
+    gLastExceptionUnwindProgress = *gProgressCounter;
+  }
+
   return isolate->UnwindAndFindHandler();
 }
 

--- a/src/runtime/runtime-promise.cc
+++ b/src/runtime/runtime-promise.cc
@@ -8,8 +8,6 @@
 #include "src/execution/microtask-queue.h"
 #include "src/objects/js-promise-inl.h"
 
-#include "src/base/replayio.h"
-
 namespace v8 {
 namespace internal {
 

--- a/src/runtime/runtime-promise.cc
+++ b/src/runtime/runtime-promise.cc
@@ -8,6 +8,8 @@
 #include "src/execution/microtask-queue.h"
 #include "src/objects/js-promise-inl.h"
 
+#include "src/base/replayio.h"
+
 namespace v8 {
 namespace internal {
 

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -183,7 +183,15 @@ constexpr bool CanTriggerGC(T... properties) {
   F(ScheduleBreak, 0, 1)                        \
   F(ScriptLocationFromLine2, 4, 1)              \
   F(SetGeneratorScopeVariableValue, 4, 1)       \
-  I(IncBlockCounter, 2, 1)
+  I(IncBlockCounter, 2, 1)                      \
+  F(RecordReplayAssertExecutionProgress, 1, 1)  \
+  F(RecordReplayTargetProgressReached, 0, 1)    \
+  F(RecordReplayNotifyActivity, 0, 1)           \
+  F(RecordReplayAssertValue, 3, 1)              \
+  F(RecordReplayInstrumentation, 2, 1)          \
+  F(RecordReplayInstrumentationGenerator, 3, 1) \
+  F(RecordReplayInstrumentationReturn, 3, 1)    \
+  F(RecordReplayTrackObjectId, 1, 1)
 
 #define FOR_EACH_INTRINSIC_FORIN(F, I) \
   F(ForInEnumerate, 1, 1)              \

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -837,7 +837,9 @@ constexpr bool CanTriggerGC(T... properties) {
 
 #define FOR_EACH_INTRINSIC_WEAKREF(F, I)                             \
   F(JSFinalizationRegistryRegisterWeakCellWithUnregisterToken, 2, 1) \
-  F(JSWeakRefAddToKeptObjects, 1, 1)
+  F(JSWeakRefAddToKeptObjects, 1, 1)                                 \
+  F(JSReplayWeakRefConstruct, 1, 1)                                  \
+  F(JSReplayWeakRefDeref, 1, 1)
 
 #define FOR_EACH_INTRINSIC_RETURN_PAIR_IMPL(F, I) \
   F(DebugBreakOnBytecode, 1, 2)                   \

--- a/src/trap-handler/handler-shared.cc
+++ b/src/trap-handler/handler-shared.cc
@@ -20,6 +20,9 @@
 
 #include "src/trap-handler/trap-handler-internal.h"
 
+#include "include/v8.h"
+#include "src/base/logging.h"
+
 namespace v8 {
 namespace internal {
 namespace trap_handler {

--- a/src/utils/utils-inl.h
+++ b/src/utils/utils-inl.h
@@ -14,6 +14,8 @@
 #include "src/init/v8.h"
 #include "src/strings/char-predicates-inl.h"
 
+#include "replayio.h"
+
 namespace v8 {
 namespace internal {
 
@@ -26,6 +28,7 @@ class V8_NODISCARD TimedScope {
 
  private:
   static inline double TimestampMs() {
+    replayio::AutoPassThroughEvents pt;
     return V8::GetCurrentPlatform()->MonotonicallyIncreasingTime() *
            static_cast<double>(base::Time::kMillisecondsPerSecond);
   }

--- a/src/wasm/module-compiler.cc
+++ b/src/wasm/module-compiler.cc
@@ -15,6 +15,7 @@
 #include "src/base/platform/mutex.h"
 #include "src/base/platform/semaphore.h"
 #include "src/base/platform/time.h"
+#include "src/base/replayio.h"
 #include "src/codegen/compiler.h"
 #include "src/compiler/wasm-compiler.h"
 #include "src/debug/debug.h"
@@ -1527,6 +1528,8 @@ void TransitiveTypeFeedbackProcessor::ProcessFunction(int func_index) {
 void TriggerTierUp(Isolate* isolate,
                    Tagged<WasmTrustedInstanceData> trusted_instance_data,
                    int func_index) {
+  replayio::AutoDisallowEvents disallow("wasm::TriggerTierUp");
+
   NativeModule* native_module = trusted_instance_data->native_module();
   CompilationStateImpl* compilation_state =
       Impl(native_module->compilation_state());

--- a/src/wasm/wasm-code-manager.h
+++ b/src/wasm/wasm-code-manager.h
@@ -39,6 +39,8 @@
 #include "src/wasm/wasm-module-sourcemap.h"
 #include "src/wasm/wasm-tier.h"
 
+#include "include/v8.h"
+
 namespace v8 {
 class CFunctionInfo;
 namespace internal {
@@ -465,6 +467,12 @@ class V8_EXPORT_PRIVATE WasmCode final {
     DCHECK_LE(handler_table_offset, unpadded_binary_size);
     DCHECK_LE(code_comments_offset, unpadded_binary_size);
     DCHECK_LE(constant_pool_offset, unpadded_binary_size);
+
+    // Keep WasmCode objects around forever to avoid problems with them being
+    // destroyed at non-deterministic points.
+    if (recordreplay::IsRecordingOrReplaying("leak-references", "WasmCode")) {
+      IncRef();
+    }
     DCHECK_LE(jump_table_info_offset, unpadded_binary_size);
   }
 

--- a/third_party/inspector_protocol/crdtp/dispatch.cc
+++ b/third_party/inspector_protocol/crdtp/dispatch.cc
@@ -11,6 +11,8 @@
 #include "frontend_channel.h"
 #include "protocol_core.h"
 
+#include "include/v8.h"
+
 namespace v8_crdtp {
 // =============================================================================
 // DispatchResponse - Error status and chaining / fall through
@@ -459,8 +461,9 @@ DomainDispatcher::Callback::Callback(
 void DomainDispatcher::Callback::sendIfActive(
     std::unique_ptr<Serializable> partialMessage,
     const DispatchResponse& response) {
-  if (!backend_impl_ || !backend_impl_->get())
+  if (!backend_impl_ || !backend_impl_->get()) {
     return;
+  }
   backend_impl_->get()->sendResponse(call_id_, response,
                                      std::move(partialMessage));
   backend_impl_ = nullptr;


### PR DESCRIPTION
## WIP: Re-apply Replay V8 instrumentation onto **V8 15.1** (Chromium M151)

`replayio/chromium-v8` was forked at **V8 10.8** (Chromium M108). This branch re-applies the
Replay V8 instrumentation onto **V8 15.1.43** (M151's V8, base `3f531962`) — ~5 major versions
forward. Companion to the chromium/src M151 port (replayio/chromium#1358). Iterative WIP.

### What's landed (3 commits, ~127 files)
| Layer | Files |
|---|---|
| 10 new replay-owned V8 files (`include/replayio*.h`, `src/replay/*`, `src/base/replayio.h`) | 10 |
| 47 cleanly 3-way-merged V8 hooks | 47 |
| 70 best-effort anchor-applied conflict hooks (NEEDS REVIEW) | 70 |

**Hooks instrumented: ~117 / 139 present files.** Auto-applied hooks passed a brace-balance
corruption check (1 file auto-reverted and deferred to manual).

### What remains
- **22 conflict files + 5 gone** need manual port — these sit in V8's most-rewritten subsystems
  (`src/heap`, `src/compiler`, `src/interpreter`, `src/codegen`), where 10.8→15.1 drift is heaviest
  (Maglev, Turboshaft, pointer-compression, GC rewrites). The 5 gone: `cpu.cc`,
  `effect-control-linearizer.cc`, `typer.cc`, `concurrent-allocator.cc`, `scavenge-job.cc`.
- `origin/upstream` should be repointed to a fresh V8 mirror (currently stale at 9.1).

### Notes for review
- **Base is `v8-m151-base`** (pinned V8 15.1 commit `3f531962`), not `master`, so the diff is
  exactly the replay re-application on clean V8 15.1.
- "NEEDS REVIEW" hooks were placed by automated anchor application; deep-engine V8 hooks are the
  highest-drift in the whole port — verify carefully (misplacements surface as replay divergences).
