### PR TITLE
Add Context-identity diagnostics to pin down garbage-Context crash in CommandCallback

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -5,7 +5,9 @@
 #include "src/api/api.h"
 
 #include <algorithm>  // For min
+#include <cinttypes>
 #include <cmath>      // For isnan.
+#include <cstdio>
 #include <limits>
 #include <sstream>
 #include <string>
@@ -11226,6 +11228,24 @@ extern "C" void V8RecordReplayGetDefaultContext(v8::Isolate* isolate, v8::Local<
 
 bool RecordReplayHasDefaultContext() {
   return !!gDefaultContext;
+}
+
+// Tagged pointer of the DefaultContext for `isolate`, or 0 if none. Deref-free:
+// survives a garbage current Context, so safe from command/teardown diagnostics.
+extern "C" uintptr_t V8RecordReplayGetDefaultContextAddress(v8::Isolate* isolate) {
+  if (!IsMainThread() || !gDefaultContext) return 0;
+  v8::Local<v8::Context> cx = gDefaultContext->Get(isolate);
+  return *reinterpret_cast<internal::Address*>(*cx);
+}
+
+// Canonical ContextAddress token "iso=.. ctx=..". `isolate` and `ctxAddr` must
+// be a coherent pair (same isolate the ctx was materialized against).
+std::string RecordReplayContextAddressToken(v8::Isolate* isolate,
+                                            uintptr_t ctxAddr) {
+  char buf[64];
+  snprintf(buf, sizeof(buf), "iso=%" PRIxPTR " ctx=%" PRIxPTR,
+           reinterpret_cast<uintptr_t>(isolate), ctxAddr);
+  return buf;
 }
 
 extern void RecordReplayInitInstrumentationState();

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -4,8 +4,8 @@
 
 #include "src/debug/debug.h"
 
-#include <cinttypes>
 #include <memory>
+#include <string>
 #include <unordered_set>
 
 #include "src/api/api-inl.h"
@@ -3850,9 +3850,10 @@ static InternalCommandCallback gInternalCommandCallbacks[] = {
 static Eternal<Value>* gCommandCallback;
 
 extern "C" void V8RecordReplayGetDefaultContext(v8::Isolate* isolate, v8::Local<v8::Context>* cx);
+std::string RecordReplayContextAddressToken(v8::Isolate* isolate, uintptr_t ctxAddr);
 extern uint64_t* gProgressCounter;
 extern int gRecordReplayCheckProgress;
-static int gPauseContextGroupId = 0;
+int gPauseContextGroupId = 0;
 
 // Make sure that the isolate has a context by switching to the default
 // context if necessary.
@@ -3870,8 +3871,11 @@ static void EnsureIsolateContext(Isolate* isolate, base::Optional<SaveAndSwitchC
   static Address gLastCommandContext = kNullAddress;
   if (ctx.ptr() != gLastCommandContext) {
     recordreplay::Print(
-        "ReplayScript COMMAND_CONTEXT_CHANGE %s iso=%" PRIxPTR " ctx=%" PRIxPTR " group=%d",
-        source, reinterpret_cast<uintptr_t>(isolate), ctx.ptr(), gPauseContextGroupId);
+        "ReplayScript COMMAND_CONTEXT_CHANGE %s %s group=%d win=? frame=?",
+        source,
+        RecordReplayContextAddressToken(
+            reinterpret_cast<v8::Isolate*>(isolate), ctx.ptr()).c_str(),
+        gPauseContextGroupId);
     gLastCommandContext = ctx.ptr();
   }
 

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -4,6 +4,7 @@
 
 #include "src/debug/debug.h"
 
+#include <cinttypes>
 #include <memory>
 #include <unordered_set>
 
@@ -23,6 +24,7 @@
 #include "src/execution/isolate-inl.h"
 #include "src/execution/v8threads.h"
 #include "src/handles/global-handles-inl.h"
+#include "src/heap/combined-heap.h"
 #include "src/heap/heap-inl.h"  // For NextDebuggingId.
 #include "src/init/bootstrapper.h"
 #include "src/inspector/v8-debugger-agent-impl.h"
@@ -3855,12 +3857,30 @@ static int gPauseContextGroupId = 0;
 // Make sure that the isolate has a context by switching to the default
 // context if necessary.
 static void EnsureIsolateContext(Isolate* isolate, base::Optional<SaveAndSwitchContext>& ssc) {
+  const char* source = "slot";
   if (isolate->context().is_null()) {
+    source = "default";
     Local<v8::Context> v8_context;
     V8RecordReplayGetDefaultContext((v8::Isolate*)isolate, &v8_context);
     Handle<Context> context = Utils::OpenHandle(*v8_context);
     ssc.emplace(isolate, *context);
   }
+
+  Context ctx = isolate->context();
+  static Address gLastCommandContext = kNullAddress;
+  if (ctx.ptr() != gLastCommandContext) {
+    recordreplay::Print(
+        "ReplayScript COMMAND_CONTEXT_CHANGE %s iso=%" PRIxPTR " ctx=%" PRIxPTR " group=%d",
+        source, reinterpret_cast<uintptr_t>(isolate), ctx.ptr(), gPauseContextGroupId);
+    gLastCommandContext = ctx.ptr();
+  }
+
+  CHECK(isolate);
+  CHECK(isolate->heap());
+  CHECK(!ctx.is_null());
+  CHECK(ctx.IsHeapObject());
+  CHECK(IsValidHeapObject(isolate->heap(), HeapObject::cast(ctx)));
+  CHECK(ctx.IsContext());
 }
 
 namespace {

--- a/src/inspector/v8-inspector-impl.cc
+++ b/src/inspector/v8-inspector-impl.cc
@@ -30,6 +30,7 @@
 
 #include "src/inspector/v8-inspector-impl.h"
 
+#include <string>
 #include <vector>
 
 #include "include/v8-context.h"
@@ -53,6 +54,13 @@
 #include "src/inspector/value-mirror.h"
 
 #include "v8.h"
+
+extern "C" uintptr_t V8RecordReplayGetDefaultContextAddress(v8::Isolate* isolate);
+namespace v8 {
+namespace internal {
+std::string RecordReplayContextAddressToken(v8::Isolate* isolate, uintptr_t ctxAddr);
+}
+}
 
 namespace v8_inspector {
 
@@ -171,16 +179,22 @@ InspectedContext* V8InspectorImpl::getContext(int groupId,
   auto contextGroupIt = m_contexts.find(groupId);
   if (contextGroupIt == m_contexts.end()) {
     v8::recordreplay::CommandDiagnostic(
-        "[RUN-2486-2537] V8InspectorImpl::getContext A %d %d %zu", contextId,
-        groupId, m_contexts.size());
+        "[RUN-2486-2537] V8InspectorImpl::getContext A %d %d %zu %s", contextId,
+        groupId, m_contexts.size(),
+        v8::internal::RecordReplayContextAddressToken(
+            m_isolate, V8RecordReplayGetDefaultContextAddress(m_isolate))
+            .c_str());
     return nullptr;
   }
 
   auto contextIt = contextGroupIt->second->find(contextId);
   if (contextIt == contextGroupIt->second->end()) {
     v8::recordreplay::CommandDiagnostic(
-        "[RUN-2486-2537] V8InspectorImpl::getContext B %d %d %zu", contextId,
-        groupId, contextGroupIt->second->size());
+        "[RUN-2486-2537] V8InspectorImpl::getContext B %d %d %zu %s", contextId,
+        groupId, contextGroupIt->second->size(),
+        v8::internal::RecordReplayContextAddressToken(
+            m_isolate, V8RecordReplayGetDefaultContextAddress(m_isolate))
+            .c_str());
     return nullptr;
   }
 


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1381