### PR TITLE
crash-0039: propagate per-session replay ownership at inspector dispatch sites

### DIFF
--- a/src/inspector/injected-script.cc
+++ b/src/inspector/injected-script.cc
@@ -51,7 +51,6 @@
 #include "src/inspector/v8-stack-trace-impl.h"
 #include "src/inspector/v8-value-utils.h"
 #include "src/inspector/value-mirror.h"
-#include "src/base/replayio.h"
 
 #include "v8.h"
 
@@ -231,11 +230,6 @@ class InjectedScript::ProtocolPromiseHandler {
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
-    const bool replay_owned = session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, m_inspector->isolate(),
-        "InjectedScript::EvaluateCallback::thenCallback");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;
@@ -281,11 +275,6 @@ class InjectedScript::ProtocolPromiseHandler {
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
-    const bool replay_owned = session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, m_inspector->isolate(),
-        "InjectedScript::EvaluateCallback::catchCallback");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;
@@ -384,11 +373,6 @@ class InjectedScript::ProtocolPromiseHandler {
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
-    const bool replay_owned = session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, m_inspector->isolate(),
-        "InjectedScript::EvaluateCallback::sendPromiseCollected");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;
@@ -410,8 +394,11 @@ class InjectedScript::ProtocolPromiseHandler {
   v8::Global<v8::Promise> m_evaluationResult;
 };
 
-InjectedScript::InjectedScript(InspectedContext* context, int sessionId)
-    : m_context(context), m_sessionId(sessionId) {}
+InjectedScript::InjectedScript(InspectedContext* context, int sessionId,
+                               bool replayOwned)
+    : m_context(context),
+      m_sessionId(sessionId),
+      m_replay_owned(replayOwned) {}
 
 InjectedScript::~InjectedScript() { discardEvaluateCallbacks(); }
 

--- a/src/inspector/injected-script.cc
+++ b/src/inspector/injected-script.cc
@@ -51,6 +51,7 @@
 #include "src/inspector/v8-stack-trace-impl.h"
 #include "src/inspector/v8-value-utils.h"
 #include "src/inspector/value-mirror.h"
+#include "src/base/replayio.h"
 
 #include "v8.h"
 
@@ -230,6 +231,11 @@ class InjectedScript::ProtocolPromiseHandler {
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
+    const bool replay_owned = session->replayOwned();
+    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+    v8::replayio::AutoMaybeDisallowEvents disallow(
+        replay_owned, m_inspector->isolate(),
+        "InjectedScript::EvaluateCallback::thenCallback");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;
@@ -275,6 +281,11 @@ class InjectedScript::ProtocolPromiseHandler {
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
+    const bool replay_owned = session->replayOwned();
+    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+    v8::replayio::AutoMaybeDisallowEvents disallow(
+        replay_owned, m_inspector->isolate(),
+        "InjectedScript::EvaluateCallback::catchCallback");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;
@@ -373,6 +384,11 @@ class InjectedScript::ProtocolPromiseHandler {
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
+    const bool replay_owned = session->replayOwned();
+    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+    v8::replayio::AutoMaybeDisallowEvents disallow(
+        replay_owned, m_inspector->isolate(),
+        "InjectedScript::EvaluateCallback::sendPromiseCollected");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;

--- a/src/inspector/injected-script.h
+++ b/src/inspector/injected-script.h
@@ -78,12 +78,13 @@ class EvaluateCallback {
 
 class InjectedScript final {
  public:
-  InjectedScript(InspectedContext*, int sessionId);
+  InjectedScript(InspectedContext*, int sessionId, bool replayOwned);
   ~InjectedScript();
   InjectedScript(const InjectedScript&) = delete;
   InjectedScript& operator=(const InjectedScript&) = delete;
 
   InspectedContext* context() const { return m_context; }
+  bool replayOwned() const { return m_replay_owned; }
 
   Response getProperties(
       v8::Local<v8::Object>, const String16& groupName, bool ownProperties,
@@ -251,6 +252,7 @@ class InjectedScript final {
 
   InspectedContext* m_context;
   int m_sessionId;
+  bool m_replay_owned;
   v8::Global<v8::Value> m_lastEvaluationResult;
   v8::Global<v8::Object> m_commandLineAPI;
   int m_lastBoundObjectId = 1;

--- a/src/inspector/inspected-context.cc
+++ b/src/inspector/inspected-context.cc
@@ -122,9 +122,10 @@ InjectedScript* InspectedContext::getInjectedScript(int sessionId) {
   return it == m_injectedScripts.end() ? nullptr : it->second.get();
 }
 
-InjectedScript* InspectedContext::createInjectedScript(int sessionId) {
+InjectedScript* InspectedContext::createInjectedScript(int sessionId,
+                                                       bool replayOwned) {
   std::unique_ptr<InjectedScript> injectedScript =
-      std::make_unique<InjectedScript>(this, sessionId);
+      std::make_unique<InjectedScript>(this, sessionId, replayOwned);
   CHECK(m_injectedScripts.find(sessionId) == m_injectedScripts.end());
   m_injectedScripts[sessionId] = std::move(injectedScript);
   return getInjectedScript(sessionId);

--- a/src/inspector/inspected-context.h
+++ b/src/inspector/inspected-context.h
@@ -53,7 +53,7 @@ class InspectedContext {
   V8InspectorImpl* inspector() const { return m_inspector; }
 
   InjectedScript* getInjectedScript(int sessionId);
-  InjectedScript* createInjectedScript(int sessionId);
+  InjectedScript* createInjectedScript(int sessionId, bool replayOwned);
   void discardInjectedScript(int sessionId);
 
   bool addInternalObject(v8::Local<v8::Object> object,

--- a/src/inspector/v8-console-agent-impl.cc
+++ b/src/inspector/v8-console-agent-impl.cc
@@ -22,7 +22,8 @@ V8ConsoleAgentImpl::V8ConsoleAgentImpl(
     : m_session(session),
       m_state(state),
       m_frontend(frontendChannel),
-      m_enabled(false) {}
+      m_enabled(false),
+      m_replay_owned(session->replayOwned()) {}
 
 V8ConsoleAgentImpl::~V8ConsoleAgentImpl() = default;
 

--- a/src/inspector/v8-console-agent-impl.h
+++ b/src/inspector/v8-console-agent-impl.h
@@ -32,6 +32,7 @@ class V8ConsoleAgentImpl : public protocol::Console::Backend {
   void messageAdded(V8ConsoleMessage*);
   void reset();
   bool enabled();
+  bool replayOwned() const { return m_replay_owned; }
 
  private:
   void reportAllMessages();
@@ -41,6 +42,7 @@ class V8ConsoleAgentImpl : public protocol::Console::Backend {
   protocol::DictionaryValue* m_state;
   protocol::Console::Frontend m_frontend;
   bool m_enabled;
+  bool m_replay_owned;
 };
 
 }  // namespace v8_inspector

--- a/src/inspector/v8-console.cc
+++ b/src/inspector/v8-console.cc
@@ -22,6 +22,7 @@
 #include "src/inspector/v8-runtime-agent-impl.h"
 #include "src/inspector/v8-stack-trace-impl.h"
 #include "src/inspector/v8-value-utils.h"
+#include "src/base/replayio.h"
 #include "src/tracing/trace-event.h"
 
 #include "v8.h"
@@ -646,6 +647,11 @@ static void setFunctionBreakpoint(ConsoleHelper& helper, int sessionId,
                                   bool enable) {
   V8InspectorSessionImpl* session = helper.session(sessionId);
   if (session == nullptr) return;
+  const bool replay_owned = session->replayOwned();
+  v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      replay_owned, session->inspector()->isolate(),
+      "V8Console::setFunctionBreakpoint");
   if (!session->debuggerAgent()->enabled()) return;
   if (enable) {
     session->debuggerAgent()->setBreakpointFor(function, condition, source);
@@ -749,6 +755,11 @@ static void inspectImpl(const v8::FunctionCallbackInfo<v8::Value>& info,
     hints->setBoolean("queryObjects", true);
   }
   if (V8InspectorSessionImpl* session = helper.session(sessionId)) {
+    const bool replay_owned = session->replayOwned();
+    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+    v8::replayio::AutoMaybeDisallowEvents disallow(
+        replay_owned, session->inspector()->isolate(),
+        "V8Console::inspectImpl");
     session->runtimeAgent()->inspect(std::move(wrappedObject), std::move(hints),
                                      helper.contextId());
   }
@@ -795,6 +806,11 @@ void V8Console::inspectedObject(const v8::FunctionCallbackInfo<v8::Value>& info,
   v8::debug::ConsoleCallArguments args(info);
   ConsoleHelper helper(args, v8::debug::ConsoleContext(), m_inspector);
   if (V8InspectorSessionImpl* session = helper.session(sessionId)) {
+    const bool replay_owned = session->replayOwned();
+    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+    v8::replayio::AutoMaybeDisallowEvents disallow(
+        replay_owned, session->inspector()->isolate(),
+        "V8Console::inspectedObject");
     V8InspectorSession::Inspectable* object = session->inspectedObject(num);
     v8::Isolate* isolate = info.GetIsolate();
     if (object)

--- a/src/inspector/v8-console.cc
+++ b/src/inspector/v8-console.cc
@@ -22,7 +22,6 @@
 #include "src/inspector/v8-runtime-agent-impl.h"
 #include "src/inspector/v8-stack-trace-impl.h"
 #include "src/inspector/v8-value-utils.h"
-#include "src/base/replayio.h"
 #include "src/tracing/trace-event.h"
 
 #include "v8.h"
@@ -647,11 +646,6 @@ static void setFunctionBreakpoint(ConsoleHelper& helper, int sessionId,
                                   bool enable) {
   V8InspectorSessionImpl* session = helper.session(sessionId);
   if (session == nullptr) return;
-  const bool replay_owned = session->replayOwned();
-  v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      replay_owned, session->inspector()->isolate(),
-      "V8Console::setFunctionBreakpoint");
   if (!session->debuggerAgent()->enabled()) return;
   if (enable) {
     session->debuggerAgent()->setBreakpointFor(function, condition, source);
@@ -755,11 +749,6 @@ static void inspectImpl(const v8::FunctionCallbackInfo<v8::Value>& info,
     hints->setBoolean("queryObjects", true);
   }
   if (V8InspectorSessionImpl* session = helper.session(sessionId)) {
-    const bool replay_owned = session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, session->inspector()->isolate(),
-        "V8Console::inspectImpl");
     session->runtimeAgent()->inspect(std::move(wrappedObject), std::move(hints),
                                      helper.contextId());
   }
@@ -806,11 +795,6 @@ void V8Console::inspectedObject(const v8::FunctionCallbackInfo<v8::Value>& info,
   v8::debug::ConsoleCallArguments args(info);
   ConsoleHelper helper(args, v8::debug::ConsoleContext(), m_inspector);
   if (V8InspectorSessionImpl* session = helper.session(sessionId)) {
-    const bool replay_owned = session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, session->inspector()->isolate(),
-        "V8Console::inspectedObject");
     V8InspectorSession::Inspectable* object = session->inspectedObject(num);
     v8::Isolate* isolate = info.GetIsolate();
     if (object)

--- a/src/inspector/v8-debugger-agent-impl.cc
+++ b/src/inspector/v8-debugger-agent-impl.cc
@@ -373,6 +373,7 @@ V8DebuggerAgentImpl::V8DebuggerAgentImpl(
       m_debugger(m_inspector->debugger()),
       m_session(session),
       m_enabled(false),
+      m_replay_owned(session->replayOwned()),
       m_state(state),
       m_frontend(frontendChannel),
       m_isolate(m_inspector->isolate()) {}

--- a/src/inspector/v8-debugger-agent-impl.h
+++ b/src/inspector/v8-debugger-agent-impl.h
@@ -43,6 +43,7 @@ class V8DebuggerAgentImpl : public protocol::Debugger::Backend {
   V8DebuggerAgentImpl(const V8DebuggerAgentImpl&) = delete;
   V8DebuggerAgentImpl& operator=(const V8DebuggerAgentImpl&) = delete;
   void restore();
+  bool replayOwned() const { return m_replay_owned; }
 
   // Part of the protocol.
   Response enable(Maybe<double> maxScriptsCacheSize,
@@ -243,6 +244,7 @@ class V8DebuggerAgentImpl : public protocol::Debugger::Backend {
   V8Debugger* m_debugger;
   V8InspectorSessionImpl* m_session;
   bool m_enabled;
+  bool m_replay_owned;
   protocol::DictionaryValue* m_state;
   protocol::Debugger::Frontend m_frontend;
   v8::Isolate* m_isolate;

--- a/src/inspector/v8-heap-profiler-agent-impl.cc
+++ b/src/inspector/v8-heap-profiler-agent-impl.cc
@@ -188,6 +188,7 @@ V8HeapProfilerAgentImpl::V8HeapProfilerAgentImpl(
       m_frontend(frontendChannel),
       m_state(state),
       m_hasTimer(false),
+      m_replay_owned(session->replayOwned()),
       m_async_gc(std::make_shared<AsyncGC>()) {}
 
 V8HeapProfilerAgentImpl::~V8HeapProfilerAgentImpl() {

--- a/src/inspector/v8-heap-profiler-agent-impl.h
+++ b/src/inspector/v8-heap-profiler-agent-impl.h
@@ -30,6 +30,7 @@ class V8HeapProfilerAgentImpl : public protocol::HeapProfiler::Backend {
   V8HeapProfilerAgentImpl(const V8HeapProfilerAgentImpl&) = delete;
   V8HeapProfilerAgentImpl& operator=(const V8HeapProfilerAgentImpl&) = delete;
   void restore();
+  bool replayOwned() const { return m_replay_owned; }
 
   void collectGarbage(
       std::unique_ptr<CollectGarbageCallback> callback) override;
@@ -78,6 +79,7 @@ class V8HeapProfilerAgentImpl : public protocol::HeapProfiler::Backend {
   protocol::HeapProfiler::Frontend m_frontend;
   protocol::DictionaryValue* m_state;
   bool m_hasTimer;
+  bool m_replay_owned;
   std::shared_ptr<AsyncGC> m_async_gc;
 };
 

--- a/src/inspector/v8-inspector-impl.cc
+++ b/src/inspector/v8-inspector-impl.cc
@@ -453,7 +453,6 @@ void V8InspectorImpl::forEachContext(
 void V8InspectorImpl::forEachSession(
     int contextGroupId,
     const std::function<void(V8InspectorSessionImpl*)>& callback) {
-  using v8::recordreplay;
   auto it = m_sessions.find(contextGroupId);
   if (it == m_sessions.end()) return;
   std::vector<int> ids;
@@ -462,13 +461,17 @@ void V8InspectorImpl::forEachSession(
 
   // Retrieve by ids each time since |callback| may destroy some contexts.
   for (auto& sessionId : ids) {
-    it = m_sessions.find(contextGroupId);
-    int hasGroup = it != m_sessions.end();
+    using v8::recordreplay;
+    V8InspectorSessionImpl* session = sessionById(contextGroupId, sessionId);
+    const bool replay_owned = session && session->replayOwned();
+    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+    v8::replayio::AutoMaybeDisallowEvents disallow(
+        replay_owned, m_isolate, "V8InspectorImpl::forEachSession");
     REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
-        "V8InspectorImpl::forEachSession %d %d", sessionId, hasGroup);
-    if (it == m_sessions.end()) continue;
-    auto sessionIt = it->second.find(sessionId);
-    if (sessionIt != it->second.end()) callback(sessionIt->second);
+        "V8InspectorImpl::forEachSession sessionId=%d hasGroup=%d",
+        sessionId,
+        m_sessions.find(contextGroupId) != m_sessions.end());
+    if (session) callback(session);
   }
 }
 

--- a/src/inspector/v8-inspector-impl.cc
+++ b/src/inspector/v8-inspector-impl.cc
@@ -281,9 +281,6 @@ void V8InspectorImpl::resetContextGroup(int contextGroupId) {
   v8::replayio::AutoMaybeDisallowEvents disallow(
       replay_owned, m_isolate, "V8InspectorImpl::resetContextGroup");
   auto contextsIt = m_contexts.find(contextGroupId);
-  REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
-      "V8InspectorImpl::resetContextGroup consoleStorage %d",
-      hasConsoleMessageStorage(contextGroupId));
   m_consoleStorageMap.erase(contextGroupId);
   m_muteExceptionsMap.erase(contextGroupId);
   // Context might have been removed already by discardContextScript()
@@ -463,14 +460,13 @@ void V8InspectorImpl::forEachSession(
   for (auto& sessionId : ids) {
     using v8::recordreplay;
     V8InspectorSessionImpl* session = sessionById(contextGroupId, sessionId);
-    const bool replay_owned = session && session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, m_isolate, "V8InspectorImpl::forEachSession");
-    REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
-        "V8InspectorImpl::forEachSession sessionId=%d hasGroup=%d",
-        sessionId,
-        m_sessions.find(contextGroupId) != m_sessions.end());
+    // Skip assert for ReplaySession: its presence in m_sessions is an allowed
+    // divergence. Do not RAII the whole session callback.
+    if (!session || !session->replayOwned()) {
+      REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
+          "V8InspectorImpl::forEachSession sessionId=%d hasGroup=%d", sessionId,
+          m_sessions.find(contextGroupId) != m_sessions.end());
+    }
     if (session) callback(session);
   }
 }

--- a/src/inspector/v8-inspector-session-impl.cc
+++ b/src/inspector/v8-inspector-session-impl.cc
@@ -109,6 +109,8 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(
       m_inspector(inspector),
       m_channel(channel),
       m_customObjectFormatterEnabled(false),
+      // ReplaySession connect is under AutoDisallowEvents; DevTools connect is not.
+      m_replay_owned(v8::recordreplay::AreEventsDisallowed()),
       m_dispatcher(this),
       m_state(ParseState(savedState)),
       m_runtimeAgent(nullptr),
@@ -117,8 +119,7 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(
       m_profilerAgent(nullptr),
       m_consoleAgent(nullptr),
       m_schemaAgent(nullptr),
-      m_clientTrustLevel(clientTrustLevel),
-      m_replay_owned(v8::replayio::CheckReplayOwned()) {
+      m_clientTrustLevel(clientTrustLevel) {
   m_state->getBoolean("use_binary_protocol", &use_binary_protocol_);
 
   v8::recordreplay::CommandDiagnosticTrace(
@@ -164,10 +165,6 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(
 
 V8InspectorSessionImpl::~V8InspectorSessionImpl() {
   v8::Isolate::Scope scope(m_inspector->isolate());
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8InspectorSessionImpl::~V8InspectorSessionImpl");
   discardInjectedScripts();
   m_consoleAgent->disable();
   m_profilerAgent->disable();
@@ -295,19 +292,12 @@ void V8InspectorSessionImpl::FlushProtocolNotifications() {
 }
 
 void V8InspectorSessionImpl::reset() {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(), "V8InspectorSessionImpl::reset");
   m_debuggerAgent->reset();
   m_runtimeAgent->reset();
   discardInjectedScripts();
 }
 
 void V8InspectorSessionImpl::discardInjectedScripts() {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8InspectorSessionImpl::discardInjectedScripts");
   m_inspectedObjects.clear();
   int sessionId = m_sessionId;
   m_inspector->forEachContext(m_contextGroupId,
@@ -331,7 +321,7 @@ Response V8InspectorSessionImpl::findInjectedScript(
   }
   injectedScript = context->getInjectedScript(m_sessionId);
   if (!injectedScript) {
-    injectedScript = context->createInjectedScript(m_sessionId);
+    injectedScript = context->createInjectedScript(m_sessionId, m_replay_owned);
     if (m_customObjectFormatterEnabled)
       injectedScript->setCustomObjectFormatterEnabled(true);
   }
@@ -356,10 +346,6 @@ void V8InspectorSessionImpl::releaseObjectGroup(StringView objectGroup) {
 }
 
 void V8InspectorSessionImpl::releaseObjectGroup(const String16& objectGroup) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8InspectorSessionImpl::releaseObjectGroup");
   int sessionId = m_sessionId;
   m_inspector->forEachContext(
       m_contextGroupId, [&objectGroup, &sessionId](InspectedContext* context) {
@@ -456,10 +442,6 @@ V8InspectorSessionImpl::wrapTable(v8::Local<v8::Context> context,
 }
 
 void V8InspectorSessionImpl::setCustomObjectFormatterEnabled(bool enabled) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8InspectorSessionImpl::setCustomObjectFormatterEnabled");
   m_customObjectFormatterEnabled = enabled;
   int sessionId = m_sessionId;
   m_inspector->forEachContext(
@@ -471,10 +453,6 @@ void V8InspectorSessionImpl::setCustomObjectFormatterEnabled(bool enabled) {
 }
 
 void V8InspectorSessionImpl::reportAllContexts(V8RuntimeAgentImpl* agent) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8InspectorSessionImpl::reportAllContexts");
   m_inspector->forEachContext(m_contextGroupId,
                               [&agent](InspectedContext* context) {
                                 agent->reportExecutionContextCreated(context);
@@ -482,10 +460,6 @@ void V8InspectorSessionImpl::reportAllContexts(V8RuntimeAgentImpl* agent) {
 }
 
 void V8InspectorSessionImpl::dispatchProtocolMessage(StringView message) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8InspectorSessionImpl::dispatchProtocolMessage");
   using v8_crdtp::span;
   using v8_crdtp::SpanFrom;
   span<uint8_t> cbor;

--- a/src/inspector/v8-inspector-session-impl.cc
+++ b/src/inspector/v8-inspector-session-impl.cc
@@ -164,6 +164,10 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(
 
 V8InspectorSessionImpl::~V8InspectorSessionImpl() {
   v8::Isolate::Scope scope(m_inspector->isolate());
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::~V8InspectorSessionImpl");
   discardInjectedScripts();
   m_consoleAgent->disable();
   m_profilerAgent->disable();
@@ -300,6 +304,10 @@ void V8InspectorSessionImpl::reset() {
 }
 
 void V8InspectorSessionImpl::discardInjectedScripts() {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::discardInjectedScripts");
   m_inspectedObjects.clear();
   int sessionId = m_sessionId;
   m_inspector->forEachContext(m_contextGroupId,
@@ -448,6 +456,10 @@ V8InspectorSessionImpl::wrapTable(v8::Local<v8::Context> context,
 }
 
 void V8InspectorSessionImpl::setCustomObjectFormatterEnabled(bool enabled) {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::setCustomObjectFormatterEnabled");
   m_customObjectFormatterEnabled = enabled;
   int sessionId = m_sessionId;
   m_inspector->forEachContext(
@@ -459,6 +471,10 @@ void V8InspectorSessionImpl::setCustomObjectFormatterEnabled(bool enabled) {
 }
 
 void V8InspectorSessionImpl::reportAllContexts(V8RuntimeAgentImpl* agent) {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::reportAllContexts");
   m_inspector->forEachContext(m_contextGroupId,
                               [&agent](InspectedContext* context) {
                                 agent->reportExecutionContextCreated(context);
@@ -466,6 +482,10 @@ void V8InspectorSessionImpl::reportAllContexts(V8RuntimeAgentImpl* agent) {
 }
 
 void V8InspectorSessionImpl::dispatchProtocolMessage(StringView message) {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::dispatchProtocolMessage");
   using v8_crdtp::span;
   using v8_crdtp::SpanFrom;
   span<uint8_t> cbor;

--- a/src/inspector/v8-inspector-session-impl.h
+++ b/src/inspector/v8-inspector-session-impl.h
@@ -156,7 +156,8 @@ class V8InspectorSessionImpl : public V8InspectorSession,
   //   (CheckReplayOwned / IsInReplayCode) into m_replay_owned.
   // - Calls on that object later: Propagate from m_replay_owned
   //   (AutoMaybeMarkReplayCode + AutoMaybeDisallowEvents).
-  // Shared inspector entry points (e.g. contextCreated) use the stack only;
+  // forEachSession: propagate per-session m_replay_owned.
+  // Other shared entry points (e.g. contextCreated): stack CheckReplayOwned only;
   // do not infer ownership from "a Replay session shares this context group".
   bool m_replay_owned;
 };

--- a/src/inspector/v8-inspector-session-impl.h
+++ b/src/inspector/v8-inspector-session-impl.h
@@ -137,6 +137,8 @@ class V8InspectorSessionImpl : public V8InspectorSession,
   V8InspectorImpl* m_inspector;
   V8Inspector::Channel* m_channel;
   bool m_customObjectFormatterEnabled;
+  // Seeded at connect: true for ReplaySession (under AutoDisallowEvents).
+  bool m_replay_owned;
 
   protocol::UberDispatcher m_dispatcher;
   std::unique_ptr<protocol::DictionaryValue> m_state;
@@ -151,15 +153,6 @@ class V8InspectorSessionImpl : public V8InspectorSession,
       m_inspectedObjects;
   bool use_binary_protocol_ = false;
   V8Inspector::ClientTrustLevel m_clientTrustLevel = V8Inspector::kUntrusted;
-  // Replay-only ownership:
-  // - Creation of a Replay-owned object: capture from stack
-  //   (CheckReplayOwned / IsInReplayCode) into m_replay_owned.
-  // - Calls on that object later: Propagate from m_replay_owned
-  //   (AutoMaybeMarkReplayCode + AutoMaybeDisallowEvents).
-  // forEachSession: propagate per-session m_replay_owned.
-  // Other shared entry points (e.g. contextCreated): stack CheckReplayOwned only;
-  // do not infer ownership from "a Replay session shares this context group".
-  bool m_replay_owned;
 };
 
 }  // namespace v8_inspector

--- a/src/inspector/v8-profiler-agent-impl.cc
+++ b/src/inspector/v8-profiler-agent-impl.cc
@@ -172,7 +172,8 @@ V8ProfilerAgentImpl::V8ProfilerAgentImpl(
     : m_session(session),
       m_isolate(m_session->inspector()->isolate()),
       m_state(state),
-      m_frontend(frontendChannel) {}
+      m_frontend(frontendChannel),
+      m_replay_owned(session->replayOwned()) {}
 
 V8ProfilerAgentImpl::~V8ProfilerAgentImpl() {
   if (m_profiler) m_profiler->Dispose();

--- a/src/inspector/v8-profiler-agent-impl.h
+++ b/src/inspector/v8-profiler-agent-impl.h
@@ -33,6 +33,7 @@ class V8ProfilerAgentImpl : public protocol::Profiler::Backend {
   V8ProfilerAgentImpl& operator=(const V8ProfilerAgentImpl&) = delete;
 
   bool enabled() const { return m_enabled; }
+  bool replayOwned() const { return m_replay_owned; }
   void restore();
 
   Response enable() override;
@@ -71,6 +72,7 @@ class V8ProfilerAgentImpl : public protocol::Profiler::Backend {
   protocol::DictionaryValue* m_state;
   protocol::Profiler::Frontend m_frontend;
   bool m_enabled = false;
+  bool m_replay_owned = false;
   bool m_recordingCPUProfile = false;
   class ProfileDescriptor;
   std::vector<ProfileDescriptor> m_startedProfiles;

--- a/src/inspector/v8-runtime-agent-impl.h
+++ b/src/inspector/v8-runtime-agent-impl.h
@@ -144,6 +144,7 @@ class V8RuntimeAgentImpl : public protocol::Runtime::Backend {
                int executionContextId);
   void messageAdded(V8ConsoleMessage*);
   bool enabled() const { return m_enabled; }
+  bool replayOwned() const { return m_replay_owned; }
 
  private:
   bool reportMessage(V8ConsoleMessage*, bool generatePreview);
@@ -158,13 +159,11 @@ class V8RuntimeAgentImpl : public protocol::Runtime::Backend {
   protocol::Runtime::Frontend m_frontend;
   V8InspectorImpl* m_inspector;
   bool m_enabled;
+  bool m_replay_owned;
   std::unordered_map<String16, std::unique_ptr<v8::Global<v8::Script>>>
       m_compiledScripts;
   // Binding name -> executionContextIds mapping.
   std::unordered_map<String16, std::unordered_set<int>> m_activeBindings;
-
-  // Whether this agent is replaying specific, and should not interact with the recording.
-  bool m_replay_owned;
 };
 
 }  // namespace v8_inspector

--- a/src/inspector/v8-schema-agent-impl.cc
+++ b/src/inspector/v8-schema-agent-impl.cc
@@ -12,7 +12,9 @@ namespace v8_inspector {
 V8SchemaAgentImpl::V8SchemaAgentImpl(V8InspectorSessionImpl* session,
                                      protocol::FrontendChannel* frontendChannel,
                                      protocol::DictionaryValue* state)
-    : m_session(session), m_frontend(frontendChannel) {}
+    : m_session(session),
+      m_frontend(frontendChannel),
+      m_replay_owned(session->replayOwned()) {}
 
 V8SchemaAgentImpl::~V8SchemaAgentImpl() = default;
 

--- a/src/inspector/v8-schema-agent-impl.h
+++ b/src/inspector/v8-schema-agent-impl.h
@@ -24,6 +24,7 @@ class V8SchemaAgentImpl : public protocol::Schema::Backend {
   ~V8SchemaAgentImpl() override;
   V8SchemaAgentImpl(const V8SchemaAgentImpl&) = delete;
   V8SchemaAgentImpl& operator=(const V8SchemaAgentImpl&) = delete;
+  bool replayOwned() const { return m_replay_owned; }
 
   Response getDomains(
       std::unique_ptr<protocol::Array<protocol::Schema::Domain>>*) override;
@@ -31,6 +32,7 @@ class V8SchemaAgentImpl : public protocol::Schema::Backend {
  private:
   V8InspectorSessionImpl* m_session;
   protocol::Schema::Frontend m_frontend;
+  bool m_replay_owned;
 };
 
 }  // namespace v8_inspector


### PR DESCRIPTION
* Big ownership fixes: What is actually "our divergently created subset of V8 inspector objects"?
* paired w/ https://github.com/replayio/chromium/pull/1403