### PR TITLE
Allow string codegen in CommandCallback (Trusted Types)

### DIFF
--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3863,6 +3863,34 @@ static void EnsureIsolateContext(Isolate* isolate, base::Optional<SaveAndSwitchC
   }
 }
 
+namespace {
+
+// Bypass Trusted Types for runtime-owned command evals.
+// Same approach as V8 Inspector InjectedScript::Scope::allowCodeGenerationFromStrings:
+// AllowCodeGenerationFromStrings(true) short-circuits before the TT callback.
+struct AutoAllowCodeGenerationFromStrings {
+  Handle<Context> context_;
+  bool need_restore_;
+
+  explicit AutoAllowCodeGenerationFromStrings(Isolate* isolate)
+      : context_(handle(isolate->context(), isolate)),
+        need_restore_(
+            context_->allow_code_gen_from_strings().IsFalse(isolate)) {
+    if (need_restore_) {
+      context_->set_allow_code_gen_from_strings(
+          ReadOnlyRoots(isolate).true_value());
+    }
+  }
+
+  ~AutoAllowCodeGenerationFromStrings() {
+    if (need_restore_) {
+      context_->set_allow_code_gen_from_strings(
+          ReadOnlyRoots(context_->GetIsolate()).false_value());
+    }
+  }
+};
+
+}  // namespace
 
 char* CommandCallback(const char* command, const char* params) {
   CHECK(IsMainThread());
@@ -3875,6 +3903,7 @@ char* CommandCallback(const char* command, const char* params) {
   EnsureIsolateContext(isolate, ssc);
 
   HandleScope scope(isolate);
+  AutoAllowCodeGenerationFromStrings allow_codegen(isolate);
 
   if (recordreplay::HasDivergedFromRecording()) {
     v8_inspector::V8Inspector* inspectorRaw = v8::debug::GetInspector((v8::Isolate*)isolate);


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1376

# Summary

* G1: Trusted Types blocks runtime-owned command eval
  * Pages with a rejecting Trusted Types `default` policy make `Target.evaluatePrivileged` throw.
  * That surfaces as `{is_error:true}` and the linker `Die`s.
  * Fix: temporarily allow string codegen in `CommandCallback`, same as V8 Inspector.

# Problem

## G1: Trusted Types blocks runtime-owned command eval

* Symptom
  * `Target.evaluatePrivileged` on Cloudflare Turnstile throws:
    * `EvalError: Refused to evaluate a string as JavaScript because this document requires 'Trusted Type' assignment.`
  * Linker then crashes via `Command.cpp` on `is_error`.
* Causal chain
  * Page installs Trusted Types `default` policy that rejects arbitrary scripts.
  * Linker dispatches command → `CommandCallback` → JS `commandCallback` → `eval(expression)`.
  * Blink `CodeGenerationCheckCallbackInMainThread` runs Trusted Types checks.
  * Policy rejects → `EvalError` → `{is_error:true}` → `Die`.
* Gap vs Inspector
  * V8 Inspector sets `AllowCodeGenerationFromStrings(true)` around evaluate.
  * That short-circuits before the Trusted Types callback.
  * `CommandCallback` did not.

# Solution

## G1: Trusted Types blocks runtime-owned command eval

* Recipe
  * Mirror Inspector’s string-codegen allow around runtime-owned command dispatch.
* Implementation
  * In `v8/src/debug/debug.cc` `CommandCallback`:
    * RAII `AutoAllowCodeGenerationFromStrings` on the current context.
    * Set allow if currently false.
    * Restore on exit.
* Why this works
  * V8 skips the Trusted Types callback when string codegen is allowed.
  * Covers raw `eval` in command handlers, including `Target.evaluatePrivileged`.

# Raw Data

* buildId: `linux-chromium-20260709-3fc067f1c293-ed87c3d17b52`
* linkerVersion: `linker-linux-16006-ed87c3d17b52`
* recordingId: `defa52c6-d700-43a7-8137-746fe0140743`