### PR TITLE
Truncate applicationDataMismatch frame lists to 10 per side

### DIFF
--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1049,17 +1049,19 @@ static uint64_t ProgressAt(int64_t k, size_t replayed_size) {
   return *gProgressCounter + k - (static_cast<int64_t>(replayed_size) - 1);
 }
 
-// Emit one array of frame strings: every entry from the first divergent index
-// d through the Assert progress. No per-entry progress; each entry k sits at
-// lastDeterministicProgress + (k - (d - 1)). A side that ran out at d yields [].
-static void AppendDivergentFrames(std::ostringstream& os, const uint64_t* entries,
-                                  size_t size, size_t d) {
+static const size_t kMaxDivergentFrames = 10;
+
+// Emits up to kMaxDivergentFrames entries from d; returns count omitted.
+static size_t AppendDivergentFrames(std::ostringstream& os, const uint64_t* entries,
+                                    size_t size, size_t d) {
+  size_t end = std::min(size, d + kMaxDivergentFrames);
   os << "[";
-  for (size_t k = d; k < size; k++) {
+  for (size_t k = d; k < end; k++) {
     if (k > d) os << ", ";
     os << "\"" << JsonEscape(GetScriptProgressEntryString(entries[k])) << "\"";
   }
   os << "]";
+  return size - end;
 }
 
 // `lastDeterministicProgress` is the progress of the last entry that matched in
@@ -1074,9 +1076,15 @@ static char* GetProgressMismatchMessage(const uint64_t* recorded, size_t recorde
   std::ostringstream os;
   os << "{ \"lastDeterministicProgress\": " << ProgressAt(static_cast<int64_t>(d) - 1, replayed_size)
      << ", \"recorded\": ";
-  AppendDivergentFrames(os, recorded, recorded_size, d);
+  size_t recordedTruncated = AppendDivergentFrames(os, recorded, recorded_size, d);
   os << ", \"replayed\": ";
-  AppendDivergentFrames(os, replayed, replayed_size, d);
+  size_t replayedTruncated = AppendDivergentFrames(os, replayed, replayed_size, d);
+  if (recordedTruncated) {
+    os << ", \"recordedTruncated\": " << recordedTruncated;
+  }
+  if (replayedTruncated) {
+    os << ", \"replayedTruncated\": " << replayedTruncated;
+  }
   os << " }";
 
   return strdup(os.str().c_str());

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -1051,17 +1051,22 @@ static uint64_t ProgressAt(int64_t k, size_t replayed_size) {
 
 static const size_t kMaxDivergentFrames = 10;
 
-// Emits up to kMaxDivergentFrames entries from d; returns count omitted.
-static size_t AppendDivergentFrames(std::ostringstream& os, const uint64_t* entries,
-                                    size_t size, size_t d) {
+// Emits up to kMaxDivergentFrames entries from d; appends a truncation note
+// as a trailing array entry if any were omitted.
+static void AppendDivergentFrames(std::ostringstream& os, const uint64_t* entries,
+                                  size_t size, size_t d) {
   size_t end = std::min(size, d + kMaxDivergentFrames);
   os << "[";
   for (size_t k = d; k < end; k++) {
     if (k > d) os << ", ";
     os << "\"" << JsonEscape(GetScriptProgressEntryString(entries[k])) << "\"";
   }
+  size_t omitted = size - end;
+  if (omitted) {
+    if (end > d) os << ", ";
+    os << "\"...truncated " << omitted << " more\"";
+  }
   os << "]";
-  return size - end;
 }
 
 // `lastDeterministicProgress` is the progress of the last entry that matched in
@@ -1076,15 +1081,9 @@ static char* GetProgressMismatchMessage(const uint64_t* recorded, size_t recorde
   std::ostringstream os;
   os << "{ \"lastDeterministicProgress\": " << ProgressAt(static_cast<int64_t>(d) - 1, replayed_size)
      << ", \"recorded\": ";
-  size_t recordedTruncated = AppendDivergentFrames(os, recorded, recorded_size, d);
+  AppendDivergentFrames(os, recorded, recorded_size, d);
   os << ", \"replayed\": ";
-  size_t replayedTruncated = AppendDivergentFrames(os, replayed, replayed_size, d);
-  if (recordedTruncated) {
-    os << ", \"recordedTruncated\": " << recordedTruncated;
-  }
-  if (replayedTruncated) {
-    os << ", \"replayedTruncated\": " << replayedTruncated;
-  }
+  AppendDivergentFrames(os, replayed, replayed_size, d);
   os << " }";
 
   return strdup(os.str().c_str());


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1371
* https://linear.app/replay/issue/RUN-2096#comment-a334b15f