### PR TITLE
crash-0020-b: extend Context-identity diagnostics for CommandCallback fault

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11239,32 +11239,27 @@ extern "C" uintptr_t V8RecordReplayGetDefaultContextAddress(v8::Isolate* isolate
   return *reinterpret_cast<internal::Address*>(*cx);
 }
 
-// [crash-0017] Trace Context identities through the execution.
-// ContextAddress token "iso=.. ctx=.."[, " id=.."].
-// includeId=true embeds id in the returned token (deref can fault first).
-// includeId=false returns address-only, but still logs id separately after
-// printing the address — so a corrupt Context still leaves an address trail.
+// [crash-0017] ContextAddress token: "iso=.. ctx=.."[, " id=.."].
+// includeId=false: address-only, no heap deref.
+// includeId=true: embeds debug_context_id (NativeContext-only; can fault).
+// Max token length on 64-bit: "iso="(4)+16+" ctx="(5)+16+" id="(4)+11+NUL < 64.
 std::string RecordReplayContextAddressToken(v8::Isolate* isolate,
                                             uintptr_t ctxAddr,
                                             bool includeId) {
-  char buf[96];
-  snprintf(buf, sizeof(buf), "iso=%" PRIxPTR " ctx=%" PRIxPTR,
-           reinterpret_cast<uintptr_t>(isolate), ctxAddr);
-  if (ctxAddr == 0) {
+  char buf[64];
+  if (!includeId || ctxAddr == 0) {
+    snprintf(buf, sizeof(buf), "iso=%" PRIxPTR " ctx=%" PRIxPTR,
+             reinterpret_cast<uintptr_t>(isolate), ctxAddr);
     return buf;
   }
-  if (!includeId) {
-    recordreplay::Print("ReplayScript CONTEXT_ADDRESS %s", buf);
+  Object obj(static_cast<Address>(ctxAddr));
+  if (!obj.IsContext() || !Context::cast(obj).IsNativeContext()) {
+    snprintf(buf, sizeof(buf), "iso=%" PRIxPTR " ctx=%" PRIxPTR,
+             reinterpret_cast<uintptr_t>(isolate), ctxAddr);
+    return buf;
   }
-  Object value =
-      Context::cast(Object(static_cast<Address>(ctxAddr))).debug_context_id();
+  Object value = Context::cast(obj).debug_context_id();
   int id = value.IsSmi() ? Smi::ToInt(value) : 0;
-  if (!includeId) {
-    recordreplay::Print(
-        "ReplayScript CONTEXT_ID iso=%" PRIxPTR " ctx=%" PRIxPTR " id=%d",
-        reinterpret_cast<uintptr_t>(isolate), ctxAddr, id);
-    return buf;
-  }
   snprintf(buf, sizeof(buf), "iso=%" PRIxPTR " ctx=%" PRIxPTR " id=%d",
            reinterpret_cast<uintptr_t>(isolate), ctxAddr, id);
   return buf;

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -11241,19 +11241,30 @@ extern "C" uintptr_t V8RecordReplayGetDefaultContextAddress(v8::Isolate* isolate
 
 // [crash-0017] Trace Context identities through the execution.
 // ContextAddress token "iso=.. ctx=.."[, " id=.."].
-// includeId adds a debug_context_id deref; can fault on a garbage Context.
+// includeId=true embeds id in the returned token (deref can fault first).
+// includeId=false returns address-only, but still logs id separately after
+// printing the address — so a corrupt Context still leaves an address trail.
 std::string RecordReplayContextAddressToken(v8::Isolate* isolate,
                                             uintptr_t ctxAddr,
                                             bool includeId) {
   char buf[96];
-  if (!includeId || ctxAddr == 0) {
-    snprintf(buf, sizeof(buf), "iso=%" PRIxPTR " ctx=%" PRIxPTR,
-             reinterpret_cast<uintptr_t>(isolate), ctxAddr);
+  snprintf(buf, sizeof(buf), "iso=%" PRIxPTR " ctx=%" PRIxPTR,
+           reinterpret_cast<uintptr_t>(isolate), ctxAddr);
+  if (ctxAddr == 0) {
     return buf;
+  }
+  if (!includeId) {
+    recordreplay::Print("ReplayScript CONTEXT_ADDRESS %s", buf);
   }
   Object value =
       Context::cast(Object(static_cast<Address>(ctxAddr))).debug_context_id();
   int id = value.IsSmi() ? Smi::ToInt(value) : 0;
+  if (!includeId) {
+    recordreplay::Print(
+        "ReplayScript CONTEXT_ID iso=%" PRIxPTR " ctx=%" PRIxPTR " id=%d",
+        reinterpret_cast<uintptr_t>(isolate), ctxAddr, id);
+    return buf;
+  }
   snprintf(buf, sizeof(buf), "iso=%" PRIxPTR " ctx=%" PRIxPTR " id=%d",
            reinterpret_cast<uintptr_t>(isolate), ctxAddr, id);
   return buf;

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3860,29 +3860,38 @@ int gPauseContextGroupId = 0;
 // Make sure that the isolate has a context by switching to the default
 // context if necessary.
 static void EnsureIsolateContext(Isolate* isolate, base::Optional<SaveAndSwitchContext>& ssc) {
-  const char* source = "slot";
-  if (isolate->context().is_null()) {
-    source = "default";
+  Context ctx = isolate->context();
+  v8::Isolate* v8_isolate = reinterpret_cast<v8::Isolate*>(isolate);
+  bool had_slot = !ctx.is_null();
+  const char* source = had_slot ? "slot" : "default";
+
+  if (!had_slot) {
     Local<v8::Context> v8_context;
-    V8RecordReplayGetDefaultContext((v8::Isolate*)isolate, &v8_context);
+    V8RecordReplayGetDefaultContext(v8_isolate, &v8_context);
     Handle<Context> context = Utils::OpenHandle(*v8_context);
     ssc.emplace(isolate, *context);
+    ctx = isolate->context();
   }
 
-  Context ctx = isolate->context();
-  static Address gLastCommandContext = kNullAddress;
-  if (ctx.ptr() != gLastCommandContext) {
-    v8::Isolate* v8_isolate = reinterpret_cast<v8::Isolate*>(isolate);
-    recordreplay::Print(
-        "ReplayScript COMMAND_CONTEXT_CHANGE %s %s group=%d win=? frame=?",
-        source,
-        RecordReplayContextAddressToken(v8_isolate, ctx.ptr(), false).c_str(),
-        gPauseContextGroupId);
-    recordreplay::Print(
-        "ReplayScript COMMAND_CONTEXT_ID %s",
-        RecordReplayContextAddressToken(v8_isolate, ctx.ptr(), true).c_str());
-    gLastCommandContext = ctx.ptr();
+  // includeId=false: address trail before any Context field access below.
+  recordreplay::Print(
+      "ReplayScript COMMAND_CONTEXT_CHANGE %s %s group=%d",
+      source,
+      RecordReplayContextAddressToken(v8_isolate, ctx.ptr(), false).c_str(),
+      gPauseContextGroupId);
+
+  if (had_slot) {
+    NativeContext nc = isolate->raw_native_context();
+    if (ctx != nc) {
+      source = "native";
+      ssc.emplace(isolate, nc);
+      ctx = nc;
+    }
   }
+
+  recordreplay::Print(
+      "ReplayScript COMMAND_CONTEXT_ID %s %s", source,
+      RecordReplayContextAddressToken(v8_isolate, ctx.ptr(), true).c_str());
 
   CHECK(isolate);
   CHECK(isolate->heap());

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3873,7 +3873,7 @@ static void EnsureIsolateContext(Isolate* isolate, base::Optional<SaveAndSwitchC
     ctx = isolate->context();
   }
 
-  // includeId=false: address trail before any Context field access below.
+  // includeId=false: address-only, no heap deref.
   recordreplay::Print(
       "ReplayScript COMMAND_CONTEXT_CHANGE %s %s group=%d",
       source,
@@ -3881,6 +3881,10 @@ static void EnsureIsolateContext(Isolate* isolate, base::Optional<SaveAndSwitchC
       gPauseContextGroupId);
 
   if (had_slot) {
+    // [CRASH-0020] Isoluate::context() sometimes gets corrupted and this will trigger a crash.
+    CHECK(ctx.IsHeapObject());
+    CHECK(IsValidHeapObject(isolate->heap(), HeapObject::cast(ctx)));
+    CHECK(ctx.IsContext());
     NativeContext nc = isolate->raw_native_context();
     if (ctx != nc) {
       source = "native";

--- a/src/execution/isolate-inl.h
+++ b/src/execution/isolate-inl.h
@@ -33,8 +33,7 @@ void Isolate::set_context(Context context) {
   DCHECK(context.is_null() || context.IsContext());
   Context previous = thread_local_top()->context_;
   thread_local_top()->context_ = context;
-  if (previous.ptr() != context.ptr() &&
-      recordreplay::AreEventsDisallowed()) {
+  if (previous.ptr() != context.ptr()) {
     v8::Isolate* v8_isolate = reinterpret_cast<v8::Isolate*>(this);
     std::string from = RecordReplayContextAddressToken(
         v8_isolate, previous.ptr(), false);

--- a/src/execution/isolate-inl.h
+++ b/src/execution/isolate-inl.h
@@ -5,6 +5,9 @@
 #ifndef V8_EXECUTION_ISOLATE_INL_H_
 #define V8_EXECUTION_ISOLATE_INL_H_
 
+#include <string>
+
+#include "include/v8.h"  // For replay.
 #include "src/execution/isolate.h"
 #include "src/objects/contexts-inl.h"
 #include "src/objects/js-function.h"
@@ -23,9 +26,23 @@
 namespace v8 {
 namespace internal {
 
+std::string RecordReplayContextAddressToken(v8::Isolate* isolate,
+                                            uintptr_t ctxAddr, bool includeId);
+
 void Isolate::set_context(Context context) {
   DCHECK(context.is_null() || context.IsContext());
+  Context previous = thread_local_top()->context_;
   thread_local_top()->context_ = context;
+  if (previous.ptr() != context.ptr() &&
+      recordreplay::AreEventsDisallowed()) {
+    v8::Isolate* v8_isolate = reinterpret_cast<v8::Isolate*>(this);
+    std::string from = RecordReplayContextAddressToken(
+        v8_isolate, previous.ptr(), false);
+    std::string to =
+        RecordReplayContextAddressToken(v8_isolate, context.ptr(), false);
+    recordreplay::Print("ReplayScript ISOLATE_CONTEXT_CHANGE from=%s to=%s",
+                        from.c_str(), to.c_str());
+  }
 }
 
 Handle<NativeContext> Isolate::native_context() {


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1388