### PR TITLE
crash-0015: force Managed destructor onto deterministic teardown path

### DIFF
--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -3108,8 +3108,18 @@ char* Isolate::RestoreThread(char* from) {
   return from + sizeof(ThreadLocalTop);
 }
 
+namespace {
+long CountManagedPtrDestructors(ManagedPtrDestructor* head) {
+  long count = 0;
+  for (; head; head = head->next_) ++count;
+  return count;
+}
+}  // namespace
+
 void Isolate::ReleaseSharedPtrs() {
   base::MutexGuard lock(&managed_ptr_destructors_mutex_);
+  recordreplay::Assert("Isolate::ReleaseSharedPtrs %ld",
+                       CountManagedPtrDestructors(managed_ptr_destructors_head_));
   while (managed_ptr_destructors_head_) {
     ManagedPtrDestructor* l = managed_ptr_destructors_head_;
     ManagedPtrDestructor* n = nullptr;
@@ -3140,6 +3150,9 @@ void Isolate::RegisterManagedPtrDestructor(ManagedPtrDestructor* destructor) {
   }
   destructor->next_ = managed_ptr_destructors_head_;
   managed_ptr_destructors_head_ = destructor;
+  recordreplay::Assert(
+      "Isolate::RegisterManagedPtrDestructor %ld",
+      CountManagedPtrDestructors(managed_ptr_destructors_head_));
 }
 
 void Isolate::UnregisterManagedPtrDestructor(ManagedPtrDestructor* destructor) {

--- a/src/objects/managed.cc
+++ b/src/objects/managed.cc
@@ -14,6 +14,13 @@ namespace {
 // Called by the GC in its second pass when a Managed<CppType> is
 // garbage collected.
 void ManagedObjectFinalizerSecondPass(const v8::WeakCallbackInfo<void>& data) {
+  // Defer teardown to the deterministic Isolate::ReleaseSharedPtrs path
+  // instead of running it here at GC time.
+  if (recordreplay::AreEventsDisallowed() &&
+      recordreplay::IsRecordingOrReplaying(
+          "leak-references", "ManagedObjectFinalizerSecondPass")) {
+    return;
+  }
   auto destructor =
       reinterpret_cast<ManagedPtrDestructor*>(data.GetParameter());
   Isolate* isolate = reinterpret_cast<Isolate*>(data.GetIsolate());


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1378

# Summary

* **Symptom**: `StackCommonFrame` replay mismatch at `Managed<WasmStreaming>::Destructor` during worker `Isolate` teardown (recorded `Managed::Destructor 1` vs replayed `OrderedLock atomic 2671`).
* **Root cause**: The GC second-pass finalizer `ManagedObjectFinalizerSecondPass` runs the managed destructor and unlinks its node from `managed_ptr_destructors_head_` at non-deterministic GC time (under `EventsDisallowed`), so the deterministic `Isolate::ReleaseSharedPtrs` teardown loop sees different list membership per side.
* **Fix (v8)**: When events are disallowed under record/replay, `ManagedObjectFinalizerSecondPass` returns early, deferring teardown to the deterministic `Isolate::ReleaseSharedPtrs` path (runs identically on record and replay).
* **Diagnostics (v8)**: Add `recordreplay::Assert` on the `managed_ptr_destructors_head_` list length at `ReleaseSharedPtrs` entry and after each `RegisterManagedPtrDestructor` insert (the guarding mutex is unordered).

# Problem

* Problem type: ReplayMismatch.
* MismatchKind: StackCommonFrame

## Important Context

* buildId: linux-chromium-20260709-3fc067f1c293-ed87c3d17b52
* linkerVersion: linker-linux-16006-ed87c3d17b52
* recordingId: 33b410a7-bdcc-48d8-8504-f153d981aa5f

### Crash Report Core
```json
{
  "why": "Mismatch",
  "category": "Sapling",
  "manifest": {
    "kind": "runToPoint",
    "endpoint": {
      "progress": 753465,
      "checkpoint": 45
    }
  },
  "recorded": "Managed::Destructor 1",
  "replayed": "OrderedLock atomic 2671",
  "threadId": 15,
  "backtrace": {
    "progress": 413743,
    "threadId": 15,
    "checkpoint": 41
  },
  "recordedStack": [
    "v8::recordreplay::Assert(char.const*,....)+149",
    "v8::internal::Managed<v8::WasmStreaming>::Destructor(void*)+31",
    "v8::internal::Isolate::Deinit()+1016",
    "v8::internal::Isolate::Delete(v8::internal::Isolate*)+100",
    "gin::IsolateHolder::~IsolateHolder()+42",
    "blink::V8PerIsolateData::Destroy(v8::Isolate*)+249",
    "blink::WorkerBackingThread::ShutdownOnBackingThread()+151",
    "blink::WorkerThread::PerformShutdownOnWorkerThread()+525"
  ],
  "replayedStack": [
    "base::internal::JobTaskSource::Cancel(base::internal::TaskSource::Transaction*)+25",
    "base::JobHandle::CancelAndDetach()+19",
    "v8::internal::wasm::CompilationState::~CompilationState()+44",
    "v8::internal::wasm::NativeModule::~NativeModule()+525",
    "std::Cr::__shared_ptr_pointer<v8::internal::wasm::NativeModule*,.std::Cr::shared_ptr<v8::internal::wasm::NativeModule>::__shared_ptr_default_delete<v8::internal::wasm::NativeModule,.v8::internal::wasm::NativeModule>,.std::Cr::allocator<v8::internal::wasm::NativeModule>.>::__on_zero_shared()+23",
    "v8::internal::Managed<v8::WasmStreaming>::Destructor(void*)+72",
    "v8::internal::Isolate::Deinit()+1016",
    "v8::internal::Isolate::Delete(v8::internal::Isolate*)+100"
  ]
}
```

## FrameCandidates

* `v8::internal::Managed<v8::WasmStreaming>::Destructor(void*)+31` (recorded)
  * location: `Managed<CppType>::Destructor` at `v8/src/objects/managed.h:109`
  * code: `AssertManagedDestructorRefcount(shared_ptr_ptr->use_count());`
* `v8::internal::Managed<v8::WasmStreaming>::Destructor(void*)+72` (replayed)
  * location: `Managed<CppType>::Destructor` at `v8/src/objects/managed.h:110`
  * code: `delete shared_ptr_ptr;` (inlined shared_ptr control-block virtual deleter dispatch)
* `v8::internal::Isolate::Deinit()+1016` (recorded & replayed, common)
  * location: `Isolate::ReleaseSharedPtrs` (inlined into `Isolate::Deinit`) at `v8/src/execution/isolate.cc:3118`
  * code: `l->destructor_(l->shared_ptr_ptr_);`
* `v8::internal::Isolate::Delete(v8::internal::Isolate*)+100` (recorded & replayed, common)
  * location: `Isolate::Delete` at `v8/src/execution/isolate.cc:3456`
  * code: `isolate->Deinit();`

## DivergentPathSegments

### Root: Isolate::Delete

```cpp
// Root (both stacks): Isolate::Delete+100
void Isolate::Delete(Isolate* isolate) {
  // Isolate::Deinit+1016
  isolate->Deinit();
  void Isolate::Deinit() {
    // Isolate::ReleaseSharedPtrs (inlined into Deinit+1016)
    ReleaseSharedPtrs();
    void Isolate::ReleaseSharedPtrs() {
      // [Branch] CANDIDATE
      while (managed_ptr_destructors_head_) {
        ManagedPtrDestructor* l = managed_ptr_destructors_head_;
        ManagedPtrDestructor* n = nullptr;
        managed_ptr_destructors_head_ = nullptr;
        // [Branch] CANDIDATE
        for (; l != nullptr; l = n) {
          // Managed<WasmStreaming>::Destructor+31 (recorded) / +72 (replayed)
          l->destructor_(l->shared_ptr_ptr_);
          void Managed<WasmStreaming>::Destructor(void* ptr) {
            AssertManagedDestructorRefcount(shared_ptr_ptr->use_count()); // <<< RECORDED LEAF
            delete shared_ptr_ptr;
              // __shared_ptr_emplace<NativeModule>::__on_zero_shared+23
              // NativeModule::~NativeModule+525
              ~NativeModule() {
                // CompilationState::~CompilationState+44
                ~CompilationStateImpl() {
                  // [Branch] NOT-ASSERTABLE DisallowEvents, sync-code
                  if (compile_job_->IsValid())
                    // JobHandle::CancelAndDetach+19
                    compile_job_->CancelAndDetach();
                      // JobTaskSource::Cancel+25
                      task_source_->Cancel(); // <<< REPLAYED LEAF
                }
              }
          }
          n = l->next_;
          delete l;
        }
      }
    }
  }
}
```

## DominantWarning

* Dominating Warning: `"Recording assertion with events disallowed: Managed::Destructor 1 [EventsDisallowed:WorkQueue::RecordReplayRunUnorderedTasks]"` (threadId 15, checkpoint 33, progress 376095, `wasRecording: false`).
* Ordering: same thread (15), same assert site/counter (`Managed::Destructor 1`) as the mismatch's `recorded` value; occurs at progress 376095, strictly before the mismatch's recorded-assert backtrace (progress 413743) and endpoint (progress 753465) — precedes the mismatch in execution order.
* Explains the mismatch:
  * Its stack is `Managed<v8::WasmStreaming>::Destructor+31` reached via `ManagedObjectFinalizerSecondPass` → `GlobalHandles::InvokeSecondPassPhantomCallbacks` → `WorkQueue::RecordReplayRunUnorderedTasks` — i.e. this destructor already fires from GC second-pass phantom-callback finalization, inside a region flagged `EventsDisallowed`.
  * The companion warning (`"Ordered lock with events disallowed atomic ..."`, `wasRecording: true`) hits the same `EventsDisallowed:WorkQueue::RecordReplayRunUnorderedTasks` context but via the replayed-side path: `NativeModule::~NativeModule` → `CompilationState::~CompilationState` → `JobTaskSource::Cancel`, landing on the same `Managed<v8::WasmStreaming>::Destructor+72` frame.
  * Both warnings independently show the same object's destructor racing with unordered-task processing under disallowed-events conditions — recorded via GC finalizer, replayed via WASM native-module teardown — which alone predicts the recorded/replayed divergence at this exact destructor.

# Solution

## Solution Recipe

* `determinism-leak-memory`: skip a GC-controlled destructor with side effects during record/replay, deferring it to a deterministic teardown path.

## Implementation

* `v8/src/objects/managed.cc` — `ManagedObjectFinalizerSecondPass`:
  * Early-return before `UnregisterManagedPtrDestructor` when `recordreplay::AreEventsDisallowed()` and `recordreplay::IsRecordingOrReplaying("leak-references", "ManagedObjectFinalizerSecondPass")`.
  * Skips `destructor_`, `delete destructor`, and `AdjustAmountOfExternalAllocatedMemory` at GC time; the node stays on `managed_ptr_destructors_head_`.
* `v8/src/execution/isolate.cc` — diagnostics:
  * `CountManagedPtrDestructors(head)` helper.
  * `recordreplay::Assert("Isolate::ReleaseSharedPtrs %ld", ...)` at loop entry.
  * `recordreplay::Assert("Isolate::RegisterManagedPtrDestructor %ld", ...)` after each insert (the guarding mutex is unordered).

## Why does this work?

* GC second-pass finalizer timing is non-deterministic, so running `destructor_` there tore each node off `managed_ptr_destructors_head_` at different points per side.
* Deferring teardown makes `Isolate::ReleaseSharedPtrs` — which runs at deterministic `Isolate::Deinit` time — the sole path that invokes `destructor_` and consumes the list, so the `Managed::Destructor` Assert stream is produced identically on record and replay.

# Raw Data

* buildId: linux-chromium-20260709-3fc067f1c293-ed87c3d17b52
* linkerVersion: linker-linux-16006-ed87c3d17b52
* recordingId: 33b410a7-bdcc-48d8-8504-f153d981aa5f
