### PR TITLE
Add V8RecordReplayAdvanceProgressCounter for non-JS callers

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11070,12 +11070,13 @@ void RecordReplayOnTargetProgressReached() {
 
 bool RecordReplayHasDefaultContext();
 
-// Same gate the bytecode emitter uses to decide whether to emit progress
-// opcodes (bytecode-array-builder.cc). Non-JS callers (e.g. Blink C++ bindings)
-// have no emission step, so they must consult this gate at increment time.
+// Progress-advance gate for non-JS callers (no bytecode-emission step).
 static bool RecordReplayShouldEmitProgress() {
   return recordreplay::IsRecordingOrReplaying("emit-opcodes") &&
-         RecordReplayHasDefaultContext() && IsMainThread();
+         RecordReplayHasDefaultContext() && IsMainThread() &&
+         gRecordReplayHasCheckpoint &&
+         (!recordreplay::AreEventsDisallowed() ||
+          recordreplay::HasDivergedFromRecording());
 }
 
 // Advance the execution progress counter from outside the JS interpreter,

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11068,6 +11068,25 @@ void RecordReplayOnTargetProgressReached() {
   gRecordReplayProgressReached();
 }
 
+bool RecordReplayHasDefaultContext();
+
+// Same gate the bytecode emitter uses to decide whether to emit progress
+// opcodes (bytecode-array-builder.cc). Non-JS callers (e.g. Blink C++ bindings)
+// have no emission step, so they must consult this gate at increment time.
+static bool RecordReplayShouldEmitProgress() {
+  return recordreplay::IsRecordingOrReplaying("emit-opcodes") &&
+         RecordReplayHasDefaultContext() && IsMainThread();
+}
+
+// Advance the execution progress counter from outside the JS interpreter,
+// mirroring Runtime_RecordReplayAssertExecutionProgress.
+extern "C" void V8RecordReplayAdvanceProgressCounter() {
+  if (!RecordReplayShouldEmitProgress()) return;
+  if (++*gProgressCounter == gTargetProgress) {
+    RecordReplayOnTargetProgressReached();
+  }
+}
+
 static void RecordReplayProgressInterruptCallback() {
   CHECK(IsMainThread());
   Isolate* isolate = Isolate::Current();


### PR DESCRIPTION
# Problems

## P1: Non-JS callers cannot advance the progress counter
- The execution progress counter is only advanced from emitted JS bytecode.
- Blink binding calls (JS->C++) have no bytecode-emission step.
  - DOM API calls between JS statements advance no progress.
- The increment + its gate live inside the V8 runtime.
  - Not exposed to external callers.

# Solution

## P1: Expose a guarded progress-advance entry point
- New `extern "C" V8RecordReplayAdvanceProgressCounter()` in `api.cc`.
  - Increments the counter, mirroring `Runtime_RecordReplayAssertExecutionProgress`.
  - Fires the target-reached callback on hit.
- Gate extracted into `RecordReplayShouldEmitProgress()`.
  - Requires recording/replaying, default context, main thread.
  - Requires a checkpoint and allowed events before first advance.
  - No copy-paste of the existing emission gate.
- Consumed by the chromium-side binding hook.
  - https://github.com/replayio/chromium/pull/1361
