### PR TITLE
crash-0008: diagnostic Assert on shared_ptr<NativeModule> refcount

### DIFF
--- a/src/objects/managed.cc
+++ b/src/objects/managed.cc
@@ -4,6 +4,7 @@
 
 #include "src/objects/managed.h"
 
+#include "include/v8.h"  // For replay.
 #include "src/handles/global-handles-inl.h"
 
 namespace v8 {
@@ -34,6 +35,10 @@ void ManagedObjectFinalizer(const v8::WeakCallbackInfo<void>& data) {
   // it can trigger garbage collection. The first pass callbacks
   // are not allowed to invoke V8 API.
   data.SetSecondPassCallback(&ManagedObjectFinalizerSecondPass);
+}
+
+void AssertManagedDestructorRefcount(long use_count) {
+  recordreplay::Assert("Managed::Destructor %ld", use_count);
 }
 
 }  // namespace internal

--- a/src/objects/managed.h
+++ b/src/objects/managed.h
@@ -102,6 +102,7 @@ class Managed : public Foreign {
   // to actually delete the shared pointer and decrement the shared refcount.
   static void Destructor(void* ptr) {
     auto shared_ptr_ptr = reinterpret_cast<std::shared_ptr<CppType>*>(ptr);
+    recordreplay::Assert("Managed::Destructor %ld", shared_ptr_ptr->use_count());
     delete shared_ptr_ptr;
   }
 };

--- a/src/objects/managed.h
+++ b/src/objects/managed.h
@@ -38,6 +38,10 @@ struct ManagedPtrDestructor {
 V8_EXPORT_PRIVATE void ManagedObjectFinalizer(
     const v8::WeakCallbackInfo<void>& data);
 
+// Out of line so callers of Managed<CppType>::Destructor don't need to
+// include the recordreplay headers from this template header.
+void AssertManagedDestructorRefcount(long use_count);
+
 // {Managed<T>} is essentially a {std::shared_ptr<T>} allocated on the heap
 // that can be used to manage the lifetime of C++ objects that are shared
 // across multiple isolates.
@@ -102,7 +106,7 @@ class Managed : public Foreign {
   // to actually delete the shared pointer and decrement the shared refcount.
   static void Destructor(void* ptr) {
     auto shared_ptr_ptr = reinterpret_cast<std::shared_ptr<CppType>*>(ptr);
-    recordreplay::Assert("Managed::Destructor %ld", shared_ptr_ptr->use_count());
+    AssertManagedDestructorRefcount(shared_ptr_ptr->use_count());
     delete shared_ptr_ptr;
   }
 };


### PR DESCRIPTION
# v8: crash-0008 diagnostic Assert in `Managed<CppType>::Destructor`

# Problem

* ReplayMismatch divergence: recorded stack shows `Managed<WasmStreaming>::Destructor` → `__on_zero_shared()` → `NativeModule::~NativeModule()` → `CompilationState::~CompilationState()` → `JobHandle::CancelAndDetach()` → `JobTaskSource::Cancel` → hits Assert `"OrderedLock atomic 2068"`.
* `__on_zero_shared()` in the recordedStack means the `delete shared_ptr_ptr` in `Managed<CppType>::Destructor` (managed.h:103) was the specific decrement that dropped the shared `shared_ptr<NativeModule>` refcount to zero, triggering the whole cascade.
* That refcount is shared with other holders (`WasmEngine::native_modules_`, other isolates, in-flight compile jobs); whether it hits zero at this exact call site can differ between record and replay depending on when those other holders release/retain — unprovable without record-time data (divergence, no repro).

# Solution

* Solution Recipe: Assert the refcount value at the decrement site to convert the divergence into a comparable data value on next replay.
* Implementation:
  * Added `recordreplay::Assert("Managed::Destructor %ld", shared_ptr_ptr->use_count())` before `delete shared_ptr_ptr;` in [managed.h:103](src/objects/managed.h#L103), using `v8::recordreplay::Assert` per existing convention in `heap-inl.h`/`isolate.cc`.
* Why does this work?
  * Surfaces the recorded vs. replayed `use_count()` at this call site, pinpointing whether the refcount hitting zero here is the divergence origin.

# Raw Data

* buildId: `linux-chromium-20260626-9aa456976e8d-bbef03887da6`
* linkerVersion: `linker-linux-15936-bbef03887da6`
* recordingId: `10b5683b-cda9-4ef7-a4b6-2ec90368298d`
* hitAssert: `348431`, thread 14, `"OrderedLock atomic 2068"`
* recordedStack: `JobTaskSource::Cancel(Transaction*)` ← `JobHandle::CancelAndDetach()` ← `CompilationState::~CompilationState()` ← `NativeModule::~NativeModule()` ← `__shared_ptr_pointer<NativeModule>::__on_zero_shared()` ← `Managed<WasmStreaming>::Destructor` ← `Isolate::Deinit()` ← `Isolate::Delete()`

---
paired w/ https://github.com/replayio/chromium/pull/1373