### PR TITLE
crash-0039: propagate per-session replay ownership at inspector dispatch sites

### DIFF
--- a/include/replayio.h
+++ b/include/replayio.h
@@ -9,8 +9,6 @@
 #ifndef INCLUDE_RECORD_REPLAY_H_
 #define INCLUDE_RECORD_REPLAY_H_
 
-#include <optional>
-
 #include "v8.h"
 
 namespace v8 {
@@ -29,37 +27,26 @@ struct AutoMarkReplayCode {
   AutoMarkReplayCode& operator=(const AutoMarkReplayCode&) = delete;
 };
 
+// Stream-only EventsDisallowed scope. C++→user-JS under EventsDisallowed is
+// gated by RecordReplayIsDivergentUserJSWithoutPause, not DUMP_ON_FAILURE.
 struct AutoDisallowEvents {
-  AutoDisallowEvents() { Begin(nullptr, nullptr); }
-  explicit AutoDisallowEvents(const char* label, v8::Isolate* isolate = nullptr) {
-    Begin(label, isolate);
+  AutoDisallowEvents() { Begin(nullptr); }
+  explicit AutoDisallowEvents(const char* label, v8::Isolate* = nullptr) {
+    Begin(label);
   }
-  ~AutoDisallowEvents() {
-    no_js_.reset();
-    v8::recordreplay::EndDisallowEvents();
-  }
+  ~AutoDisallowEvents() { v8::recordreplay::EndDisallowEvents(); }
 
   AutoDisallowEvents(const AutoDisallowEvents&) = delete;
   AutoDisallowEvents& operator=(const AutoDisallowEvents&) = delete;
 
  private:
-  void Begin(const char* label, v8::Isolate* isolate) {
+  void Begin(const char* label) {
     if (label) {
       v8::recordreplay::BeginDisallowEventsWithLabel(label);
     } else {
       v8::recordreplay::BeginDisallowEvents();
     }
-    if (!isolate) {
-      isolate = v8::Isolate::TryGetCurrent();
-    }
-    if (isolate) {
-      no_js_.emplace(
-          isolate,
-          v8::Isolate::DisallowJavascriptExecutionScope::DUMP_ON_FAILURE);
-    }
   }
-
-  std::optional<v8::Isolate::DisallowJavascriptExecutionScope> no_js_;
 };
 
 }  // namespace replayio

--- a/include/replayio.h
+++ b/include/replayio.h
@@ -27,8 +27,6 @@ struct AutoMarkReplayCode {
   AutoMarkReplayCode& operator=(const AutoMarkReplayCode&) = delete;
 };
 
-// Stream-only EventsDisallowed scope. C++→user-JS under EventsDisallowed is
-// gated by RecordReplayIsDivergentUserJSWithoutPause, not DUMP_ON_FAILURE.
 struct AutoDisallowEvents {
   AutoDisallowEvents() { Begin(nullptr); }
   explicit AutoDisallowEvents(const char* label, v8::Isolate* = nullptr) {

--- a/src/base/replayio.h
+++ b/src/base/replayio.h
@@ -45,6 +45,16 @@ struct AutoMaybeDisallowEvents {
   v8::base::Optional<v8::replayio::AutoDisallowEvents> disallow;
 };
 
+// Mark+Disallow for replay-owned inspector object work sites.
+struct AutoMaybeReplayOwned {
+  AutoMaybeReplayOwned(bool owned, v8::Isolate* isolate, const char* label)
+      : mark(owned), disallow(owned, isolate, label) {}
+
+ private:
+  AutoMaybeMarkReplayCode mark;
+  AutoMaybeDisallowEvents disallow;
+};
+
 }  // namespace replayio
 }  // namespace v8
 

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3823,7 +3823,6 @@ static void RecordReplayRegisterScript(Handle<Script> script) {
       callArgs[2] = Handle<Object>(script->source_mapping_url(), isolate);
 
       Handle<Object> undefined = isolate->factory()->undefined_value();
-      v8::Isolate::AllowJavascriptExecutionScope allow_js((v8::Isolate*)isolate);
       MaybeHandle<Object> rv = Execution::Call(isolate, handler, undefined, 3, callArgs);
       CHECK(!rv.is_null());
     }
@@ -3936,7 +3935,6 @@ char* CommandCallback(const char* command, const char* params) {
 
   HandleScope scope(isolate);
   AutoAllowCodeGenerationFromStrings allow_codegen(isolate);
-  v8::Isolate::AllowJavascriptExecutionScope allow_js((v8::Isolate*)isolate);
 
   if (recordreplay::HasDivergedFromRecording()) {
     v8_inspector::V8Inspector* inspectorRaw = v8::debug::GetInspector((v8::Isolate*)isolate);
@@ -4029,7 +4027,6 @@ void ClearPauseDataCallback() {
   EnsureIsolateContext(isolate, ssc);
 
   HandleScope scope(isolate);
-  v8::Isolate::AllowJavascriptExecutionScope allow_js((v8::Isolate*)isolate);
 
   Local<v8::Value> callbackValue = gClearPauseDataCallback->Get((v8::Isolate*)isolate);
   Handle<Object> callback = Utils::OpenHandle(*callbackValue);

--- a/src/execution/execution.cc
+++ b/src/execution/execution.cc
@@ -279,6 +279,17 @@ MaybeHandle<Context> NewScriptContext(Isolate* isolate,
   return result;
 }
 
+static std::string GetFunctionScriptName(Isolate* isolate,
+                                         Handle<JSFunction> function) {
+  if (!function->shared().script().IsScript()) {
+    return "<not-script>";
+  }
+  Handle<Script> script(Script::cast(function->shared().script()), isolate);
+  return script->name().IsString()
+             ? String::cast(script->name()).ToCString().get()
+             : "(anonymous script)";
+}
+
 // Get a description of a function's location for logging etc.
 static std::string GetFunctionLocationInfo(Isolate* isolate, Handle<JSFunction> function) {
   if (!function->shared().script().IsScript()) {
@@ -291,13 +302,10 @@ static std::string GetFunctionLocationInfo(Isolate* isolate, Handle<JSFunction> 
   Script::GetPositionInfo(script, function->shared().StartPosition(),
                           &info, Script::WITH_OFFSET);
 
-  std::string name = script->name().IsString()
-    ? String::cast(script->name()).ToCString().get()
-    : "(anonymous script)";
-
   std::ostringstream os;
   os << "scriptId=" << (script.is_null() ? script->id() : -1);
-  os << " @" << name << ":" << info.line + 1 << ":" << info.column;
+  os << " @" << GetFunctionScriptName(isolate, function) << ":"
+     << info.line + 1 << ":" << info.column;
   return os.str();
 }
 
@@ -419,8 +427,18 @@ V8_WARN_UNUSED_RESULT MaybeHandle<Object> Invoke(Isolate* isolate,
     // Under record/replay, AutoDisallowEvents uses DUMP_ON_FAILURE to block
     // C++→JS without throwing (throws would propagate and diverge).
     if (recordreplay::IsRecordingOrReplaying()) {
+      std::string script_name =
+          params.target->IsJSFunction()
+              ? GetFunctionScriptName(
+                    isolate, Handle<JSFunction>::cast(params.target))
+              : "<non-function>";
       recordreplay::Print(
-          "DisallowJavascriptExecution: blocked C++→JS entry (DUMP_ON_FAILURE)");
+          "DisallowJavascriptExecution: blocked C++→JS entry "
+          "(DUMP_ON_FAILURE) %s",
+          script_name.c_str());
+      if (recordreplay::IsRecording()) {
+        recordreplay::Crash("EncounteredDivergentJSWhenRecording");
+      }
     } else {
       V8::GetCurrentPlatform()->DumpWithoutCrashing();
     }

--- a/src/execution/execution.cc
+++ b/src/execution/execution.cc
@@ -424,21 +424,19 @@ V8_WARN_UNUSED_RESULT MaybeHandle<Object> Invoke(Isolate* isolate,
     return MaybeHandle<Object>();
   }
   if (!DumpOnJavascriptExecution::IsAllowed(isolate)) {
-    // DUMP_ON_FAILURE blocks C++→JS without throwing (throws would diverge).
-    // Replay EventsDisallowed does not use this; user-JS is gated by
-    // RecordReplayIsDivergentUserJSWithoutPause instead.
     if (recordreplay::IsRecordingOrReplaying()) {
       std::string script_name =
           params.target->IsJSFunction()
               ? GetFunctionScriptName(
                     isolate, Handle<JSFunction>::cast(params.target))
               : "<non-function>";
-      recordreplay::Print(
+      std::string message =
           "DisallowJavascriptExecution: blocked C++→JS entry "
-          "(DUMP_ON_FAILURE) %s",
-          script_name.c_str());
+          "(DUMP_ON_FAILURE) " +
+          script_name;
+      recordreplay::Print("%s", message.c_str());
       if (recordreplay::IsRecording()) {
-        recordreplay::Crash("EncounteredDivergentJSWhenRecording");
+        recordreplay::Crash("%s", message.c_str());
       }
     } else {
       V8::GetCurrentPlatform()->DumpWithoutCrashing();

--- a/src/execution/execution.cc
+++ b/src/execution/execution.cc
@@ -424,8 +424,9 @@ V8_WARN_UNUSED_RESULT MaybeHandle<Object> Invoke(Isolate* isolate,
     return MaybeHandle<Object>();
   }
   if (!DumpOnJavascriptExecution::IsAllowed(isolate)) {
-    // Under record/replay, AutoDisallowEvents uses DUMP_ON_FAILURE to block
-    // C++→JS without throwing (throws would propagate and diverge).
+    // DUMP_ON_FAILURE blocks C++→JS without throwing (throws would diverge).
+    // Replay EventsDisallowed does not use this; user-JS is gated by
+    // RecordReplayIsDivergentUserJSWithoutPause instead.
     if (recordreplay::IsRecordingOrReplaying()) {
       std::string script_name =
           params.target->IsJSFunction()

--- a/src/inspector/injected-script.cc
+++ b/src/inspector/injected-script.cc
@@ -206,7 +206,8 @@ class InjectedScript::ProtocolPromiseHandler {
         m_throwOnSideEffect(throwOnSideEffect),
         m_callback(std::move(callback)),
         m_wrapper(m_inspector->isolate(),
-                  v8::External::New(m_inspector->isolate(), this)) {
+                  v8::External::New(m_inspector->isolate(), this)),
+        m_replay_owned(session->replayOwned()) {
     m_wrapper.SetWeak(this, cleanup, v8::WeakCallbackType::kParameter);
     v8::Local<v8::Promise> promise;
     if (maybeEvaluationResult.ToLocal(&promise)) {
@@ -228,14 +229,12 @@ class InjectedScript::ProtocolPromiseHandler {
   }
 
   void thenCallback(v8::Local<v8::Value> value) {
+    v8::replayio::AutoMaybeReplayOwned replay_owned(
+        m_replay_owned, m_inspector->isolate(),
+        "InjectedScript::EvaluateCallback::thenCallback");
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
-    const bool replay_owned = session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, m_inspector->isolate(),
-        "InjectedScript::EvaluateCallback::thenCallback");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;
@@ -278,14 +277,12 @@ class InjectedScript::ProtocolPromiseHandler {
   }
 
   void catchCallback(v8::Local<v8::Value> result) {
+    v8::replayio::AutoMaybeReplayOwned replay_owned(
+        m_replay_owned, m_inspector->isolate(),
+        "InjectedScript::EvaluateCallback::catchCallback");
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
-    const bool replay_owned = session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, m_inspector->isolate(),
-        "InjectedScript::EvaluateCallback::catchCallback");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;
@@ -381,14 +378,12 @@ class InjectedScript::ProtocolPromiseHandler {
   }
 
   void sendPromiseCollected() {
+    v8::replayio::AutoMaybeReplayOwned replay_owned(
+        m_replay_owned, m_inspector->isolate(),
+        "InjectedScript::EvaluateCallback::sendPromiseCollected");
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
-    const bool replay_owned = session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, m_inspector->isolate(),
-        "InjectedScript::EvaluateCallback::sendPromiseCollected");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;
@@ -408,6 +403,7 @@ class InjectedScript::ProtocolPromiseHandler {
   std::weak_ptr<EvaluateCallback> m_callback;
   v8::Global<v8::External> m_wrapper;
   v8::Global<v8::Promise> m_evaluationResult;
+  bool m_replay_owned;
 };
 
 InjectedScript::InjectedScript(InspectedContext* context, int sessionId,
@@ -444,6 +440,8 @@ Response InjectedScript::getProperties(
     const v8::KeyIterationParams* params,
     std::unique_ptr<Array<PropertyDescriptor>>* properties,
     Maybe<protocol::Runtime::ExceptionDetails>* exceptionDetails) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(), "InjectedScript::getProperties");
   v8::HandleScope handles(m_context->isolate());
   v8::Local<v8::Context> context = m_context->context();
   v8::Isolate* isolate = m_context->isolate();
@@ -533,6 +531,9 @@ Response InjectedScript::getInternalAndPrivateProperties(
         internalProperties,
     std::unique_ptr<protocol::Array<PrivatePropertyDescriptor>>*
         privateProperties) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(),
+      "InjectedScript::getInternalAndPrivateProperties");
   *internalProperties = std::make_unique<Array<InternalPropertyDescriptor>>();
   *privateProperties = std::make_unique<Array<PrivatePropertyDescriptor>>();
 
@@ -615,6 +616,8 @@ Response InjectedScript::getInternalAndPrivateProperties(
 }
 
 void InjectedScript::releaseObject(const String16& objectId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(), "InjectedScript::releaseObject");
   std::unique_ptr<RemoteObjectId> remoteId;
   Response response = RemoteObjectId::parse(objectId, &remoteId);
   if (response.IsSuccess()) unbindObject(remoteId->id());
@@ -631,6 +634,8 @@ Response InjectedScript::wrapObject(
     v8::Local<v8::Value> value, const String16& groupName, WrapMode wrapMode,
     v8::MaybeLocal<v8::Value> customPreviewConfig, int maxCustomPreviewDepth,
     std::unique_ptr<protocol::Runtime::RemoteObject>* result) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(), "InjectedScript::wrapObject");
   v8::Local<v8::Context> context = m_context->context();
   v8::Context::Scope contextScope(context);
   std::unique_ptr<ValueMirror> mirror = ValueMirror::create(context, value);
@@ -643,6 +648,8 @@ Response InjectedScript::wrapObjectMirror(
     const ValueMirror& mirror, const String16& groupName, WrapMode wrapMode,
     v8::MaybeLocal<v8::Value> customPreviewConfig, int maxCustomPreviewDepth,
     std::unique_ptr<protocol::Runtime::RemoteObject>* result) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(), "InjectedScript::wrapObjectMirror");
   int customPreviewEnabled = m_customPreviewEnabled;
   int sessionId = m_sessionId;
   v8::Local<v8::Context> context = m_context->context();
@@ -673,6 +680,8 @@ Response InjectedScript::wrapObjectMirror(
 
 std::unique_ptr<protocol::Runtime::RemoteObject> InjectedScript::wrapTable(
     v8::Local<v8::Object> table, v8::MaybeLocal<v8::Array> maybeColumns) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(), "InjectedScript::wrapTable");
   using protocol::Runtime::RemoteObject;
   using protocol::Runtime::ObjectPreview;
   using protocol::Runtime::PropertyPreview;
@@ -738,6 +747,8 @@ void InjectedScript::addPromiseCallback(
     V8InspectorSessionImpl* session, v8::MaybeLocal<v8::Value> value,
     const String16& objectGroup, WrapMode wrapMode, bool replMode,
     bool throwOnSideEffect, std::shared_ptr<EvaluateCallback> callback) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(), "InjectedScript::addPromiseCallback");
   m_evaluateCallbacks.insert(callback);
   // After stashing the shared_ptr in `m_evaluateCallback`, we reset `callback`.
   // `ProtocolPromiseHandler:add` can take longer than the life time of this
@@ -764,6 +775,9 @@ void InjectedScript::addPromiseCallback(
 }
 
 void InjectedScript::discardEvaluateCallbacks() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(),
+      "InjectedScript::discardEvaluateCallbacks");
   while (!m_evaluateCallbacks.empty()) {
     EvaluateCallback::sendFailure(
         *m_evaluateCallbacks.begin(), this,
@@ -795,6 +809,9 @@ String16 InjectedScript::objectGroupName(const RemoteObjectId& objectId) const {
 }
 
 void InjectedScript::releaseObjectGroup(const String16& objectGroup) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(),
+      "InjectedScript::releaseObjectGroup");
   if (objectGroup == "console") m_lastEvaluationResult.Reset();
   if (objectGroup.isEmpty()) return;
   auto it = m_nameToObjectGroup.find(objectGroup);
@@ -804,6 +821,9 @@ void InjectedScript::releaseObjectGroup(const String16& objectGroup) {
 }
 
 void InjectedScript::setCustomObjectFormatterEnabled(bool enabled) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(),
+      "InjectedScript::setCustomObjectFormatterEnabled");
   m_customPreviewEnabled = enabled;
 }
 
@@ -814,6 +834,9 @@ v8::Local<v8::Value> InjectedScript::lastEvaluationResult() const {
 }
 
 void InjectedScript::setLastEvaluationResult(v8::Local<v8::Value> result) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(),
+      "InjectedScript::setLastEvaluationResult");
   m_lastEvaluationResult.Reset(m_context->isolate(), result);
   m_lastEvaluationResult.AnnotateStrongRetainer(kGlobalHandleLabel);
 }
@@ -821,6 +844,9 @@ void InjectedScript::setLastEvaluationResult(v8::Local<v8::Value> result) {
 Response InjectedScript::resolveCallArgument(
     protocol::Runtime::CallArgument* callArgument,
     v8::Local<v8::Value>* result) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(),
+      "InjectedScript::resolveCallArgument");
   if (callArgument->hasObjectId()) {
     std::unique_ptr<RemoteObjectId> remoteObjectId;
     Response response =
@@ -872,6 +898,9 @@ Response InjectedScript::addExceptionToDetails(
     v8::Local<v8::Value> exception,
     protocol::Runtime::ExceptionDetails* exceptionDetails,
     const String16& objectGroup) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(),
+      "InjectedScript::addExceptionToDetails");
   if (exception.IsEmpty()) return Response::Success();
   std::unique_ptr<protocol::Runtime::RemoteObject> wrapped;
   Response response =
@@ -887,6 +916,9 @@ Response InjectedScript::addExceptionToDetails(
 Response InjectedScript::createExceptionDetails(
     const v8::TryCatch& tryCatch, const String16& objectGroup,
     Maybe<protocol::Runtime::ExceptionDetails>* result) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(),
+      "InjectedScript::createExceptionDetails");
   if (!tryCatch.HasCaught()) return Response::InternalError();
   v8::Local<v8::Message> message = tryCatch.Message();
   v8::Local<v8::Value> exception = tryCatch.Exception();
@@ -897,6 +929,9 @@ Response InjectedScript::createExceptionDetails(
     v8::Local<v8::Message> message, v8::Local<v8::Value> exception,
     const String16& objectGroup,
     Maybe<protocol::Runtime::ExceptionDetails>* result) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(),
+      "InjectedScript::createExceptionDetails");
   String16 messageText =
       message.IsEmpty()
           ? String16()
@@ -940,6 +975,9 @@ Response InjectedScript::wrapEvaluateResult(
     const String16& objectGroup, WrapMode wrapMode, bool throwOnSideEffect,
     std::unique_ptr<protocol::Runtime::RemoteObject>* result,
     Maybe<protocol::Runtime::ExceptionDetails>* exceptionDetails) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(),
+      "InjectedScript::wrapEvaluateResult");
   v8::Local<v8::Value> resultValue;
   if (!tryCatch.HasCaught()) {
     if (!maybeResultValue.ToLocal(&resultValue))
@@ -1149,18 +1187,21 @@ String16 InjectedScript::bindObject(v8::Local<v8::Value> value,
 Response InjectedScript::bindRemoteObjectIfNeeded(
     int sessionId, v8::Local<v8::Context> context, v8::Local<v8::Value> value,
     const String16& groupName, protocol::Runtime::RemoteObject* remoteObject) {
+  v8::Isolate* isolate = context->GetIsolate();
+  V8InspectorImpl* inspector =
+      static_cast<V8InspectorImpl*>(v8::debug::GetInspector(isolate));
+  InspectedContext* inspectedContext =
+      inspector->getContext(InspectedContext::contextId(context));
+  InjectedScript* injectedScript =
+      inspectedContext ? inspectedContext->getInjectedScript(sessionId)
+                       : nullptr;
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      injectedScript ? injectedScript->replayOwned() : false, isolate,
+      "InjectedScript::bindRemoteObjectIfNeeded");
   if (!remoteObject) return Response::Success();
   if (remoteObject->hasValue()) return Response::Success();
   if (remoteObject->hasUnserializableValue()) return Response::Success();
   if (remoteObject->getType() != RemoteObject::TypeEnum::Undefined) {
-    v8::Isolate* isolate = context->GetIsolate();
-    V8InspectorImpl* inspector =
-        static_cast<V8InspectorImpl*>(v8::debug::GetInspector(isolate));
-    InspectedContext* inspectedContext =
-        inspector->getContext(InspectedContext::contextId(context));
-    InjectedScript* injectedScript =
-        inspectedContext ? inspectedContext->getInjectedScript(sessionId)
-                         : nullptr;
     if (!injectedScript) {
       if (v8::recordreplay::IsInReplayCode("InjectedScript::bindRemoteObjectIfNeeded")) {
         v8::recordreplay::Warning(
@@ -1186,6 +1227,8 @@ Response InjectedScript::bindRemoteObjectIfNeeded(
 }
 
 void InjectedScript::unbindObject(int id) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_context->isolate(), "InjectedScript::unbindObject");
   m_idToWrappedObject.erase(id);
   m_idToObjectGroupName.erase(id);
 }

--- a/src/inspector/injected-script.cc
+++ b/src/inspector/injected-script.cc
@@ -51,7 +51,6 @@
 #include "src/inspector/v8-stack-trace-impl.h"
 #include "src/inspector/v8-value-utils.h"
 #include "src/inspector/value-mirror.h"
-#include "src/base/replayio.h"
 
 #include "v8.h"
 
@@ -231,11 +230,6 @@ class InjectedScript::ProtocolPromiseHandler {
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
-    const bool replay_owned = session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, m_inspector->isolate(),
-        "InjectedScript::EvaluateCallback::thenCallback");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;
@@ -281,11 +275,6 @@ class InjectedScript::ProtocolPromiseHandler {
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
-    const bool replay_owned = session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, m_inspector->isolate(),
-        "InjectedScript::EvaluateCallback::catchCallback");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;
@@ -384,11 +373,6 @@ class InjectedScript::ProtocolPromiseHandler {
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
-    const bool replay_owned = session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, m_inspector->isolate(),
-        "InjectedScript::EvaluateCallback::sendPromiseCollected");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;
@@ -410,8 +394,11 @@ class InjectedScript::ProtocolPromiseHandler {
   v8::Global<v8::Promise> m_evaluationResult;
 };
 
-InjectedScript::InjectedScript(InspectedContext* context, int sessionId)
-    : m_context(context), m_sessionId(sessionId) {}
+InjectedScript::InjectedScript(InspectedContext* context, int sessionId,
+                               bool replayOwned)
+    : m_context(context),
+      m_sessionId(sessionId),
+      m_replay_owned(replayOwned) {}
 
 InjectedScript::~InjectedScript() { discardEvaluateCallbacks(); }
 

--- a/src/inspector/injected-script.cc
+++ b/src/inspector/injected-script.cc
@@ -440,8 +440,6 @@ Response InjectedScript::getProperties(
     const v8::KeyIterationParams* params,
     std::unique_ptr<Array<PropertyDescriptor>>* properties,
     Maybe<protocol::Runtime::ExceptionDetails>* exceptionDetails) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(), "InjectedScript::getProperties");
   v8::HandleScope handles(m_context->isolate());
   v8::Local<v8::Context> context = m_context->context();
   v8::Isolate* isolate = m_context->isolate();
@@ -531,9 +529,6 @@ Response InjectedScript::getInternalAndPrivateProperties(
         internalProperties,
     std::unique_ptr<protocol::Array<PrivatePropertyDescriptor>>*
         privateProperties) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(),
-      "InjectedScript::getInternalAndPrivateProperties");
   *internalProperties = std::make_unique<Array<InternalPropertyDescriptor>>();
   *privateProperties = std::make_unique<Array<PrivatePropertyDescriptor>>();
 
@@ -616,8 +611,6 @@ Response InjectedScript::getInternalAndPrivateProperties(
 }
 
 void InjectedScript::releaseObject(const String16& objectId) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(), "InjectedScript::releaseObject");
   std::unique_ptr<RemoteObjectId> remoteId;
   Response response = RemoteObjectId::parse(objectId, &remoteId);
   if (response.IsSuccess()) unbindObject(remoteId->id());
@@ -648,8 +641,6 @@ Response InjectedScript::wrapObjectMirror(
     const ValueMirror& mirror, const String16& groupName, WrapMode wrapMode,
     v8::MaybeLocal<v8::Value> customPreviewConfig, int maxCustomPreviewDepth,
     std::unique_ptr<protocol::Runtime::RemoteObject>* result) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(), "InjectedScript::wrapObjectMirror");
   int customPreviewEnabled = m_customPreviewEnabled;
   int sessionId = m_sessionId;
   v8::Local<v8::Context> context = m_context->context();
@@ -680,8 +671,6 @@ Response InjectedScript::wrapObjectMirror(
 
 std::unique_ptr<protocol::Runtime::RemoteObject> InjectedScript::wrapTable(
     v8::Local<v8::Object> table, v8::MaybeLocal<v8::Array> maybeColumns) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(), "InjectedScript::wrapTable");
   using protocol::Runtime::RemoteObject;
   using protocol::Runtime::ObjectPreview;
   using protocol::Runtime::PropertyPreview;
@@ -747,8 +736,6 @@ void InjectedScript::addPromiseCallback(
     V8InspectorSessionImpl* session, v8::MaybeLocal<v8::Value> value,
     const String16& objectGroup, WrapMode wrapMode, bool replMode,
     bool throwOnSideEffect, std::shared_ptr<EvaluateCallback> callback) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(), "InjectedScript::addPromiseCallback");
   m_evaluateCallbacks.insert(callback);
   // After stashing the shared_ptr in `m_evaluateCallback`, we reset `callback`.
   // `ProtocolPromiseHandler:add` can take longer than the life time of this
@@ -809,9 +796,6 @@ String16 InjectedScript::objectGroupName(const RemoteObjectId& objectId) const {
 }
 
 void InjectedScript::releaseObjectGroup(const String16& objectGroup) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(),
-      "InjectedScript::releaseObjectGroup");
   if (objectGroup == "console") m_lastEvaluationResult.Reset();
   if (objectGroup.isEmpty()) return;
   auto it = m_nameToObjectGroup.find(objectGroup);
@@ -834,9 +818,6 @@ v8::Local<v8::Value> InjectedScript::lastEvaluationResult() const {
 }
 
 void InjectedScript::setLastEvaluationResult(v8::Local<v8::Value> result) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(),
-      "InjectedScript::setLastEvaluationResult");
   m_lastEvaluationResult.Reset(m_context->isolate(), result);
   m_lastEvaluationResult.AnnotateStrongRetainer(kGlobalHandleLabel);
 }
@@ -844,9 +825,6 @@ void InjectedScript::setLastEvaluationResult(v8::Local<v8::Value> result) {
 Response InjectedScript::resolveCallArgument(
     protocol::Runtime::CallArgument* callArgument,
     v8::Local<v8::Value>* result) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(),
-      "InjectedScript::resolveCallArgument");
   if (callArgument->hasObjectId()) {
     std::unique_ptr<RemoteObjectId> remoteObjectId;
     Response response =
@@ -898,9 +876,6 @@ Response InjectedScript::addExceptionToDetails(
     v8::Local<v8::Value> exception,
     protocol::Runtime::ExceptionDetails* exceptionDetails,
     const String16& objectGroup) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(),
-      "InjectedScript::addExceptionToDetails");
   if (exception.IsEmpty()) return Response::Success();
   std::unique_ptr<protocol::Runtime::RemoteObject> wrapped;
   Response response =
@@ -916,9 +891,6 @@ Response InjectedScript::addExceptionToDetails(
 Response InjectedScript::createExceptionDetails(
     const v8::TryCatch& tryCatch, const String16& objectGroup,
     Maybe<protocol::Runtime::ExceptionDetails>* result) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(),
-      "InjectedScript::createExceptionDetails");
   if (!tryCatch.HasCaught()) return Response::InternalError();
   v8::Local<v8::Message> message = tryCatch.Message();
   v8::Local<v8::Value> exception = tryCatch.Exception();
@@ -929,9 +901,6 @@ Response InjectedScript::createExceptionDetails(
     v8::Local<v8::Message> message, v8::Local<v8::Value> exception,
     const String16& objectGroup,
     Maybe<protocol::Runtime::ExceptionDetails>* result) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(),
-      "InjectedScript::createExceptionDetails");
   String16 messageText =
       message.IsEmpty()
           ? String16()
@@ -975,9 +944,6 @@ Response InjectedScript::wrapEvaluateResult(
     const String16& objectGroup, WrapMode wrapMode, bool throwOnSideEffect,
     std::unique_ptr<protocol::Runtime::RemoteObject>* result,
     Maybe<protocol::Runtime::ExceptionDetails>* exceptionDetails) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(),
-      "InjectedScript::wrapEvaluateResult");
   v8::Local<v8::Value> resultValue;
   if (!tryCatch.HasCaught()) {
     if (!maybeResultValue.ToLocal(&resultValue))
@@ -1195,9 +1161,6 @@ Response InjectedScript::bindRemoteObjectIfNeeded(
   InjectedScript* injectedScript =
       inspectedContext ? inspectedContext->getInjectedScript(sessionId)
                        : nullptr;
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      injectedScript ? injectedScript->replayOwned() : false, isolate,
-      "InjectedScript::bindRemoteObjectIfNeeded");
   if (!remoteObject) return Response::Success();
   if (remoteObject->hasValue()) return Response::Success();
   if (remoteObject->hasUnserializableValue()) return Response::Success();
@@ -1227,8 +1190,6 @@ Response InjectedScript::bindRemoteObjectIfNeeded(
 }
 
 void InjectedScript::unbindObject(int id) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_context->isolate(), "InjectedScript::unbindObject");
   m_idToWrappedObject.erase(id);
   m_idToObjectGroupName.erase(id);
 }

--- a/src/inspector/injected-script.cc
+++ b/src/inspector/injected-script.cc
@@ -51,6 +51,7 @@
 #include "src/inspector/v8-stack-trace-impl.h"
 #include "src/inspector/v8-value-utils.h"
 #include "src/inspector/value-mirror.h"
+#include "src/base/replayio.h"
 
 #include "v8.h"
 
@@ -230,6 +231,11 @@ class InjectedScript::ProtocolPromiseHandler {
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
+    const bool replay_owned = session->replayOwned();
+    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+    v8::replayio::AutoMaybeDisallowEvents disallow(
+        replay_owned, m_inspector->isolate(),
+        "InjectedScript::EvaluateCallback::thenCallback");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;
@@ -275,6 +281,11 @@ class InjectedScript::ProtocolPromiseHandler {
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
+    const bool replay_owned = session->replayOwned();
+    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+    v8::replayio::AutoMaybeDisallowEvents disallow(
+        replay_owned, m_inspector->isolate(),
+        "InjectedScript::EvaluateCallback::catchCallback");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;
@@ -373,6 +384,11 @@ class InjectedScript::ProtocolPromiseHandler {
     V8InspectorSessionImpl* session =
         m_inspector->sessionById(m_contextGroupId, m_sessionId);
     if (!session) return;
+    const bool replay_owned = session->replayOwned();
+    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+    v8::replayio::AutoMaybeDisallowEvents disallow(
+        replay_owned, m_inspector->isolate(),
+        "InjectedScript::EvaluateCallback::sendPromiseCollected");
     InjectedScript::ContextScope scope(session, m_executionContextId);
     Response response = scope.initialize();
     if (!response.IsSuccess()) return;

--- a/src/inspector/injected-script.h
+++ b/src/inspector/injected-script.h
@@ -78,12 +78,13 @@ class EvaluateCallback {
 
 class InjectedScript final {
  public:
-  InjectedScript(InspectedContext*, int sessionId);
+  InjectedScript(InspectedContext*, int sessionId, bool replayOwned);
   ~InjectedScript();
   InjectedScript(const InjectedScript&) = delete;
   InjectedScript& operator=(const InjectedScript&) = delete;
 
   InspectedContext* context() const { return m_context; }
+  bool replayOwned() const { return m_replay_owned; }
 
   Response getProperties(
       v8::Local<v8::Object>, const String16& groupName, bool ownProperties,
@@ -251,6 +252,7 @@ class InjectedScript final {
 
   InspectedContext* m_context;
   int m_sessionId;
+  bool m_replay_owned;
   v8::Global<v8::Value> m_lastEvaluationResult;
   v8::Global<v8::Object> m_commandLineAPI;
   int m_lastBoundObjectId = 1;

--- a/src/inspector/inspected-context.cc
+++ b/src/inspector/inspected-context.cc
@@ -122,9 +122,10 @@ InjectedScript* InspectedContext::getInjectedScript(int sessionId) {
   return it == m_injectedScripts.end() ? nullptr : it->second.get();
 }
 
-InjectedScript* InspectedContext::createInjectedScript(int sessionId) {
+InjectedScript* InspectedContext::createInjectedScript(int sessionId,
+                                                       bool replayOwned) {
   std::unique_ptr<InjectedScript> injectedScript =
-      std::make_unique<InjectedScript>(this, sessionId);
+      std::make_unique<InjectedScript>(this, sessionId, replayOwned);
   CHECK(m_injectedScripts.find(sessionId) == m_injectedScripts.end());
   m_injectedScripts[sessionId] = std::move(injectedScript);
   return getInjectedScript(sessionId);

--- a/src/inspector/inspected-context.h
+++ b/src/inspector/inspected-context.h
@@ -53,7 +53,7 @@ class InspectedContext {
   V8InspectorImpl* inspector() const { return m_inspector; }
 
   InjectedScript* getInjectedScript(int sessionId);
-  InjectedScript* createInjectedScript(int sessionId);
+  InjectedScript* createInjectedScript(int sessionId, bool replayOwned);
   void discardInjectedScript(int sessionId);
 
   bool addInternalObject(v8::Local<v8::Object> object,

--- a/src/inspector/v8-console-agent-impl.cc
+++ b/src/inspector/v8-console-agent-impl.cc
@@ -4,6 +4,7 @@
 
 #include "src/inspector/v8-console-agent-impl.h"
 
+#include "src/base/replayio.h"
 #include "src/inspector/protocol/Protocol.h"
 #include "src/inspector/v8-console-message.h"
 #include "src/inspector/v8-inspector-impl.h"
@@ -28,6 +29,9 @@ V8ConsoleAgentImpl::V8ConsoleAgentImpl(
 V8ConsoleAgentImpl::~V8ConsoleAgentImpl() = default;
 
 Response V8ConsoleAgentImpl::enable() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_session->inspector()->isolate(),
+      "V8ConsoleAgentImpl::enable");
   if (m_enabled) return Response::Success();
   m_state->setBoolean(ConsoleAgentState::consoleEnabled, true);
   m_enabled = true;
@@ -36,6 +40,9 @@ Response V8ConsoleAgentImpl::enable() {
 }
 
 Response V8ConsoleAgentImpl::disable() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_session->inspector()->isolate(),
+      "V8ConsoleAgentImpl::disable");
   if (!m_enabled) return Response::Success();
   m_state->setBoolean(ConsoleAgentState::consoleEnabled, false);
   m_enabled = false;
@@ -45,18 +52,27 @@ Response V8ConsoleAgentImpl::disable() {
 Response V8ConsoleAgentImpl::clearMessages() { return Response::Success(); }
 
 void V8ConsoleAgentImpl::restore() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_session->inspector()->isolate(),
+      "V8ConsoleAgentImpl::restore");
   if (!m_state->booleanProperty(ConsoleAgentState::consoleEnabled, false))
     return;
   enable();
 }
 
 void V8ConsoleAgentImpl::messageAdded(V8ConsoleMessage* message) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_session->inspector()->isolate(),
+      "V8ConsoleAgentImpl::messageAdded");
   if (m_enabled) reportMessage(message, true);
 }
 
 bool V8ConsoleAgentImpl::enabled() { return m_enabled; }
 
 void V8ConsoleAgentImpl::reportAllMessages() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_session->inspector()->isolate(),
+      "V8ConsoleAgentImpl::reportAllMessages");
   V8ConsoleMessageStorage* storage =
       m_session->inspector()->ensureConsoleMessageStorage(
           m_session->contextGroupId());
@@ -69,6 +85,9 @@ void V8ConsoleAgentImpl::reportAllMessages() {
 
 bool V8ConsoleAgentImpl::reportMessage(V8ConsoleMessage* message,
                                        bool generatePreview) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_session->inspector()->isolate(),
+      "V8ConsoleAgentImpl::reportMessage");
   DCHECK_EQ(V8MessageOrigin::kConsole, message->origin());
   message->reportToFrontend(&m_frontend);
   m_frontend.flush();

--- a/src/inspector/v8-console-agent-impl.cc
+++ b/src/inspector/v8-console-agent-impl.cc
@@ -29,9 +29,6 @@ V8ConsoleAgentImpl::V8ConsoleAgentImpl(
 V8ConsoleAgentImpl::~V8ConsoleAgentImpl() = default;
 
 Response V8ConsoleAgentImpl::enable() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_session->inspector()->isolate(),
-      "V8ConsoleAgentImpl::enable");
   if (m_enabled) return Response::Success();
   m_state->setBoolean(ConsoleAgentState::consoleEnabled, true);
   m_enabled = true;
@@ -40,9 +37,6 @@ Response V8ConsoleAgentImpl::enable() {
 }
 
 Response V8ConsoleAgentImpl::disable() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_session->inspector()->isolate(),
-      "V8ConsoleAgentImpl::disable");
   if (!m_enabled) return Response::Success();
   m_state->setBoolean(ConsoleAgentState::consoleEnabled, false);
   m_enabled = false;
@@ -61,18 +55,12 @@ void V8ConsoleAgentImpl::restore() {
 }
 
 void V8ConsoleAgentImpl::messageAdded(V8ConsoleMessage* message) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_session->inspector()->isolate(),
-      "V8ConsoleAgentImpl::messageAdded");
   if (m_enabled) reportMessage(message, true);
 }
 
 bool V8ConsoleAgentImpl::enabled() { return m_enabled; }
 
 void V8ConsoleAgentImpl::reportAllMessages() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_session->inspector()->isolate(),
-      "V8ConsoleAgentImpl::reportAllMessages");
   V8ConsoleMessageStorage* storage =
       m_session->inspector()->ensureConsoleMessageStorage(
           m_session->contextGroupId());
@@ -85,9 +73,6 @@ void V8ConsoleAgentImpl::reportAllMessages() {
 
 bool V8ConsoleAgentImpl::reportMessage(V8ConsoleMessage* message,
                                        bool generatePreview) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_session->inspector()->isolate(),
-      "V8ConsoleAgentImpl::reportMessage");
   DCHECK_EQ(V8MessageOrigin::kConsole, message->origin());
   message->reportToFrontend(&m_frontend);
   m_frontend.flush();

--- a/src/inspector/v8-console-agent-impl.cc
+++ b/src/inspector/v8-console-agent-impl.cc
@@ -22,7 +22,8 @@ V8ConsoleAgentImpl::V8ConsoleAgentImpl(
     : m_session(session),
       m_state(state),
       m_frontend(frontendChannel),
-      m_enabled(false) {}
+      m_enabled(false),
+      m_replay_owned(session->replayOwned()) {}
 
 V8ConsoleAgentImpl::~V8ConsoleAgentImpl() = default;
 

--- a/src/inspector/v8-console-agent-impl.h
+++ b/src/inspector/v8-console-agent-impl.h
@@ -32,6 +32,7 @@ class V8ConsoleAgentImpl : public protocol::Console::Backend {
   void messageAdded(V8ConsoleMessage*);
   void reset();
   bool enabled();
+  bool replayOwned() const { return m_replay_owned; }
 
  private:
   void reportAllMessages();
@@ -41,6 +42,7 @@ class V8ConsoleAgentImpl : public protocol::Console::Backend {
   protocol::DictionaryValue* m_state;
   protocol::Console::Frontend m_frontend;
   bool m_enabled;
+  bool m_replay_owned;
 };
 
 }  // namespace v8_inspector

--- a/src/inspector/v8-console.cc
+++ b/src/inspector/v8-console.cc
@@ -22,6 +22,7 @@
 #include "src/inspector/v8-runtime-agent-impl.h"
 #include "src/inspector/v8-stack-trace-impl.h"
 #include "src/inspector/v8-value-utils.h"
+#include "src/base/replayio.h"
 #include "src/tracing/trace-event.h"
 
 #include "v8.h"
@@ -646,6 +647,11 @@ static void setFunctionBreakpoint(ConsoleHelper& helper, int sessionId,
                                   bool enable) {
   V8InspectorSessionImpl* session = helper.session(sessionId);
   if (session == nullptr) return;
+  const bool replay_owned = session->replayOwned();
+  v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      replay_owned, session->inspector()->isolate(),
+      "V8Console::setFunctionBreakpoint");
   if (!session->debuggerAgent()->enabled()) return;
   if (enable) {
     session->debuggerAgent()->setBreakpointFor(function, condition, source);
@@ -749,6 +755,11 @@ static void inspectImpl(const v8::FunctionCallbackInfo<v8::Value>& info,
     hints->setBoolean("queryObjects", true);
   }
   if (V8InspectorSessionImpl* session = helper.session(sessionId)) {
+    const bool replay_owned = session->replayOwned();
+    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+    v8::replayio::AutoMaybeDisallowEvents disallow(
+        replay_owned, session->inspector()->isolate(),
+        "V8Console::inspectImpl");
     session->runtimeAgent()->inspect(std::move(wrappedObject), std::move(hints),
                                      helper.contextId());
   }
@@ -795,6 +806,11 @@ void V8Console::inspectedObject(const v8::FunctionCallbackInfo<v8::Value>& info,
   v8::debug::ConsoleCallArguments args(info);
   ConsoleHelper helper(args, v8::debug::ConsoleContext(), m_inspector);
   if (V8InspectorSessionImpl* session = helper.session(sessionId)) {
+    const bool replay_owned = session->replayOwned();
+    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+    v8::replayio::AutoMaybeDisallowEvents disallow(
+        replay_owned, session->inspector()->isolate(),
+        "V8Console::inspectedObject");
     V8InspectorSession::Inspectable* object = session->inspectedObject(num);
     v8::Isolate* isolate = info.GetIsolate();
     if (object)

--- a/src/inspector/v8-console.cc
+++ b/src/inspector/v8-console.cc
@@ -22,7 +22,6 @@
 #include "src/inspector/v8-runtime-agent-impl.h"
 #include "src/inspector/v8-stack-trace-impl.h"
 #include "src/inspector/v8-value-utils.h"
-#include "src/base/replayio.h"
 #include "src/tracing/trace-event.h"
 
 #include "v8.h"
@@ -647,11 +646,6 @@ static void setFunctionBreakpoint(ConsoleHelper& helper, int sessionId,
                                   bool enable) {
   V8InspectorSessionImpl* session = helper.session(sessionId);
   if (session == nullptr) return;
-  const bool replay_owned = session->replayOwned();
-  v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      replay_owned, session->inspector()->isolate(),
-      "V8Console::setFunctionBreakpoint");
   if (!session->debuggerAgent()->enabled()) return;
   if (enable) {
     session->debuggerAgent()->setBreakpointFor(function, condition, source);
@@ -755,11 +749,6 @@ static void inspectImpl(const v8::FunctionCallbackInfo<v8::Value>& info,
     hints->setBoolean("queryObjects", true);
   }
   if (V8InspectorSessionImpl* session = helper.session(sessionId)) {
-    const bool replay_owned = session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, session->inspector()->isolate(),
-        "V8Console::inspectImpl");
     session->runtimeAgent()->inspect(std::move(wrappedObject), std::move(hints),
                                      helper.contextId());
   }
@@ -806,11 +795,6 @@ void V8Console::inspectedObject(const v8::FunctionCallbackInfo<v8::Value>& info,
   v8::debug::ConsoleCallArguments args(info);
   ConsoleHelper helper(args, v8::debug::ConsoleContext(), m_inspector);
   if (V8InspectorSessionImpl* session = helper.session(sessionId)) {
-    const bool replay_owned = session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, session->inspector()->isolate(),
-        "V8Console::inspectedObject");
     V8InspectorSession::Inspectable* object = session->inspectedObject(num);
     v8::Isolate* isolate = info.GetIsolate();
     if (object)

--- a/src/inspector/v8-debugger-agent-impl.cc
+++ b/src/inspector/v8-debugger-agent-impl.cc
@@ -29,6 +29,7 @@
 #include "src/inspector/v8-runtime-agent-impl.h"
 #include "src/inspector/v8-stack-trace-impl.h"
 #include "src/inspector/v8-value-utils.h"
+#include "src/base/replayio.h"
 
 namespace v8_inspector {
 
@@ -381,6 +382,9 @@ V8DebuggerAgentImpl::V8DebuggerAgentImpl(
 V8DebuggerAgentImpl::~V8DebuggerAgentImpl() = default;
 
 void V8DebuggerAgentImpl::enableImpl() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::enableImpl");
   m_enabled = true;
   m_state->setBoolean(DebuggerAgentState::debuggerEnabled, true);
   m_debugger->enable();
@@ -403,6 +407,9 @@ void V8DebuggerAgentImpl::enableImpl() {
 
 Response V8DebuggerAgentImpl::enable(Maybe<double> maxScriptsCacheSize,
                                      String16* outDebuggerId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::enable");
   m_maxScriptCacheSize = v8::base::saturated_cast<size_t>(
       maxScriptsCacheSize.fromMaybe(std::numeric_limits<double>::max()));
   *outDebuggerId =
@@ -417,6 +424,9 @@ Response V8DebuggerAgentImpl::enable(Maybe<double> maxScriptsCacheSize,
 }
 
 Response V8DebuggerAgentImpl::disable() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::disable");
   if (!enabled()) return Response::Success();
 
   m_state->remove(DebuggerAgentState::breakpointsByRegex);
@@ -458,6 +468,9 @@ Response V8DebuggerAgentImpl::disable() {
 }
 
 void V8DebuggerAgentImpl::restore() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::restore");
   DCHECK(!m_enabled);
   if (!m_state->booleanProperty(DebuggerAgentState::debuggerEnabled, false))
     return;
@@ -486,6 +499,9 @@ void V8DebuggerAgentImpl::restore() {
 }
 
 Response V8DebuggerAgentImpl::setBreakpointsActive(bool active) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setBreakpointsActive");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   if (m_breakpointsActive == active) return Response::Success();
   m_breakpointsActive = active;
@@ -498,6 +514,9 @@ Response V8DebuggerAgentImpl::setBreakpointsActive(bool active) {
 }
 
 Response V8DebuggerAgentImpl::setSkipAllPauses(bool skip) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setSkipAllPauses");
   m_state->setBoolean(DebuggerAgentState::skipAllPauses, skip);
   m_skipAllPauses = skip;
   return Response::Success();
@@ -528,6 +547,9 @@ Response V8DebuggerAgentImpl::setBreakpointByUrl(
     Maybe<int> optionalColumnNumber, Maybe<String16> optionalCondition,
     String16* outBreakpointId,
     std::unique_ptr<protocol::Array<protocol::Debugger::Location>>* locations) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setBreakpointByUrl");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
 
   *locations = std::make_unique<Array<protocol::Debugger::Location>>();
@@ -616,6 +638,9 @@ Response V8DebuggerAgentImpl::setBreakpoint(
     std::unique_ptr<protocol::Debugger::Location> location,
     Maybe<String16> optionalCondition, String16* outBreakpointId,
     std::unique_ptr<protocol::Debugger::Location>* actualLocation) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setBreakpoint");
   String16 breakpointId = generateBreakpointId(
       BreakpointType::kByScriptId, location->getScriptId(),
       location->getLineNumber(), location->getColumnNumber(0));
@@ -639,6 +664,9 @@ Response V8DebuggerAgentImpl::setBreakpoint(
 Response V8DebuggerAgentImpl::setBreakpointOnFunctionCall(
     const String16& functionObjectId, Maybe<String16> optionalCondition,
     String16* outBreakpointId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setBreakpointOnFunctionCall");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
 
   InjectedScript::ObjectScope scope(m_session, functionObjectId);
@@ -665,6 +693,9 @@ Response V8DebuggerAgentImpl::setBreakpointOnFunctionCall(
 
 Response V8DebuggerAgentImpl::setInstrumentationBreakpoint(
     const String16& instrumentation, String16* outBreakpointId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setInstrumentationBreakpoint");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   String16 breakpointId = generateInstrumentationBreakpointId(instrumentation);
   protocol::DictionaryValue* breakpoints = getOrCreateObject(
@@ -679,6 +710,9 @@ Response V8DebuggerAgentImpl::setInstrumentationBreakpoint(
 }
 
 Response V8DebuggerAgentImpl::removeBreakpoint(const String16& breakpointId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::removeBreakpoint");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   BreakpointType type;
   String16 selector;
@@ -739,6 +773,9 @@ Response V8DebuggerAgentImpl::removeBreakpoint(const String16& breakpointId) {
 void V8DebuggerAgentImpl::removeBreakpointImpl(
     const String16& breakpointId,
     const std::vector<V8DebuggerScript*>& scripts) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::removeBreakpointImpl");
   DCHECK(enabled());
   BreakpointIdToDebuggerBreakpointIdsMap::iterator
       debuggerBreakpointIdsIterator =
@@ -764,6 +801,9 @@ Response V8DebuggerAgentImpl::getPossibleBreakpoints(
     Maybe<protocol::Debugger::Location> end, Maybe<bool> restrictToFunction,
     std::unique_ptr<protocol::Array<protocol::Debugger::BreakLocation>>*
         locations) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::getPossibleBreakpoints");
   String16 scriptId = start->getScriptId();
 
   if (start->getLineNumber() < 0 || start->getColumnNumber(0) < 0)
@@ -827,6 +867,9 @@ Response V8DebuggerAgentImpl::getPossibleBreakpoints(
 Response V8DebuggerAgentImpl::continueToLocation(
     std::unique_ptr<protocol::Debugger::Location> location,
     Maybe<String16> targetCallFrames) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::continueToLocation");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
   ScriptsMap::iterator it = m_scripts.find(location->getScriptId());
@@ -849,6 +892,9 @@ Response V8DebuggerAgentImpl::continueToLocation(
 Response V8DebuggerAgentImpl::getStackTrace(
     std::unique_ptr<protocol::Runtime::StackTraceId> inStackTraceId,
     std::unique_ptr<protocol::Runtime::StackTrace>* outStackTrace) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::getStackTrace");
   bool isOk = false;
   int64_t id = inStackTraceId->getId().toInteger64(&isOk);
   if (!isOk) return Response::ServerError("Invalid stack trace id");
@@ -946,6 +992,9 @@ V8DebuggerAgentImpl::setBreakpointImpl(const String16& breakpointId,
                                        const String16& scriptId,
                                        const String16& condition,
                                        int lineNumber, int columnNumber) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setBreakpointImpl");
   v8::HandleScope handles(m_isolate);
   DCHECK(enabled());
 
@@ -980,6 +1029,9 @@ V8DebuggerAgentImpl::setBreakpointImpl(const String16& breakpointId,
 void V8DebuggerAgentImpl::setBreakpointImpl(const String16& breakpointId,
                                             v8::Local<v8::Function> function,
                                             v8::Local<v8::String> condition) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setBreakpointImpl");
   v8::debug::BreakpointId debuggerBreakpointId;
   if (!v8::debug::SetFunctionBreakpoint(function, condition,
                                         &debuggerBreakpointId)) {
@@ -994,6 +1046,9 @@ Response V8DebuggerAgentImpl::searchInContent(
     const String16& scriptId, const String16& query,
     Maybe<bool> optionalCaseSensitive, Maybe<bool> optionalIsRegex,
     std::unique_ptr<Array<protocol::Debugger::SearchMatch>>* results) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::searchInContent");
   v8::HandleScope handles(m_isolate);
   ScriptsMap::iterator it = m_scripts.find(scriptId);
   if (it == m_scripts.end())
@@ -1031,6 +1086,9 @@ Response V8DebuggerAgentImpl::setScriptSource(
     Maybe<protocol::Runtime::StackTrace>* asyncStackTrace,
     Maybe<protocol::Runtime::StackTraceId>* asyncStackTraceId, String16* status,
     Maybe<protocol::Runtime::ExceptionDetails>* optOutCompileError) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setScriptSource");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
 
   ScriptsMap::iterator it = m_scripts.find(scriptId);
@@ -1081,6 +1139,9 @@ Response V8DebuggerAgentImpl::restartFrame(
     std::unique_ptr<Array<CallFrame>>* newCallFrames,
     Maybe<protocol::Runtime::StackTrace>* asyncStackTrace,
     Maybe<protocol::Runtime::StackTraceId>* asyncStackTraceId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::restartFrame");
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
   if (!mode.isJust()) {
     return Response::ServerError(
@@ -1106,6 +1167,9 @@ Response V8DebuggerAgentImpl::restartFrame(
 Response V8DebuggerAgentImpl::getScriptSource(
     const String16& scriptId, String16* scriptSource,
     Maybe<protocol::Binary>* bytecode) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::getScriptSource");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   ScriptsMap::iterator it = m_scripts.find(scriptId);
   if (it == m_scripts.end()) {
@@ -1203,6 +1267,9 @@ Response V8DebuggerAgentImpl::disassembleWasmModule(
     int* out_totalNumberOfLines,
     std::unique_ptr<protocol::Array<int>>* out_functionBodyOffsets,
     std::unique_ptr<protocol::Debugger::WasmDisassemblyChunk>* out_chunk) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::disassembleWasmModule");
 #if V8_ENABLE_WEBASSEMBLY
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   ScriptsMap::iterator it = m_scripts.find(in_scriptId);
@@ -1244,6 +1311,9 @@ Response V8DebuggerAgentImpl::disassembleWasmModule(
 Response V8DebuggerAgentImpl::nextWasmDisassemblyChunk(
     const String16& in_streamId,
     std::unique_ptr<protocol::Debugger::WasmDisassemblyChunk>* out_chunk) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::nextWasmDisassemblyChunk");
 #if V8_ENABLE_WEBASSEMBLY
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   auto it = m_wasmDisassemblies.find(in_streamId);
@@ -1275,6 +1345,9 @@ Response V8DebuggerAgentImpl::nextWasmDisassemblyChunk(
 
 Response V8DebuggerAgentImpl::getWasmBytecode(const String16& scriptId,
                                               protocol::Binary* bytecode) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::getWasmBytecode");
 #if V8_ENABLE_WEBASSEMBLY
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   ScriptsMap::iterator it = m_scripts.find(scriptId);
@@ -1297,15 +1370,24 @@ Response V8DebuggerAgentImpl::getWasmBytecode(const String16& scriptId,
 void V8DebuggerAgentImpl::pushBreakDetails(
     const String16& breakReason,
     std::unique_ptr<protocol::DictionaryValue> breakAuxData) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::pushBreakDetails");
   m_breakReason.push_back(std::make_pair(breakReason, std::move(breakAuxData)));
 }
 
 void V8DebuggerAgentImpl::popBreakDetails() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::popBreakDetails");
   if (m_breakReason.empty()) return;
   m_breakReason.pop_back();
 }
 
 void V8DebuggerAgentImpl::clearBreakDetails() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::clearBreakDetails");
   std::vector<BreakReason> emptyBreakReason;
   m_breakReason.swap(emptyBreakReason);
 }
@@ -1313,6 +1395,9 @@ void V8DebuggerAgentImpl::clearBreakDetails() {
 void V8DebuggerAgentImpl::schedulePauseOnNextStatement(
     const String16& breakReason,
     std::unique_ptr<protocol::DictionaryValue> data) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::schedulePauseOnNextStatement");
   if (isPaused() || !acceptsPause(false) || !m_breakpointsActive) return;
   if (m_breakReason.empty()) {
     m_debugger->setPauseOnNextCall(true, m_session->contextGroupId());
@@ -1321,6 +1406,9 @@ void V8DebuggerAgentImpl::schedulePauseOnNextStatement(
 }
 
 void V8DebuggerAgentImpl::cancelPauseOnNextStatement() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::cancelPauseOnNextStatement");
   if (isPaused() || !acceptsPause(false) || !m_breakpointsActive) return;
   if (m_breakReason.size() == 1) {
     m_debugger->setPauseOnNextCall(false, m_session->contextGroupId());
@@ -1329,6 +1417,9 @@ void V8DebuggerAgentImpl::cancelPauseOnNextStatement() {
 }
 
 Response V8DebuggerAgentImpl::pause() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::pause");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   if (isPaused()) return Response::Success();
 
@@ -1343,6 +1434,9 @@ Response V8DebuggerAgentImpl::pause() {
 }
 
 Response V8DebuggerAgentImpl::resume(Maybe<bool> terminateOnResume) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::resume");
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
   m_session->releaseObjectGroup(kBacktraceObjectGroup);
   m_debugger->continueProgram(m_session->contextGroupId(),
@@ -1352,6 +1446,9 @@ Response V8DebuggerAgentImpl::resume(Maybe<bool> terminateOnResume) {
 
 Response V8DebuggerAgentImpl::stepOver(
     Maybe<protocol::Array<protocol::Debugger::LocationRange>> inSkipList) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::stepOver");
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
 
   if (inSkipList.isJust()) {
@@ -1369,6 +1466,9 @@ Response V8DebuggerAgentImpl::stepOver(
 Response V8DebuggerAgentImpl::stepInto(
     Maybe<bool> inBreakOnAsyncCall,
     Maybe<protocol::Array<protocol::Debugger::LocationRange>> inSkipList) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::stepInto");
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
 
   if (inSkipList.isJust()) {
@@ -1385,6 +1485,9 @@ Response V8DebuggerAgentImpl::stepInto(
 }
 
 Response V8DebuggerAgentImpl::stepOut() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::stepOut");
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
   m_session->releaseObjectGroup(kBacktraceObjectGroup);
   m_debugger->stepOutOfFunction(m_session->contextGroupId());
@@ -1393,12 +1496,18 @@ Response V8DebuggerAgentImpl::stepOut() {
 
 Response V8DebuggerAgentImpl::pauseOnAsyncCall(
     std::unique_ptr<protocol::Runtime::StackTraceId> inParentStackTraceId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::pauseOnAsyncCall");
   // Deprecated, just return OK.
   return Response::Success();
 }
 
 Response V8DebuggerAgentImpl::setPauseOnExceptions(
     const String16& stringPauseState) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setPauseOnExceptions");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   v8::debug::ExceptionBreakState pauseState;
   if (stringPauseState == "none") {
@@ -1416,6 +1525,9 @@ Response V8DebuggerAgentImpl::setPauseOnExceptions(
 }
 
 void V8DebuggerAgentImpl::setPauseOnExceptionsImpl(int pauseState) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setPauseOnExceptionsImpl");
   // TODO(dgozman): this changes the global state and forces all context groups
   // to pause. We should make this flag be per-context-group.
   m_debugger->setPauseOnExceptionsState(
@@ -1430,6 +1542,9 @@ Response V8DebuggerAgentImpl::evaluateOnCallFrame(
     Maybe<bool> throwOnSideEffect, Maybe<double> timeout,
     std::unique_ptr<RemoteObject>* result,
     Maybe<protocol::Runtime::ExceptionDetails>* exceptionDetails) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::evaluateOnCallFrame");
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
   InjectedScript::CallFrameScope scope(m_session, callFrameId);
   Response response = scope.initialize();
@@ -1469,6 +1584,9 @@ Response V8DebuggerAgentImpl::evaluateOnCallFrame(
 //   -> https://linear.app/replay/issue/RUN-1061#comment-fc1c3ee4
 v8::MaybeLocal<v8::Value> V8DebuggerAgentImpl::getArgumentsOfCallFrame(
     const String16& callFrameId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::getArgumentsOfCallFrame");
   InjectedScript::CallFrameScope scope(m_session, callFrameId);
   Response response = scope.initialize();
   if (!response.IsSuccess()) {
@@ -1494,6 +1612,9 @@ Response V8DebuggerAgentImpl::setVariableValue(
     int scopeNumber, const String16& variableName,
     std::unique_ptr<protocol::Runtime::CallArgument> newValueArgument,
     const String16& callFrameId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setVariableValue");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
   InjectedScript::CallFrameScope scope(m_session, callFrameId);
@@ -1528,6 +1649,9 @@ Response V8DebuggerAgentImpl::setVariableValue(
 
 Response V8DebuggerAgentImpl::setReturnValue(
     std::unique_ptr<protocol::Runtime::CallArgument> protocolNewValue) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setReturnValue");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
   v8::HandleScope handleScope(m_isolate);
@@ -1551,6 +1675,9 @@ Response V8DebuggerAgentImpl::setReturnValue(
 }
 
 Response V8DebuggerAgentImpl::setAsyncCallStackDepth(int depth) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setAsyncCallStackDepth");
   if (!enabled() && !m_session->runtimeAgent()->enabled()) {
     return Response::ServerError(kDebuggerNotEnabled);
   }
@@ -1561,6 +1688,9 @@ Response V8DebuggerAgentImpl::setAsyncCallStackDepth(int depth) {
 
 Response V8DebuggerAgentImpl::setBlackboxPatterns(
     std::unique_ptr<protocol::Array<String16>> patterns) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setBlackboxPatterns");
   if (patterns->empty()) {
     m_blackboxPattern = nullptr;
     resetBlackboxedStateCache();
@@ -1585,6 +1715,9 @@ Response V8DebuggerAgentImpl::setBlackboxPatterns(
 }
 
 Response V8DebuggerAgentImpl::setBlackboxPattern(const String16& pattern) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setBlackboxPattern");
   std::unique_ptr<V8Regex> regex(new V8Regex(
       m_inspector, pattern, true /** caseSensitive */, false /** multiline */));
   if (!regex->isValid())
@@ -1595,6 +1728,9 @@ Response V8DebuggerAgentImpl::setBlackboxPattern(const String16& pattern) {
 }
 
 void V8DebuggerAgentImpl::resetBlackboxedStateCache() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::resetBlackboxedStateCache");
   for (const auto& it : m_scripts) {
     it.second->resetBlackboxedStateCache();
   }
@@ -1604,6 +1740,9 @@ Response V8DebuggerAgentImpl::setBlackboxedRanges(
     const String16& scriptId,
     std::unique_ptr<protocol::Array<protocol::Debugger::ScriptPosition>>
         inPositions) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setBlackboxedRanges");
   auto it = m_scripts.find(scriptId);
   if (it == m_scripts.end())
     return Response::ServerError("No script with passed id.");
@@ -1636,11 +1775,17 @@ Response V8DebuggerAgentImpl::getCallFrames(
     Maybe<int> maxFrames, Maybe<bool> noContents,
     Maybe<String16> objectGroup,
     std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>* out_callFrames) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::getCallFrames");
   return currentCallFrames(std::move(maxFrames), std::move(noContents),
                            std::move(objectGroup), out_callFrames);
 }
 
 Response V8DebuggerAgentImpl::getTopFrameLocation(Maybe<protocol::Debugger::Location>* out_location) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::getTopFrameLocation");
   if (!isPaused()) {
     return Response::Success();
   }
@@ -1667,6 +1812,9 @@ extern "C" void V8RecordReplayGetCurrentException(v8::MaybeLocal<v8::Value>* exc
 
 Response V8DebuggerAgentImpl::getPendingException(
     Maybe<String16> objectGroup, Maybe<RemoteObject>* out_exception) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::getPendingException");
   v8::MaybeLocal<v8::Value> maybe_exception;
   V8RecordReplayGetCurrentException(&maybe_exception);
 
@@ -1686,6 +1834,9 @@ Response V8DebuggerAgentImpl::currentCallFrames(
     Maybe<int> maxFrames, Maybe<bool> noContentsRaw,
     Maybe<String16> objectGroup,
     std::unique_ptr<Array<CallFrame>>* result) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::currentCallFrames");
   if (!isPaused()) {
     *result = std::make_unique<Array<CallFrame>>();
     return Response::Success();
@@ -1779,6 +1930,9 @@ Response V8DebuggerAgentImpl::currentCallFrames(
 
 std::unique_ptr<protocol::Runtime::StackTrace>
 V8DebuggerAgentImpl::currentAsyncStackTrace() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::currentAsyncStackTrace");
   std::shared_ptr<AsyncStackTrace> asyncParent =
       m_debugger->currentAsyncParent();
   if (!asyncParent) return nullptr;
@@ -1788,6 +1942,9 @@ V8DebuggerAgentImpl::currentAsyncStackTrace() {
 
 std::unique_ptr<protocol::Runtime::StackTraceId>
 V8DebuggerAgentImpl::currentExternalStackTrace() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::currentExternalStackTrace");
   V8StackTraceId externalParent = m_debugger->currentExternalParent();
   if (externalParent.IsInvalid()) return nullptr;
   return protocol::Runtime::StackTraceId::create()
@@ -1848,6 +2005,9 @@ static std::unique_ptr<protocol::Debugger::DebugSymbols> getDebugSymbols(
 
 void V8DebuggerAgentImpl::didParseSource(
     std::unique_ptr<V8DebuggerScript> script, bool success) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::didParseSource");
   v8::HandleScope handles(m_isolate);
   if (!success) {
     String16 scriptSource = script->source(0);
@@ -1985,6 +2145,9 @@ void V8DebuggerAgentImpl::didParseSource(
 
 void V8DebuggerAgentImpl::setScriptInstrumentationBreakpointIfNeeded(
     V8DebuggerScript* scriptRef) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setScriptInstrumentationBreakpointIfNeeded");
   protocol::DictionaryValue* breakpoints =
       m_state->getObject(DebuggerAgentState::instrumentationBreakpoints);
   if (!breakpoints) return;
@@ -2012,6 +2175,9 @@ void V8DebuggerAgentImpl::setScriptInstrumentationBreakpointIfNeeded(
 
 void V8DebuggerAgentImpl::didPauseOnInstrumentation(
     v8::debug::BreakpointId instrumentationId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::didPauseOnInstrumentation");
   String16 breakReason = protocol::Debugger::Paused::ReasonEnum::Other;
   std::unique_ptr<protocol::DictionaryValue> breakAuxData;
 
@@ -2050,6 +2216,9 @@ void V8DebuggerAgentImpl::didPause(
     const std::vector<v8::debug::BreakpointId>& hitBreakpoints,
     v8::debug::ExceptionType exceptionType, bool isUncaught,
     v8::debug::BreakReasons breakReasons) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::didPause");
   v8::HandleScope handles(m_isolate);
 
   std::vector<BreakReason> hitReasons;
@@ -2156,6 +2325,9 @@ void V8DebuggerAgentImpl::didPause(
 }
 
 void V8DebuggerAgentImpl::didContinue() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::didContinue");
   m_frontend.resumed();
   m_frontend.flush();
 }
@@ -2163,6 +2335,9 @@ void V8DebuggerAgentImpl::didContinue() {
 void V8DebuggerAgentImpl::breakProgram(
     const String16& breakReason,
     std::unique_ptr<protocol::DictionaryValue> data) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::breakProgram");
   if (!enabled() || m_skipAllPauses || !m_debugger->canBreakProgram()) return;
   std::vector<BreakReason> currentScheduledReason;
   currentScheduledReason.swap(m_breakReason);
@@ -2186,6 +2361,9 @@ void V8DebuggerAgentImpl::breakProgram(
 void V8DebuggerAgentImpl::setBreakpointFor(v8::Local<v8::Function> function,
                                            v8::Local<v8::String> condition,
                                            BreakpointSource source) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::setBreakpointFor");
   String16 breakpointId = generateBreakpointId(
       source == DebugCommandBreakpointSource ? BreakpointType::kDebugCommand
                                              : BreakpointType::kMonitorCommand,
@@ -2199,6 +2377,9 @@ void V8DebuggerAgentImpl::setBreakpointFor(v8::Local<v8::Function> function,
 
 void V8DebuggerAgentImpl::removeBreakpointFor(v8::Local<v8::Function> function,
                                               BreakpointSource source) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::removeBreakpointFor");
   String16 breakpointId = generateBreakpointId(
       source == DebugCommandBreakpointSource ? BreakpointType::kDebugCommand
                                              : BreakpointType::kMonitorCommand,
@@ -2208,6 +2389,9 @@ void V8DebuggerAgentImpl::removeBreakpointFor(v8::Local<v8::Function> function,
 }
 
 void V8DebuggerAgentImpl::reset() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::reset");
   if (!enabled()) return;
   m_blackboxedPositions.clear();
   resetBlackboxedStateCache();
@@ -2219,6 +2403,9 @@ void V8DebuggerAgentImpl::reset() {
 }
 
 void V8DebuggerAgentImpl::ScriptCollected(const V8DebuggerScript* script) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::ScriptCollected");
   DCHECK_NE(m_scripts.find(script->scriptId()), m_scripts.end());
   std::vector<uint8_t> bytecode;
 #if V8_ENABLE_WEBASSEMBLY
@@ -2244,6 +2431,9 @@ void V8DebuggerAgentImpl::ScriptCollected(const V8DebuggerScript* script) {
 
 Response V8DebuggerAgentImpl::processSkipList(
     protocol::Array<protocol::Debugger::LocationRange>* skipList) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::processSkipList");
   std::unordered_map<String16, std::vector<std::pair<int, int>>> skipListInit;
   for (std::unique_ptr<protocol::Debugger::LocationRange>& range : *skipList) {
     protocol::Debugger::ScriptPosition* start = range->getStart();
@@ -2279,6 +2469,9 @@ Response V8DebuggerAgentImpl::processSkipList(
 
 std::unique_ptr<protocol::Runtime::RemoteObject>
 V8DebuggerAgentImpl::wrapObject(int context_id, v8::Local<v8::Value> val) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8DebuggerAgentImpl::wrapObject");
   InjectedScript* injectedScript = nullptr;
   m_session->findInjectedScript(context_id, injectedScript);
 

--- a/src/inspector/v8-debugger-agent-impl.cc
+++ b/src/inspector/v8-debugger-agent-impl.cc
@@ -373,6 +373,7 @@ V8DebuggerAgentImpl::V8DebuggerAgentImpl(
       m_debugger(m_inspector->debugger()),
       m_session(session),
       m_enabled(false),
+      m_replay_owned(session->replayOwned()),
       m_state(state),
       m_frontend(frontendChannel),
       m_isolate(m_inspector->isolate()) {}

--- a/src/inspector/v8-debugger-agent-impl.cc
+++ b/src/inspector/v8-debugger-agent-impl.cc
@@ -382,9 +382,6 @@ V8DebuggerAgentImpl::V8DebuggerAgentImpl(
 V8DebuggerAgentImpl::~V8DebuggerAgentImpl() = default;
 
 void V8DebuggerAgentImpl::enableImpl() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::enableImpl");
   m_enabled = true;
   m_state->setBoolean(DebuggerAgentState::debuggerEnabled, true);
   m_debugger->enable();
@@ -407,9 +404,6 @@ void V8DebuggerAgentImpl::enableImpl() {
 
 Response V8DebuggerAgentImpl::enable(Maybe<double> maxScriptsCacheSize,
                                      String16* outDebuggerId) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::enable");
   m_maxScriptCacheSize = v8::base::saturated_cast<size_t>(
       maxScriptsCacheSize.fromMaybe(std::numeric_limits<double>::max()));
   *outDebuggerId =
@@ -424,9 +418,6 @@ Response V8DebuggerAgentImpl::enable(Maybe<double> maxScriptsCacheSize,
 }
 
 Response V8DebuggerAgentImpl::disable() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::disable");
   if (!enabled()) return Response::Success();
 
   m_state->remove(DebuggerAgentState::breakpointsByRegex);
@@ -499,9 +490,6 @@ void V8DebuggerAgentImpl::restore() {
 }
 
 Response V8DebuggerAgentImpl::setBreakpointsActive(bool active) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setBreakpointsActive");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   if (m_breakpointsActive == active) return Response::Success();
   m_breakpointsActive = active;
@@ -547,9 +535,6 @@ Response V8DebuggerAgentImpl::setBreakpointByUrl(
     Maybe<int> optionalColumnNumber, Maybe<String16> optionalCondition,
     String16* outBreakpointId,
     std::unique_ptr<protocol::Array<protocol::Debugger::Location>>* locations) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setBreakpointByUrl");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
 
   *locations = std::make_unique<Array<protocol::Debugger::Location>>();
@@ -638,9 +623,6 @@ Response V8DebuggerAgentImpl::setBreakpoint(
     std::unique_ptr<protocol::Debugger::Location> location,
     Maybe<String16> optionalCondition, String16* outBreakpointId,
     std::unique_ptr<protocol::Debugger::Location>* actualLocation) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setBreakpoint");
   String16 breakpointId = generateBreakpointId(
       BreakpointType::kByScriptId, location->getScriptId(),
       location->getLineNumber(), location->getColumnNumber(0));
@@ -664,9 +646,6 @@ Response V8DebuggerAgentImpl::setBreakpoint(
 Response V8DebuggerAgentImpl::setBreakpointOnFunctionCall(
     const String16& functionObjectId, Maybe<String16> optionalCondition,
     String16* outBreakpointId) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setBreakpointOnFunctionCall");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
 
   InjectedScript::ObjectScope scope(m_session, functionObjectId);
@@ -693,9 +672,6 @@ Response V8DebuggerAgentImpl::setBreakpointOnFunctionCall(
 
 Response V8DebuggerAgentImpl::setInstrumentationBreakpoint(
     const String16& instrumentation, String16* outBreakpointId) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setInstrumentationBreakpoint");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   String16 breakpointId = generateInstrumentationBreakpointId(instrumentation);
   protocol::DictionaryValue* breakpoints = getOrCreateObject(
@@ -710,9 +686,6 @@ Response V8DebuggerAgentImpl::setInstrumentationBreakpoint(
 }
 
 Response V8DebuggerAgentImpl::removeBreakpoint(const String16& breakpointId) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::removeBreakpoint");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   BreakpointType type;
   String16 selector;
@@ -773,9 +746,6 @@ Response V8DebuggerAgentImpl::removeBreakpoint(const String16& breakpointId) {
 void V8DebuggerAgentImpl::removeBreakpointImpl(
     const String16& breakpointId,
     const std::vector<V8DebuggerScript*>& scripts) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::removeBreakpointImpl");
   DCHECK(enabled());
   BreakpointIdToDebuggerBreakpointIdsMap::iterator
       debuggerBreakpointIdsIterator =
@@ -801,9 +771,6 @@ Response V8DebuggerAgentImpl::getPossibleBreakpoints(
     Maybe<protocol::Debugger::Location> end, Maybe<bool> restrictToFunction,
     std::unique_ptr<protocol::Array<protocol::Debugger::BreakLocation>>*
         locations) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::getPossibleBreakpoints");
   String16 scriptId = start->getScriptId();
 
   if (start->getLineNumber() < 0 || start->getColumnNumber(0) < 0)
@@ -867,9 +834,6 @@ Response V8DebuggerAgentImpl::getPossibleBreakpoints(
 Response V8DebuggerAgentImpl::continueToLocation(
     std::unique_ptr<protocol::Debugger::Location> location,
     Maybe<String16> targetCallFrames) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::continueToLocation");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
   ScriptsMap::iterator it = m_scripts.find(location->getScriptId());
@@ -892,9 +856,6 @@ Response V8DebuggerAgentImpl::continueToLocation(
 Response V8DebuggerAgentImpl::getStackTrace(
     std::unique_ptr<protocol::Runtime::StackTraceId> inStackTraceId,
     std::unique_ptr<protocol::Runtime::StackTrace>* outStackTrace) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::getStackTrace");
   bool isOk = false;
   int64_t id = inStackTraceId->getId().toInteger64(&isOk);
   if (!isOk) return Response::ServerError("Invalid stack trace id");
@@ -992,9 +953,6 @@ V8DebuggerAgentImpl::setBreakpointImpl(const String16& breakpointId,
                                        const String16& scriptId,
                                        const String16& condition,
                                        int lineNumber, int columnNumber) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setBreakpointImpl");
   v8::HandleScope handles(m_isolate);
   DCHECK(enabled());
 
@@ -1029,9 +987,6 @@ V8DebuggerAgentImpl::setBreakpointImpl(const String16& breakpointId,
 void V8DebuggerAgentImpl::setBreakpointImpl(const String16& breakpointId,
                                             v8::Local<v8::Function> function,
                                             v8::Local<v8::String> condition) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setBreakpointImpl");
   v8::debug::BreakpointId debuggerBreakpointId;
   if (!v8::debug::SetFunctionBreakpoint(function, condition,
                                         &debuggerBreakpointId)) {
@@ -1046,9 +1001,6 @@ Response V8DebuggerAgentImpl::searchInContent(
     const String16& scriptId, const String16& query,
     Maybe<bool> optionalCaseSensitive, Maybe<bool> optionalIsRegex,
     std::unique_ptr<Array<protocol::Debugger::SearchMatch>>* results) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::searchInContent");
   v8::HandleScope handles(m_isolate);
   ScriptsMap::iterator it = m_scripts.find(scriptId);
   if (it == m_scripts.end())
@@ -1086,9 +1038,6 @@ Response V8DebuggerAgentImpl::setScriptSource(
     Maybe<protocol::Runtime::StackTrace>* asyncStackTrace,
     Maybe<protocol::Runtime::StackTraceId>* asyncStackTraceId, String16* status,
     Maybe<protocol::Runtime::ExceptionDetails>* optOutCompileError) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setScriptSource");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
 
   ScriptsMap::iterator it = m_scripts.find(scriptId);
@@ -1139,9 +1088,6 @@ Response V8DebuggerAgentImpl::restartFrame(
     std::unique_ptr<Array<CallFrame>>* newCallFrames,
     Maybe<protocol::Runtime::StackTrace>* asyncStackTrace,
     Maybe<protocol::Runtime::StackTraceId>* asyncStackTraceId) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::restartFrame");
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
   if (!mode.isJust()) {
     return Response::ServerError(
@@ -1167,9 +1113,6 @@ Response V8DebuggerAgentImpl::restartFrame(
 Response V8DebuggerAgentImpl::getScriptSource(
     const String16& scriptId, String16* scriptSource,
     Maybe<protocol::Binary>* bytecode) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::getScriptSource");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   ScriptsMap::iterator it = m_scripts.find(scriptId);
   if (it == m_scripts.end()) {
@@ -1267,9 +1210,6 @@ Response V8DebuggerAgentImpl::disassembleWasmModule(
     int* out_totalNumberOfLines,
     std::unique_ptr<protocol::Array<int>>* out_functionBodyOffsets,
     std::unique_ptr<protocol::Debugger::WasmDisassemblyChunk>* out_chunk) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::disassembleWasmModule");
 #if V8_ENABLE_WEBASSEMBLY
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   ScriptsMap::iterator it = m_scripts.find(in_scriptId);
@@ -1311,9 +1251,6 @@ Response V8DebuggerAgentImpl::disassembleWasmModule(
 Response V8DebuggerAgentImpl::nextWasmDisassemblyChunk(
     const String16& in_streamId,
     std::unique_ptr<protocol::Debugger::WasmDisassemblyChunk>* out_chunk) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::nextWasmDisassemblyChunk");
 #if V8_ENABLE_WEBASSEMBLY
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   auto it = m_wasmDisassemblies.find(in_streamId);
@@ -1345,9 +1282,6 @@ Response V8DebuggerAgentImpl::nextWasmDisassemblyChunk(
 
 Response V8DebuggerAgentImpl::getWasmBytecode(const String16& scriptId,
                                               protocol::Binary* bytecode) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::getWasmBytecode");
 #if V8_ENABLE_WEBASSEMBLY
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   ScriptsMap::iterator it = m_scripts.find(scriptId);
@@ -1370,24 +1304,15 @@ Response V8DebuggerAgentImpl::getWasmBytecode(const String16& scriptId,
 void V8DebuggerAgentImpl::pushBreakDetails(
     const String16& breakReason,
     std::unique_ptr<protocol::DictionaryValue> breakAuxData) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::pushBreakDetails");
   m_breakReason.push_back(std::make_pair(breakReason, std::move(breakAuxData)));
 }
 
 void V8DebuggerAgentImpl::popBreakDetails() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::popBreakDetails");
   if (m_breakReason.empty()) return;
   m_breakReason.pop_back();
 }
 
 void V8DebuggerAgentImpl::clearBreakDetails() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::clearBreakDetails");
   std::vector<BreakReason> emptyBreakReason;
   m_breakReason.swap(emptyBreakReason);
 }
@@ -1417,9 +1342,6 @@ void V8DebuggerAgentImpl::cancelPauseOnNextStatement() {
 }
 
 Response V8DebuggerAgentImpl::pause() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::pause");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   if (isPaused()) return Response::Success();
 
@@ -1466,9 +1388,6 @@ Response V8DebuggerAgentImpl::stepOver(
 Response V8DebuggerAgentImpl::stepInto(
     Maybe<bool> inBreakOnAsyncCall,
     Maybe<protocol::Array<protocol::Debugger::LocationRange>> inSkipList) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::stepInto");
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
 
   if (inSkipList.isJust()) {
@@ -1485,9 +1404,6 @@ Response V8DebuggerAgentImpl::stepInto(
 }
 
 Response V8DebuggerAgentImpl::stepOut() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::stepOut");
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
   m_session->releaseObjectGroup(kBacktraceObjectGroup);
   m_debugger->stepOutOfFunction(m_session->contextGroupId());
@@ -1496,18 +1412,12 @@ Response V8DebuggerAgentImpl::stepOut() {
 
 Response V8DebuggerAgentImpl::pauseOnAsyncCall(
     std::unique_ptr<protocol::Runtime::StackTraceId> inParentStackTraceId) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::pauseOnAsyncCall");
   // Deprecated, just return OK.
   return Response::Success();
 }
 
 Response V8DebuggerAgentImpl::setPauseOnExceptions(
     const String16& stringPauseState) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setPauseOnExceptions");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   v8::debug::ExceptionBreakState pauseState;
   if (stringPauseState == "none") {
@@ -1525,9 +1435,6 @@ Response V8DebuggerAgentImpl::setPauseOnExceptions(
 }
 
 void V8DebuggerAgentImpl::setPauseOnExceptionsImpl(int pauseState) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setPauseOnExceptionsImpl");
   // TODO(dgozman): this changes the global state and forces all context groups
   // to pause. We should make this flag be per-context-group.
   m_debugger->setPauseOnExceptionsState(
@@ -1542,9 +1449,6 @@ Response V8DebuggerAgentImpl::evaluateOnCallFrame(
     Maybe<bool> throwOnSideEffect, Maybe<double> timeout,
     std::unique_ptr<RemoteObject>* result,
     Maybe<protocol::Runtime::ExceptionDetails>* exceptionDetails) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::evaluateOnCallFrame");
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
   InjectedScript::CallFrameScope scope(m_session, callFrameId);
   Response response = scope.initialize();
@@ -1612,9 +1516,6 @@ Response V8DebuggerAgentImpl::setVariableValue(
     int scopeNumber, const String16& variableName,
     std::unique_ptr<protocol::Runtime::CallArgument> newValueArgument,
     const String16& callFrameId) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setVariableValue");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
   InjectedScript::CallFrameScope scope(m_session, callFrameId);
@@ -1649,9 +1550,6 @@ Response V8DebuggerAgentImpl::setVariableValue(
 
 Response V8DebuggerAgentImpl::setReturnValue(
     std::unique_ptr<protocol::Runtime::CallArgument> protocolNewValue) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setReturnValue");
   if (!enabled()) return Response::ServerError(kDebuggerNotEnabled);
   if (!isPaused()) return Response::ServerError(kDebuggerNotPaused);
   v8::HandleScope handleScope(m_isolate);
@@ -1675,9 +1573,6 @@ Response V8DebuggerAgentImpl::setReturnValue(
 }
 
 Response V8DebuggerAgentImpl::setAsyncCallStackDepth(int depth) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setAsyncCallStackDepth");
   if (!enabled() && !m_session->runtimeAgent()->enabled()) {
     return Response::ServerError(kDebuggerNotEnabled);
   }
@@ -1688,9 +1583,6 @@ Response V8DebuggerAgentImpl::setAsyncCallStackDepth(int depth) {
 
 Response V8DebuggerAgentImpl::setBlackboxPatterns(
     std::unique_ptr<protocol::Array<String16>> patterns) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setBlackboxPatterns");
   if (patterns->empty()) {
     m_blackboxPattern = nullptr;
     resetBlackboxedStateCache();
@@ -1715,9 +1607,6 @@ Response V8DebuggerAgentImpl::setBlackboxPatterns(
 }
 
 Response V8DebuggerAgentImpl::setBlackboxPattern(const String16& pattern) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setBlackboxPattern");
   std::unique_ptr<V8Regex> regex(new V8Regex(
       m_inspector, pattern, true /** caseSensitive */, false /** multiline */));
   if (!regex->isValid())
@@ -1728,9 +1617,6 @@ Response V8DebuggerAgentImpl::setBlackboxPattern(const String16& pattern) {
 }
 
 void V8DebuggerAgentImpl::resetBlackboxedStateCache() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::resetBlackboxedStateCache");
   for (const auto& it : m_scripts) {
     it.second->resetBlackboxedStateCache();
   }
@@ -1740,9 +1626,6 @@ Response V8DebuggerAgentImpl::setBlackboxedRanges(
     const String16& scriptId,
     std::unique_ptr<protocol::Array<protocol::Debugger::ScriptPosition>>
         inPositions) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setBlackboxedRanges");
   auto it = m_scripts.find(scriptId);
   if (it == m_scripts.end())
     return Response::ServerError("No script with passed id.");
@@ -1775,17 +1658,11 @@ Response V8DebuggerAgentImpl::getCallFrames(
     Maybe<int> maxFrames, Maybe<bool> noContents,
     Maybe<String16> objectGroup,
     std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>* out_callFrames) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::getCallFrames");
   return currentCallFrames(std::move(maxFrames), std::move(noContents),
                            std::move(objectGroup), out_callFrames);
 }
 
 Response V8DebuggerAgentImpl::getTopFrameLocation(Maybe<protocol::Debugger::Location>* out_location) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::getTopFrameLocation");
   if (!isPaused()) {
     return Response::Success();
   }
@@ -1812,9 +1689,6 @@ extern "C" void V8RecordReplayGetCurrentException(v8::MaybeLocal<v8::Value>* exc
 
 Response V8DebuggerAgentImpl::getPendingException(
     Maybe<String16> objectGroup, Maybe<RemoteObject>* out_exception) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::getPendingException");
   v8::MaybeLocal<v8::Value> maybe_exception;
   V8RecordReplayGetCurrentException(&maybe_exception);
 
@@ -1834,9 +1708,6 @@ Response V8DebuggerAgentImpl::currentCallFrames(
     Maybe<int> maxFrames, Maybe<bool> noContentsRaw,
     Maybe<String16> objectGroup,
     std::unique_ptr<Array<CallFrame>>* result) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::currentCallFrames");
   if (!isPaused()) {
     *result = std::make_unique<Array<CallFrame>>();
     return Response::Success();
@@ -1930,9 +1801,6 @@ Response V8DebuggerAgentImpl::currentCallFrames(
 
 std::unique_ptr<protocol::Runtime::StackTrace>
 V8DebuggerAgentImpl::currentAsyncStackTrace() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::currentAsyncStackTrace");
   std::shared_ptr<AsyncStackTrace> asyncParent =
       m_debugger->currentAsyncParent();
   if (!asyncParent) return nullptr;
@@ -1942,9 +1810,6 @@ V8DebuggerAgentImpl::currentAsyncStackTrace() {
 
 std::unique_ptr<protocol::Runtime::StackTraceId>
 V8DebuggerAgentImpl::currentExternalStackTrace() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::currentExternalStackTrace");
   V8StackTraceId externalParent = m_debugger->currentExternalParent();
   if (externalParent.IsInvalid()) return nullptr;
   return protocol::Runtime::StackTraceId::create()
@@ -2005,9 +1870,6 @@ static std::unique_ptr<protocol::Debugger::DebugSymbols> getDebugSymbols(
 
 void V8DebuggerAgentImpl::didParseSource(
     std::unique_ptr<V8DebuggerScript> script, bool success) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::didParseSource");
   v8::HandleScope handles(m_isolate);
   if (!success) {
     String16 scriptSource = script->source(0);
@@ -2145,9 +2007,6 @@ void V8DebuggerAgentImpl::didParseSource(
 
 void V8DebuggerAgentImpl::setScriptInstrumentationBreakpointIfNeeded(
     V8DebuggerScript* scriptRef) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setScriptInstrumentationBreakpointIfNeeded");
   protocol::DictionaryValue* breakpoints =
       m_state->getObject(DebuggerAgentState::instrumentationBreakpoints);
   if (!breakpoints) return;
@@ -2175,9 +2034,6 @@ void V8DebuggerAgentImpl::setScriptInstrumentationBreakpointIfNeeded(
 
 void V8DebuggerAgentImpl::didPauseOnInstrumentation(
     v8::debug::BreakpointId instrumentationId) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::didPauseOnInstrumentation");
   String16 breakReason = protocol::Debugger::Paused::ReasonEnum::Other;
   std::unique_ptr<protocol::DictionaryValue> breakAuxData;
 
@@ -2216,9 +2072,6 @@ void V8DebuggerAgentImpl::didPause(
     const std::vector<v8::debug::BreakpointId>& hitBreakpoints,
     v8::debug::ExceptionType exceptionType, bool isUncaught,
     v8::debug::BreakReasons breakReasons) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::didPause");
   v8::HandleScope handles(m_isolate);
 
   std::vector<BreakReason> hitReasons;
@@ -2325,9 +2178,6 @@ void V8DebuggerAgentImpl::didPause(
 }
 
 void V8DebuggerAgentImpl::didContinue() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::didContinue");
   m_frontend.resumed();
   m_frontend.flush();
 }
@@ -2361,9 +2211,6 @@ void V8DebuggerAgentImpl::breakProgram(
 void V8DebuggerAgentImpl::setBreakpointFor(v8::Local<v8::Function> function,
                                            v8::Local<v8::String> condition,
                                            BreakpointSource source) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::setBreakpointFor");
   String16 breakpointId = generateBreakpointId(
       source == DebugCommandBreakpointSource ? BreakpointType::kDebugCommand
                                              : BreakpointType::kMonitorCommand,
@@ -2377,9 +2224,6 @@ void V8DebuggerAgentImpl::setBreakpointFor(v8::Local<v8::Function> function,
 
 void V8DebuggerAgentImpl::removeBreakpointFor(v8::Local<v8::Function> function,
                                               BreakpointSource source) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::removeBreakpointFor");
   String16 breakpointId = generateBreakpointId(
       source == DebugCommandBreakpointSource ? BreakpointType::kDebugCommand
                                              : BreakpointType::kMonitorCommand,
@@ -2389,9 +2233,6 @@ void V8DebuggerAgentImpl::removeBreakpointFor(v8::Local<v8::Function> function,
 }
 
 void V8DebuggerAgentImpl::reset() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::reset");
   if (!enabled()) return;
   m_blackboxedPositions.clear();
   resetBlackboxedStateCache();
@@ -2431,9 +2272,6 @@ void V8DebuggerAgentImpl::ScriptCollected(const V8DebuggerScript* script) {
 
 Response V8DebuggerAgentImpl::processSkipList(
     protocol::Array<protocol::Debugger::LocationRange>* skipList) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::processSkipList");
   std::unordered_map<String16, std::vector<std::pair<int, int>>> skipListInit;
   for (std::unique_ptr<protocol::Debugger::LocationRange>& range : *skipList) {
     protocol::Debugger::ScriptPosition* start = range->getStart();
@@ -2469,9 +2307,6 @@ Response V8DebuggerAgentImpl::processSkipList(
 
 std::unique_ptr<protocol::Runtime::RemoteObject>
 V8DebuggerAgentImpl::wrapObject(int context_id, v8::Local<v8::Value> val) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8DebuggerAgentImpl::wrapObject");
   InjectedScript* injectedScript = nullptr;
   m_session->findInjectedScript(context_id, injectedScript);
 

--- a/src/inspector/v8-debugger-agent-impl.h
+++ b/src/inspector/v8-debugger-agent-impl.h
@@ -43,6 +43,7 @@ class V8DebuggerAgentImpl : public protocol::Debugger::Backend {
   V8DebuggerAgentImpl(const V8DebuggerAgentImpl&) = delete;
   V8DebuggerAgentImpl& operator=(const V8DebuggerAgentImpl&) = delete;
   void restore();
+  bool replayOwned() const { return m_replay_owned; }
 
   // Part of the protocol.
   Response enable(Maybe<double> maxScriptsCacheSize,
@@ -243,6 +244,7 @@ class V8DebuggerAgentImpl : public protocol::Debugger::Backend {
   V8Debugger* m_debugger;
   V8InspectorSessionImpl* m_session;
   bool m_enabled;
+  bool m_replay_owned;
   protocol::DictionaryValue* m_state;
   protocol::Debugger::Frontend m_frontend;
   v8::Isolate* m_isolate;

--- a/src/inspector/v8-heap-profiler-agent-impl.cc
+++ b/src/inspector/v8-heap-profiler-agent-impl.cc
@@ -188,6 +188,7 @@ V8HeapProfilerAgentImpl::V8HeapProfilerAgentImpl(
       m_frontend(frontendChannel),
       m_state(state),
       m_hasTimer(false),
+      m_replay_owned(session->replayOwned()),
       m_async_gc(std::make_shared<AsyncGC>()) {}
 
 V8HeapProfilerAgentImpl::~V8HeapProfilerAgentImpl() {

--- a/src/inspector/v8-heap-profiler-agent-impl.cc
+++ b/src/inspector/v8-heap-profiler-agent-impl.cc
@@ -228,8 +228,6 @@ void V8HeapProfilerAgentImpl::restore() {
 
 void V8HeapProfilerAgentImpl::collectGarbage(
     std::unique_ptr<CollectGarbageCallback> callback) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::collectGarbage");
   v8::base::MutexGuard lock(&m_async_gc->m_mutex);
   m_async_gc->m_pending_callbacks.push_back(std::move(callback));
   if (!m_async_gc->m_pending) {
@@ -241,9 +239,6 @@ void V8HeapProfilerAgentImpl::collectGarbage(
 
 Response V8HeapProfilerAgentImpl::startTrackingHeapObjects(
     Maybe<bool> trackAllocations) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate,
-      "V8HeapProfilerAgentImpl::startTrackingHeapObjects");
   m_state->setBoolean(HeapProfilerAgentState::heapObjectsTrackingEnabled, true);
   bool allocationTrackingEnabled = trackAllocations.fromMaybe(false);
   m_state->setBoolean(HeapProfilerAgentState::allocationTrackingEnabled,
@@ -255,9 +250,6 @@ Response V8HeapProfilerAgentImpl::startTrackingHeapObjects(
 Response V8HeapProfilerAgentImpl::stopTrackingHeapObjects(
     Maybe<bool> reportProgress, Maybe<bool> treatGlobalObjectsAsRoots,
     Maybe<bool> captureNumericValue, Maybe<bool> exposeInternals) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate,
-      "V8HeapProfilerAgentImpl::stopTrackingHeapObjects");
   requestHeapStatsUpdate();
   takeHeapSnapshot(std::move(reportProgress),
                    std::move(treatGlobalObjectsAsRoots),
@@ -267,15 +259,11 @@ Response V8HeapProfilerAgentImpl::stopTrackingHeapObjects(
 }
 
 Response V8HeapProfilerAgentImpl::enable() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::enable");
   m_state->setBoolean(HeapProfilerAgentState::heapProfilerEnabled, true);
   return Response::Success();
 }
 
 Response V8HeapProfilerAgentImpl::disable() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::disable");
   stopTrackingHeapObjectsInternal();
   if (m_state->booleanProperty(
           HeapProfilerAgentState::samplingHeapProfilerEnabled, false)) {
@@ -290,8 +278,6 @@ Response V8HeapProfilerAgentImpl::disable() {
 Response V8HeapProfilerAgentImpl::takeHeapSnapshot(
     Maybe<bool> reportProgress, Maybe<bool> treatGlobalObjectsAsRoots,
     Maybe<bool> captureNumericValue, Maybe<bool> exposeInternals) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::takeHeapSnapshot");
   v8::HeapProfiler* profiler = m_isolate->GetHeapProfiler();
   if (!profiler) return Response::ServerError("Cannot access v8 heap profiler");
   std::unique_ptr<HeapSnapshotProgress> progress;
@@ -324,9 +310,6 @@ Response V8HeapProfilerAgentImpl::takeHeapSnapshot(
 Response V8HeapProfilerAgentImpl::getObjectByHeapObjectId(
     const String16& heapSnapshotObjectId, Maybe<String16> objectGroup,
     std::unique_ptr<protocol::Runtime::RemoteObject>* result) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate,
-      "V8HeapProfilerAgentImpl::getObjectByHeapObjectId");
   bool ok;
   int id = heapSnapshotObjectId.toInteger(&ok);
   if (!ok) return Response::ServerError("Invalid heap snapshot object id");
@@ -351,9 +334,6 @@ Response V8HeapProfilerAgentImpl::getObjectByHeapObjectId(
 
 Response V8HeapProfilerAgentImpl::addInspectedHeapObject(
     const String16& inspectedHeapObjectId) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate,
-      "V8HeapProfilerAgentImpl::addInspectedHeapObject");
   bool ok;
   int id = inspectedHeapObjectId.toInteger(&ok);
   if (!ok) return Response::ServerError("Invalid heap snapshot object id");
@@ -372,8 +352,6 @@ Response V8HeapProfilerAgentImpl::addInspectedHeapObject(
 
 Response V8HeapProfilerAgentImpl::getHeapObjectId(
     const String16& objectId, String16* heapSnapshotObjectId) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::getHeapObjectId");
   v8::HandleScope handles(m_isolate);
   v8::Local<v8::Value> value;
   v8::Local<v8::Context> context;
@@ -405,9 +383,6 @@ void V8HeapProfilerAgentImpl::onTimer(void* data) {
 
 void V8HeapProfilerAgentImpl::startTrackingHeapObjectsInternal(
     bool trackAllocations) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate,
-      "V8HeapProfilerAgentImpl::startTrackingHeapObjectsInternal");
   m_isolate->GetHeapProfiler()->StartTrackingHeapObjects(trackAllocations);
   if (!m_hasTimer) {
     m_hasTimer = true;
@@ -417,9 +392,6 @@ void V8HeapProfilerAgentImpl::startTrackingHeapObjectsInternal(
 }
 
 void V8HeapProfilerAgentImpl::stopTrackingHeapObjectsInternal() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate,
-      "V8HeapProfilerAgentImpl::stopTrackingHeapObjectsInternal");
   if (m_hasTimer) {
     m_session->inspector()->client()->cancelTimer(
         reinterpret_cast<void*>(this));
@@ -435,8 +407,6 @@ Response V8HeapProfilerAgentImpl::startSampling(
     Maybe<double> samplingInterval,
     Maybe<bool> includeObjectsCollectedByMajorGC,
     Maybe<bool> includeObjectsCollectedByMinorGC) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::startSampling");
   v8::HeapProfiler* profiler = m_isolate->GetHeapProfiler();
   if (!profiler) return Response::ServerError("Cannot access v8 heap profiler");
   const unsigned defaultSamplingInterval = 1 << 15;
@@ -495,8 +465,6 @@ buildSampingHeapProfileNode(v8::Isolate* isolate,
 
 Response V8HeapProfilerAgentImpl::stopSampling(
     std::unique_ptr<protocol::HeapProfiler::SamplingHeapProfile>* profile) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::stopSampling");
   Response result = getSamplingProfile(profile);
   if (result.IsSuccess()) {
     m_isolate->GetHeapProfiler()->StopSamplingHeapProfiler();
@@ -508,8 +476,6 @@ Response V8HeapProfilerAgentImpl::stopSampling(
 
 Response V8HeapProfilerAgentImpl::getSamplingProfile(
     std::unique_ptr<protocol::HeapProfiler::SamplingHeapProfile>* profile) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::getSamplingProfile");
   v8::HeapProfiler* profiler = m_isolate->GetHeapProfiler();
   // Need a scope as v8::AllocationProfile contains Local handles.
   v8::HandleScope scope(m_isolate);

--- a/src/inspector/v8-heap-profiler-agent-impl.cc
+++ b/src/inspector/v8-heap-profiler-agent-impl.cc
@@ -10,6 +10,7 @@
 #include "include/v8-profiler.h"
 #include "include/v8-version.h"
 #include "src/base/platform/mutex.h"
+#include "src/base/replayio.h"
 #include "src/inspector/injected-script.h"
 #include "src/inspector/inspected-context.h"
 #include "src/inspector/protocol/Protocol.h"
@@ -198,6 +199,8 @@ V8HeapProfilerAgentImpl::~V8HeapProfilerAgentImpl() {
 }
 
 void V8HeapProfilerAgentImpl::restore() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::restore");
   if (m_state->booleanProperty(HeapProfilerAgentState::heapProfilerEnabled,
                                false))
     m_frontend.resetProfiles();
@@ -225,6 +228,8 @@ void V8HeapProfilerAgentImpl::restore() {
 
 void V8HeapProfilerAgentImpl::collectGarbage(
     std::unique_ptr<CollectGarbageCallback> callback) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::collectGarbage");
   v8::base::MutexGuard lock(&m_async_gc->m_mutex);
   m_async_gc->m_pending_callbacks.push_back(std::move(callback));
   if (!m_async_gc->m_pending) {
@@ -236,6 +241,9 @@ void V8HeapProfilerAgentImpl::collectGarbage(
 
 Response V8HeapProfilerAgentImpl::startTrackingHeapObjects(
     Maybe<bool> trackAllocations) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate,
+      "V8HeapProfilerAgentImpl::startTrackingHeapObjects");
   m_state->setBoolean(HeapProfilerAgentState::heapObjectsTrackingEnabled, true);
   bool allocationTrackingEnabled = trackAllocations.fromMaybe(false);
   m_state->setBoolean(HeapProfilerAgentState::allocationTrackingEnabled,
@@ -247,6 +255,9 @@ Response V8HeapProfilerAgentImpl::startTrackingHeapObjects(
 Response V8HeapProfilerAgentImpl::stopTrackingHeapObjects(
     Maybe<bool> reportProgress, Maybe<bool> treatGlobalObjectsAsRoots,
     Maybe<bool> captureNumericValue, Maybe<bool> exposeInternals) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate,
+      "V8HeapProfilerAgentImpl::stopTrackingHeapObjects");
   requestHeapStatsUpdate();
   takeHeapSnapshot(std::move(reportProgress),
                    std::move(treatGlobalObjectsAsRoots),
@@ -256,11 +267,15 @@ Response V8HeapProfilerAgentImpl::stopTrackingHeapObjects(
 }
 
 Response V8HeapProfilerAgentImpl::enable() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::enable");
   m_state->setBoolean(HeapProfilerAgentState::heapProfilerEnabled, true);
   return Response::Success();
 }
 
 Response V8HeapProfilerAgentImpl::disable() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::disable");
   stopTrackingHeapObjectsInternal();
   if (m_state->booleanProperty(
           HeapProfilerAgentState::samplingHeapProfilerEnabled, false)) {
@@ -275,6 +290,8 @@ Response V8HeapProfilerAgentImpl::disable() {
 Response V8HeapProfilerAgentImpl::takeHeapSnapshot(
     Maybe<bool> reportProgress, Maybe<bool> treatGlobalObjectsAsRoots,
     Maybe<bool> captureNumericValue, Maybe<bool> exposeInternals) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::takeHeapSnapshot");
   v8::HeapProfiler* profiler = m_isolate->GetHeapProfiler();
   if (!profiler) return Response::ServerError("Cannot access v8 heap profiler");
   std::unique_ptr<HeapSnapshotProgress> progress;
@@ -307,6 +324,9 @@ Response V8HeapProfilerAgentImpl::takeHeapSnapshot(
 Response V8HeapProfilerAgentImpl::getObjectByHeapObjectId(
     const String16& heapSnapshotObjectId, Maybe<String16> objectGroup,
     std::unique_ptr<protocol::Runtime::RemoteObject>* result) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate,
+      "V8HeapProfilerAgentImpl::getObjectByHeapObjectId");
   bool ok;
   int id = heapSnapshotObjectId.toInteger(&ok);
   if (!ok) return Response::ServerError("Invalid heap snapshot object id");
@@ -331,6 +351,9 @@ Response V8HeapProfilerAgentImpl::getObjectByHeapObjectId(
 
 Response V8HeapProfilerAgentImpl::addInspectedHeapObject(
     const String16& inspectedHeapObjectId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate,
+      "V8HeapProfilerAgentImpl::addInspectedHeapObject");
   bool ok;
   int id = inspectedHeapObjectId.toInteger(&ok);
   if (!ok) return Response::ServerError("Invalid heap snapshot object id");
@@ -349,6 +372,8 @@ Response V8HeapProfilerAgentImpl::addInspectedHeapObject(
 
 Response V8HeapProfilerAgentImpl::getHeapObjectId(
     const String16& objectId, String16* heapSnapshotObjectId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::getHeapObjectId");
   v8::HandleScope handles(m_isolate);
   v8::Local<v8::Value> value;
   v8::Local<v8::Context> context;
@@ -363,6 +388,9 @@ Response V8HeapProfilerAgentImpl::getHeapObjectId(
 }
 
 void V8HeapProfilerAgentImpl::requestHeapStatsUpdate() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate,
+      "V8HeapProfilerAgentImpl::requestHeapStatsUpdate");
   HeapStatsStream stream(&m_frontend);
   v8::SnapshotObjectId lastSeenObjectId =
       m_isolate->GetHeapProfiler()->GetHeapStats(&stream);
@@ -377,6 +405,9 @@ void V8HeapProfilerAgentImpl::onTimer(void* data) {
 
 void V8HeapProfilerAgentImpl::startTrackingHeapObjectsInternal(
     bool trackAllocations) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate,
+      "V8HeapProfilerAgentImpl::startTrackingHeapObjectsInternal");
   m_isolate->GetHeapProfiler()->StartTrackingHeapObjects(trackAllocations);
   if (!m_hasTimer) {
     m_hasTimer = true;
@@ -386,6 +417,9 @@ void V8HeapProfilerAgentImpl::startTrackingHeapObjectsInternal(
 }
 
 void V8HeapProfilerAgentImpl::stopTrackingHeapObjectsInternal() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate,
+      "V8HeapProfilerAgentImpl::stopTrackingHeapObjectsInternal");
   if (m_hasTimer) {
     m_session->inspector()->client()->cancelTimer(
         reinterpret_cast<void*>(this));
@@ -401,6 +435,8 @@ Response V8HeapProfilerAgentImpl::startSampling(
     Maybe<double> samplingInterval,
     Maybe<bool> includeObjectsCollectedByMajorGC,
     Maybe<bool> includeObjectsCollectedByMinorGC) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::startSampling");
   v8::HeapProfiler* profiler = m_isolate->GetHeapProfiler();
   if (!profiler) return Response::ServerError("Cannot access v8 heap profiler");
   const unsigned defaultSamplingInterval = 1 << 15;
@@ -459,6 +495,8 @@ buildSampingHeapProfileNode(v8::Isolate* isolate,
 
 Response V8HeapProfilerAgentImpl::stopSampling(
     std::unique_ptr<protocol::HeapProfiler::SamplingHeapProfile>* profile) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::stopSampling");
   Response result = getSamplingProfile(profile);
   if (result.IsSuccess()) {
     m_isolate->GetHeapProfiler()->StopSamplingHeapProfiler();
@@ -470,6 +508,8 @@ Response V8HeapProfilerAgentImpl::stopSampling(
 
 Response V8HeapProfilerAgentImpl::getSamplingProfile(
     std::unique_ptr<protocol::HeapProfiler::SamplingHeapProfile>* profile) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8HeapProfilerAgentImpl::getSamplingProfile");
   v8::HeapProfiler* profiler = m_isolate->GetHeapProfiler();
   // Need a scope as v8::AllocationProfile contains Local handles.
   v8::HandleScope scope(m_isolate);

--- a/src/inspector/v8-heap-profiler-agent-impl.h
+++ b/src/inspector/v8-heap-profiler-agent-impl.h
@@ -30,6 +30,7 @@ class V8HeapProfilerAgentImpl : public protocol::HeapProfiler::Backend {
   V8HeapProfilerAgentImpl(const V8HeapProfilerAgentImpl&) = delete;
   V8HeapProfilerAgentImpl& operator=(const V8HeapProfilerAgentImpl&) = delete;
   void restore();
+  bool replayOwned() const { return m_replay_owned; }
 
   void collectGarbage(
       std::unique_ptr<CollectGarbageCallback> callback) override;
@@ -78,6 +79,7 @@ class V8HeapProfilerAgentImpl : public protocol::HeapProfiler::Backend {
   protocol::HeapProfiler::Frontend m_frontend;
   protocol::DictionaryValue* m_state;
   bool m_hasTimer;
+  bool m_replay_owned;
   std::shared_ptr<AsyncGC> m_async_gc;
 };
 

--- a/src/inspector/v8-inspector-impl.cc
+++ b/src/inspector/v8-inspector-impl.cc
@@ -460,13 +460,13 @@ void V8InspectorImpl::forEachSession(
   for (auto& sessionId : ids) {
     using v8::recordreplay;
     V8InspectorSessionImpl* session = sessionById(contextGroupId, sessionId);
-    // Skip assert for ReplaySession: its presence in m_sessions is an allowed
-    // divergence. Do not RAII the whole session callback.
-    if (!session || !session->replayOwned()) {
-      REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
-          "V8InspectorImpl::forEachSession sessionId=%d hasGroup=%d", sessionId,
-          m_sessions.find(contextGroupId) != m_sessions.end());
-    }
+    const bool replay_owned = session && session->replayOwned();
+    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+    v8::replayio::AutoMaybeDisallowEvents disallow(
+        replay_owned, m_isolate, "V8InspectorImpl::forEachSession");
+    REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
+        "V8InspectorImpl::forEachSession sessionId=%d hasGroup=%d", sessionId,
+        m_sessions.find(contextGroupId) != m_sessions.end());
     if (session) callback(session);
   }
 }

--- a/src/inspector/v8-inspector-impl.cc
+++ b/src/inspector/v8-inspector-impl.cc
@@ -453,7 +453,6 @@ void V8InspectorImpl::forEachContext(
 void V8InspectorImpl::forEachSession(
     int contextGroupId,
     const std::function<void(V8InspectorSessionImpl*)>& callback) {
-  using v8::recordreplay;
   auto it = m_sessions.find(contextGroupId);
   if (it == m_sessions.end()) return;
   std::vector<int> ids;
@@ -462,13 +461,17 @@ void V8InspectorImpl::forEachSession(
 
   // Retrieve by ids each time since |callback| may destroy some contexts.
   for (auto& sessionId : ids) {
-    it = m_sessions.find(contextGroupId);
-    int hasGroup = it != m_sessions.end();
+    using v8::recordreplay;
+    V8InspectorSessionImpl* session = sessionById(contextGroupId, sessionId);
+    const bool replay_owned = session && session->replayOwned();
+    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
+    v8::replayio::AutoMaybeDisallowEvents disallow(
+        replay_owned, m_isolate, "V8InspectorImpl::forEachSession");
     REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
-        "V8InspectorImpl::forEachSession %d %d", sessionId, hasGroup);
-    if (it == m_sessions.end()) continue;
-    auto sessionIt = it->second.find(sessionId);
-    if (sessionIt != it->second.end()) callback(sessionIt->second);
+        "V8InspectorImpl::forEachSession sessionId=%d hasGroup=%d",
+        sessionId,
+        m_sessions.find(contextGroupId) != m_sessions.end());
+    if (session) callback(session);
   }
 }
 

--- a/src/inspector/v8-inspector-impl.cc
+++ b/src/inspector/v8-inspector-impl.cc
@@ -281,9 +281,6 @@ void V8InspectorImpl::resetContextGroup(int contextGroupId) {
   v8::replayio::AutoMaybeDisallowEvents disallow(
       replay_owned, m_isolate, "V8InspectorImpl::resetContextGroup");
   auto contextsIt = m_contexts.find(contextGroupId);
-  REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
-      "V8InspectorImpl::resetContextGroup consoleStorage %d",
-      hasConsoleMessageStorage(contextGroupId));
   m_consoleStorageMap.erase(contextGroupId);
   m_muteExceptionsMap.erase(contextGroupId);
   // Context might have been removed already by discardContextScript()
@@ -463,14 +460,13 @@ void V8InspectorImpl::forEachSession(
   for (auto& sessionId : ids) {
     using v8::recordreplay;
     V8InspectorSessionImpl* session = sessionById(contextGroupId, sessionId);
-    const bool replay_owned = session && session->replayOwned();
-    v8::replayio::AutoMaybeMarkReplayCode mark(replay_owned);
-    v8::replayio::AutoMaybeDisallowEvents disallow(
-        replay_owned, m_isolate, "V8InspectorImpl::forEachSession");
-    REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
-        "V8InspectorImpl::forEachSession sessionId=%d hasGroup=%d",
-        sessionId,
-        m_sessions.find(contextGroupId) != m_sessions.end());
+    // Skip assert for ReplaySession: its presence in m_sessions is an allowed
+    // divergence. Do not RAII the whole session callback.
+    if (!session || !session->replayOwned()) {
+      REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
+          "V8InspectorImpl::forEachSession sessionId=%d hasGroup=%d", sessionId,
+          m_sessions.find(contextGroupId) != m_sessions.end());
+    }
     if (session) callback(session);
   }
 }

--- a/src/inspector/v8-inspector-session-impl.cc
+++ b/src/inspector/v8-inspector-session-impl.cc
@@ -109,6 +109,8 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(
       m_inspector(inspector),
       m_channel(channel),
       m_customObjectFormatterEnabled(false),
+      // ReplaySession connect is under AutoDisallowEvents; DevTools connect is not.
+      m_replay_owned(v8::recordreplay::AreEventsDisallowed()),
       m_dispatcher(this),
       m_state(ParseState(savedState)),
       m_runtimeAgent(nullptr),
@@ -117,8 +119,7 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(
       m_profilerAgent(nullptr),
       m_consoleAgent(nullptr),
       m_schemaAgent(nullptr),
-      m_clientTrustLevel(clientTrustLevel),
-      m_replay_owned(v8::replayio::CheckReplayOwned()) {
+      m_clientTrustLevel(clientTrustLevel) {
   m_state->getBoolean("use_binary_protocol", &use_binary_protocol_);
 
   v8::recordreplay::CommandDiagnosticTrace(
@@ -164,10 +165,6 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(
 
 V8InspectorSessionImpl::~V8InspectorSessionImpl() {
   v8::Isolate::Scope scope(m_inspector->isolate());
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8InspectorSessionImpl::~V8InspectorSessionImpl");
   discardInjectedScripts();
   m_consoleAgent->disable();
   m_profilerAgent->disable();
@@ -295,19 +292,12 @@ void V8InspectorSessionImpl::FlushProtocolNotifications() {
 }
 
 void V8InspectorSessionImpl::reset() {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(), "V8InspectorSessionImpl::reset");
   m_debuggerAgent->reset();
   m_runtimeAgent->reset();
   discardInjectedScripts();
 }
 
 void V8InspectorSessionImpl::discardInjectedScripts() {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8InspectorSessionImpl::discardInjectedScripts");
   m_inspectedObjects.clear();
   int sessionId = m_sessionId;
   m_inspector->forEachContext(m_contextGroupId,
@@ -331,7 +321,7 @@ Response V8InspectorSessionImpl::findInjectedScript(
   }
   injectedScript = context->getInjectedScript(m_sessionId);
   if (!injectedScript) {
-    injectedScript = context->createInjectedScript(m_sessionId);
+    injectedScript = context->createInjectedScript(m_sessionId, m_replay_owned);
     if (m_customObjectFormatterEnabled)
       injectedScript->setCustomObjectFormatterEnabled(true);
   }
@@ -356,10 +346,6 @@ void V8InspectorSessionImpl::releaseObjectGroup(StringView objectGroup) {
 }
 
 void V8InspectorSessionImpl::releaseObjectGroup(const String16& objectGroup) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8InspectorSessionImpl::releaseObjectGroup");
   int sessionId = m_sessionId;
   m_inspector->forEachContext(
       m_contextGroupId, [&objectGroup, &sessionId](InspectedContext* context) {
@@ -456,10 +442,6 @@ V8InspectorSessionImpl::wrapTable(v8::Local<v8::Context> context,
 }
 
 void V8InspectorSessionImpl::setCustomObjectFormatterEnabled(bool enabled) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8InspectorSessionImpl::setCustomObjectFormatterEnabled");
   m_customObjectFormatterEnabled = enabled;
   int sessionId = m_sessionId;
   m_inspector->forEachContext(
@@ -471,10 +453,6 @@ void V8InspectorSessionImpl::setCustomObjectFormatterEnabled(bool enabled) {
 }
 
 void V8InspectorSessionImpl::reportAllContexts(V8RuntimeAgentImpl* agent) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8InspectorSessionImpl::reportAllContexts");
   m_inspector->forEachContext(m_contextGroupId,
                               [&agent](InspectedContext* context) {
                                 agent->reportExecutionContextCreated(context);
@@ -482,10 +460,6 @@ void V8InspectorSessionImpl::reportAllContexts(V8RuntimeAgentImpl* agent) {
 }
 
 void V8InspectorSessionImpl::dispatchProtocolMessage(StringView message) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8InspectorSessionImpl::dispatchProtocolMessage");
   using v8_crdtp::span;
   using v8_crdtp::SpanFrom;
   span<uint8_t> cbor;

--- a/src/inspector/v8-inspector-session-impl.cc
+++ b/src/inspector/v8-inspector-session-impl.cc
@@ -164,6 +164,10 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(
 
 V8InspectorSessionImpl::~V8InspectorSessionImpl() {
   v8::Isolate::Scope scope(m_inspector->isolate());
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::~V8InspectorSessionImpl");
   discardInjectedScripts();
   m_consoleAgent->disable();
   m_profilerAgent->disable();
@@ -300,6 +304,10 @@ void V8InspectorSessionImpl::reset() {
 }
 
 void V8InspectorSessionImpl::discardInjectedScripts() {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::discardInjectedScripts");
   m_inspectedObjects.clear();
   int sessionId = m_sessionId;
   m_inspector->forEachContext(m_contextGroupId,
@@ -448,6 +456,10 @@ V8InspectorSessionImpl::wrapTable(v8::Local<v8::Context> context,
 }
 
 void V8InspectorSessionImpl::setCustomObjectFormatterEnabled(bool enabled) {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::setCustomObjectFormatterEnabled");
   m_customObjectFormatterEnabled = enabled;
   int sessionId = m_sessionId;
   m_inspector->forEachContext(
@@ -459,6 +471,10 @@ void V8InspectorSessionImpl::setCustomObjectFormatterEnabled(bool enabled) {
 }
 
 void V8InspectorSessionImpl::reportAllContexts(V8RuntimeAgentImpl* agent) {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::reportAllContexts");
   m_inspector->forEachContext(m_contextGroupId,
                               [&agent](InspectedContext* context) {
                                 agent->reportExecutionContextCreated(context);
@@ -466,6 +482,10 @@ void V8InspectorSessionImpl::reportAllContexts(V8RuntimeAgentImpl* agent) {
 }
 
 void V8InspectorSessionImpl::dispatchProtocolMessage(StringView message) {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::dispatchProtocolMessage");
   using v8_crdtp::span;
   using v8_crdtp::SpanFrom;
   span<uint8_t> cbor;

--- a/src/inspector/v8-inspector-session-impl.cc
+++ b/src/inspector/v8-inspector-session-impl.cc
@@ -165,6 +165,10 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(
 
 V8InspectorSessionImpl::~V8InspectorSessionImpl() {
   v8::Isolate::Scope scope(m_inspector->isolate());
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::~V8InspectorSessionImpl");
   discardInjectedScripts();
   m_consoleAgent->disable();
   m_profilerAgent->disable();
@@ -292,12 +296,19 @@ void V8InspectorSessionImpl::FlushProtocolNotifications() {
 }
 
 void V8InspectorSessionImpl::reset() {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(), "V8InspectorSessionImpl::reset");
   m_debuggerAgent->reset();
   m_runtimeAgent->reset();
   discardInjectedScripts();
 }
 
 void V8InspectorSessionImpl::discardInjectedScripts() {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::discardInjectedScripts");
   m_inspectedObjects.clear();
   int sessionId = m_sessionId;
   m_inspector->forEachContext(m_contextGroupId,
@@ -346,6 +357,10 @@ void V8InspectorSessionImpl::releaseObjectGroup(StringView objectGroup) {
 }
 
 void V8InspectorSessionImpl::releaseObjectGroup(const String16& objectGroup) {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::releaseObjectGroup");
   int sessionId = m_sessionId;
   m_inspector->forEachContext(
       m_contextGroupId, [&objectGroup, &sessionId](InspectedContext* context) {
@@ -442,6 +457,10 @@ V8InspectorSessionImpl::wrapTable(v8::Local<v8::Context> context,
 }
 
 void V8InspectorSessionImpl::setCustomObjectFormatterEnabled(bool enabled) {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::setCustomObjectFormatterEnabled");
   m_customObjectFormatterEnabled = enabled;
   int sessionId = m_sessionId;
   m_inspector->forEachContext(
@@ -453,6 +472,10 @@ void V8InspectorSessionImpl::setCustomObjectFormatterEnabled(bool enabled) {
 }
 
 void V8InspectorSessionImpl::reportAllContexts(V8RuntimeAgentImpl* agent) {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::reportAllContexts");
   m_inspector->forEachContext(m_contextGroupId,
                               [&agent](InspectedContext* context) {
                                 agent->reportExecutionContextCreated(context);
@@ -460,6 +483,10 @@ void V8InspectorSessionImpl::reportAllContexts(V8RuntimeAgentImpl* agent) {
 }
 
 void V8InspectorSessionImpl::dispatchProtocolMessage(StringView message) {
+  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
+  v8::replayio::AutoMaybeDisallowEvents disallow(
+      m_replay_owned, m_inspector->isolate(),
+      "V8InspectorSessionImpl::dispatchProtocolMessage");
   using v8_crdtp::span;
   using v8_crdtp::SpanFrom;
   span<uint8_t> cbor;

--- a/src/inspector/v8-inspector-session-impl.h
+++ b/src/inspector/v8-inspector-session-impl.h
@@ -138,6 +138,8 @@ class V8InspectorSessionImpl : public V8InspectorSession,
   V8Inspector::Channel* m_channel;
   bool m_customObjectFormatterEnabled;
   // Seeded at connect: true for ReplaySession (under AutoDisallowEvents).
+  // Owned-session work sites key AutoMaybeMarkReplayCode +
+  // AutoMaybeDisallowEvents off this flag.
   bool m_replay_owned;
 
   protocol::UberDispatcher m_dispatcher;

--- a/src/inspector/v8-inspector-session-impl.h
+++ b/src/inspector/v8-inspector-session-impl.h
@@ -156,7 +156,8 @@ class V8InspectorSessionImpl : public V8InspectorSession,
   //   (CheckReplayOwned / IsInReplayCode) into m_replay_owned.
   // - Calls on that object later: Propagate from m_replay_owned
   //   (AutoMaybeMarkReplayCode + AutoMaybeDisallowEvents).
-  // Shared inspector entry points (e.g. contextCreated) use the stack only;
+  // forEachSession: propagate per-session m_replay_owned.
+  // Other shared entry points (e.g. contextCreated): stack CheckReplayOwned only;
   // do not infer ownership from "a Replay session shares this context group".
   bool m_replay_owned;
 };

--- a/src/inspector/v8-inspector-session-impl.h
+++ b/src/inspector/v8-inspector-session-impl.h
@@ -137,6 +137,8 @@ class V8InspectorSessionImpl : public V8InspectorSession,
   V8InspectorImpl* m_inspector;
   V8Inspector::Channel* m_channel;
   bool m_customObjectFormatterEnabled;
+  // Seeded at connect: true for ReplaySession (under AutoDisallowEvents).
+  bool m_replay_owned;
 
   protocol::UberDispatcher m_dispatcher;
   std::unique_ptr<protocol::DictionaryValue> m_state;
@@ -151,15 +153,6 @@ class V8InspectorSessionImpl : public V8InspectorSession,
       m_inspectedObjects;
   bool use_binary_protocol_ = false;
   V8Inspector::ClientTrustLevel m_clientTrustLevel = V8Inspector::kUntrusted;
-  // Replay-only ownership:
-  // - Creation of a Replay-owned object: capture from stack
-  //   (CheckReplayOwned / IsInReplayCode) into m_replay_owned.
-  // - Calls on that object later: Propagate from m_replay_owned
-  //   (AutoMaybeMarkReplayCode + AutoMaybeDisallowEvents).
-  // forEachSession: propagate per-session m_replay_owned.
-  // Other shared entry points (e.g. contextCreated): stack CheckReplayOwned only;
-  // do not infer ownership from "a Replay session shares this context group".
-  bool m_replay_owned;
 };
 
 }  // namespace v8_inspector

--- a/src/inspector/v8-profiler-agent-impl.cc
+++ b/src/inspector/v8-profiler-agent-impl.cc
@@ -172,7 +172,8 @@ V8ProfilerAgentImpl::V8ProfilerAgentImpl(
     : m_session(session),
       m_isolate(m_session->inspector()->isolate()),
       m_state(state),
-      m_frontend(frontendChannel) {}
+      m_frontend(frontendChannel),
+      m_replay_owned(session->replayOwned()) {}
 
 V8ProfilerAgentImpl::~V8ProfilerAgentImpl() {
   if (m_profiler) m_profiler->Dispose();

--- a/src/inspector/v8-profiler-agent-impl.cc
+++ b/src/inspector/v8-profiler-agent-impl.cc
@@ -9,6 +9,7 @@
 #include "include/v8-profiler.h"
 #include "src/base/atomicops.h"
 #include "src/base/platform/time.h"
+#include "src/base/replayio.h"
 #include "src/debug/debug-interface.h"
 #include "src/inspector/protocol/Protocol.h"
 #include "src/inspector/string-util.h"
@@ -180,6 +181,8 @@ V8ProfilerAgentImpl::~V8ProfilerAgentImpl() {
 }
 
 void V8ProfilerAgentImpl::consoleProfile(const String16& title) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::consoleProfile");
   if (!m_enabled) return;
   String16 id = nextProfileId();
   m_startedProfiles.push_back(ProfileDescriptor(id, title));
@@ -189,6 +192,8 @@ void V8ProfilerAgentImpl::consoleProfile(const String16& title) {
 }
 
 void V8ProfilerAgentImpl::consoleProfileEnd(const String16& title) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::consoleProfileEnd");
   if (!m_enabled) return;
   String16 id;
   String16 resolvedTitle;
@@ -218,6 +223,8 @@ void V8ProfilerAgentImpl::consoleProfileEnd(const String16& title) {
 }
 
 Response V8ProfilerAgentImpl::enable() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::enable");
   if (!m_enabled) {
     m_enabled = true;
     m_state->setBoolean(ProfilerAgentState::profilerEnabled, true);
@@ -227,6 +234,8 @@ Response V8ProfilerAgentImpl::enable() {
 }
 
 Response V8ProfilerAgentImpl::disable() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::disable");
   if (m_enabled) {
     for (size_t i = m_startedProfiles.size(); i > 0; --i)
       stopProfiling(m_startedProfiles[i - 1].m_id, false);
@@ -242,6 +251,8 @@ Response V8ProfilerAgentImpl::disable() {
 }
 
 Response V8ProfilerAgentImpl::setSamplingInterval(int interval) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::setSamplingInterval");
   if (m_profiler) {
     return Response::ServerError(
         "Cannot change sampling interval when profiling.");
@@ -251,6 +262,8 @@ Response V8ProfilerAgentImpl::setSamplingInterval(int interval) {
 }
 
 void V8ProfilerAgentImpl::restore() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::restore");
   DCHECK(!m_enabled);
   if (m_state->booleanProperty(ProfilerAgentState::profilerEnabled, false)) {
     m_enabled = true;
@@ -275,6 +288,8 @@ void V8ProfilerAgentImpl::restore() {
 }
 
 Response V8ProfilerAgentImpl::start() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::start");
   if (m_recordingCPUProfile) return Response::Success();
   if (!m_enabled) return Response::ServerError("Profiler is not enabled");
   m_recordingCPUProfile = true;
@@ -286,6 +301,8 @@ Response V8ProfilerAgentImpl::start() {
 
 Response V8ProfilerAgentImpl::stop(
     std::unique_ptr<protocol::Profiler::Profile>* profile) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::stop");
   if (!m_recordingCPUProfile) {
     return Response::ServerError("No recording profiles found");
   }
@@ -304,6 +321,8 @@ Response V8ProfilerAgentImpl::stop(
 Response V8ProfilerAgentImpl::startPreciseCoverage(
     Maybe<bool> callCount, Maybe<bool> detailed,
     Maybe<bool> allowTriggeredUpdates, double* out_timestamp) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::startPreciseCoverage");
   if (!m_enabled) return Response::ServerError("Profiler is not enabled");
   *out_timestamp = v8::base::TimeTicks::Now().since_origin().InSecondsF();
   bool callCountValue = callCount.fromMaybe(false);
@@ -330,6 +349,8 @@ Response V8ProfilerAgentImpl::startPreciseCoverage(
 }
 
 Response V8ProfilerAgentImpl::stopPreciseCoverage() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::stopPreciseCoverage");
   if (!m_enabled) return Response::ServerError("Profiler is not enabled");
   m_state->setBoolean(ProfilerAgentState::preciseCoverageStarted, false);
   m_state->setBoolean(ProfilerAgentState::preciseCoverageCallCount, false);
@@ -412,6 +433,8 @@ Response V8ProfilerAgentImpl::takePreciseCoverage(
     std::unique_ptr<protocol::Array<protocol::Profiler::ScriptCoverage>>*
         out_result,
     double* out_timestamp) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::takePreciseCoverage");
   if (!m_state->booleanProperty(ProfilerAgentState::preciseCoverageStarted,
                                 false)) {
     return Response::ServerError("Precise coverage has not been started.");
@@ -424,6 +447,9 @@ Response V8ProfilerAgentImpl::takePreciseCoverage(
 
 void V8ProfilerAgentImpl::triggerPreciseCoverageDeltaUpdate(
     const String16& occasion) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate,
+      "V8ProfilerAgentImpl::triggerPreciseCoverageDeltaUpdate");
   if (!m_state->booleanProperty(ProfilerAgentState::preciseCoverageStarted,
                                 false)) {
     return;
@@ -444,6 +470,8 @@ void V8ProfilerAgentImpl::triggerPreciseCoverageDeltaUpdate(
 Response V8ProfilerAgentImpl::getBestEffortCoverage(
     std::unique_ptr<protocol::Array<protocol::Profiler::ScriptCoverage>>*
         out_result) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::getBestEffortCoverage");
   v8::HandleScope handle_scope(m_isolate);
   v8::debug::Coverage coverage =
       v8::debug::Coverage::CollectBestEffort(m_isolate);
@@ -456,6 +484,8 @@ String16 V8ProfilerAgentImpl::nextProfileId() {
 }
 
 void V8ProfilerAgentImpl::startProfiling(const String16& title) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::startProfiling");
   v8::HandleScope handleScope(m_isolate);
   if (!m_startedProfilesCount) {
     DCHECK(!m_profiler);
@@ -470,6 +500,8 @@ void V8ProfilerAgentImpl::startProfiling(const String16& title) {
 
 std::unique_ptr<protocol::Profiler::Profile> V8ProfilerAgentImpl::stopProfiling(
     const String16& title, bool serialize) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::stopProfiling");
   v8::HandleScope handleScope(m_isolate);
   v8::CpuProfile* profile =
       m_profiler->StopProfiling(toV8String(m_isolate, title));

--- a/src/inspector/v8-profiler-agent-impl.cc
+++ b/src/inspector/v8-profiler-agent-impl.cc
@@ -181,8 +181,6 @@ V8ProfilerAgentImpl::~V8ProfilerAgentImpl() {
 }
 
 void V8ProfilerAgentImpl::consoleProfile(const String16& title) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::consoleProfile");
   if (!m_enabled) return;
   String16 id = nextProfileId();
   m_startedProfiles.push_back(ProfileDescriptor(id, title));
@@ -192,8 +190,6 @@ void V8ProfilerAgentImpl::consoleProfile(const String16& title) {
 }
 
 void V8ProfilerAgentImpl::consoleProfileEnd(const String16& title) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::consoleProfileEnd");
   if (!m_enabled) return;
   String16 id;
   String16 resolvedTitle;
@@ -223,8 +219,6 @@ void V8ProfilerAgentImpl::consoleProfileEnd(const String16& title) {
 }
 
 Response V8ProfilerAgentImpl::enable() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::enable");
   if (!m_enabled) {
     m_enabled = true;
     m_state->setBoolean(ProfilerAgentState::profilerEnabled, true);
@@ -234,8 +228,6 @@ Response V8ProfilerAgentImpl::enable() {
 }
 
 Response V8ProfilerAgentImpl::disable() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::disable");
   if (m_enabled) {
     for (size_t i = m_startedProfiles.size(); i > 0; --i)
       stopProfiling(m_startedProfiles[i - 1].m_id, false);
@@ -251,8 +243,6 @@ Response V8ProfilerAgentImpl::disable() {
 }
 
 Response V8ProfilerAgentImpl::setSamplingInterval(int interval) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::setSamplingInterval");
   if (m_profiler) {
     return Response::ServerError(
         "Cannot change sampling interval when profiling.");
@@ -288,8 +278,6 @@ void V8ProfilerAgentImpl::restore() {
 }
 
 Response V8ProfilerAgentImpl::start() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::start");
   if (m_recordingCPUProfile) return Response::Success();
   if (!m_enabled) return Response::ServerError("Profiler is not enabled");
   m_recordingCPUProfile = true;
@@ -301,8 +289,6 @@ Response V8ProfilerAgentImpl::start() {
 
 Response V8ProfilerAgentImpl::stop(
     std::unique_ptr<protocol::Profiler::Profile>* profile) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::stop");
   if (!m_recordingCPUProfile) {
     return Response::ServerError("No recording profiles found");
   }
@@ -321,8 +307,6 @@ Response V8ProfilerAgentImpl::stop(
 Response V8ProfilerAgentImpl::startPreciseCoverage(
     Maybe<bool> callCount, Maybe<bool> detailed,
     Maybe<bool> allowTriggeredUpdates, double* out_timestamp) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::startPreciseCoverage");
   if (!m_enabled) return Response::ServerError("Profiler is not enabled");
   *out_timestamp = v8::base::TimeTicks::Now().since_origin().InSecondsF();
   bool callCountValue = callCount.fromMaybe(false);
@@ -349,8 +333,6 @@ Response V8ProfilerAgentImpl::startPreciseCoverage(
 }
 
 Response V8ProfilerAgentImpl::stopPreciseCoverage() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::stopPreciseCoverage");
   if (!m_enabled) return Response::ServerError("Profiler is not enabled");
   m_state->setBoolean(ProfilerAgentState::preciseCoverageStarted, false);
   m_state->setBoolean(ProfilerAgentState::preciseCoverageCallCount, false);
@@ -433,8 +415,6 @@ Response V8ProfilerAgentImpl::takePreciseCoverage(
     std::unique_ptr<protocol::Array<protocol::Profiler::ScriptCoverage>>*
         out_result,
     double* out_timestamp) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::takePreciseCoverage");
   if (!m_state->booleanProperty(ProfilerAgentState::preciseCoverageStarted,
                                 false)) {
     return Response::ServerError("Precise coverage has not been started.");
@@ -470,8 +450,6 @@ void V8ProfilerAgentImpl::triggerPreciseCoverageDeltaUpdate(
 Response V8ProfilerAgentImpl::getBestEffortCoverage(
     std::unique_ptr<protocol::Array<protocol::Profiler::ScriptCoverage>>*
         out_result) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::getBestEffortCoverage");
   v8::HandleScope handle_scope(m_isolate);
   v8::debug::Coverage coverage =
       v8::debug::Coverage::CollectBestEffort(m_isolate);
@@ -484,8 +462,6 @@ String16 V8ProfilerAgentImpl::nextProfileId() {
 }
 
 void V8ProfilerAgentImpl::startProfiling(const String16& title) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::startProfiling");
   v8::HandleScope handleScope(m_isolate);
   if (!m_startedProfilesCount) {
     DCHECK(!m_profiler);
@@ -500,8 +476,6 @@ void V8ProfilerAgentImpl::startProfiling(const String16& title) {
 
 std::unique_ptr<protocol::Profiler::Profile> V8ProfilerAgentImpl::stopProfiling(
     const String16& title, bool serialize) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_isolate, "V8ProfilerAgentImpl::stopProfiling");
   v8::HandleScope handleScope(m_isolate);
   v8::CpuProfile* profile =
       m_profiler->StopProfiling(toV8String(m_isolate, title));

--- a/src/inspector/v8-profiler-agent-impl.h
+++ b/src/inspector/v8-profiler-agent-impl.h
@@ -33,6 +33,7 @@ class V8ProfilerAgentImpl : public protocol::Profiler::Backend {
   V8ProfilerAgentImpl& operator=(const V8ProfilerAgentImpl&) = delete;
 
   bool enabled() const { return m_enabled; }
+  bool replayOwned() const { return m_replay_owned; }
   void restore();
 
   Response enable() override;
@@ -71,6 +72,7 @@ class V8ProfilerAgentImpl : public protocol::Profiler::Backend {
   protocol::DictionaryValue* m_state;
   protocol::Profiler::Frontend m_frontend;
   bool m_enabled = false;
+  bool m_replay_owned = false;
   bool m_recordingCPUProfile = false;
   class ProfileDescriptor;
   std::vector<ProfileDescriptor> m_startedProfiles;

--- a/src/inspector/v8-runtime-agent-impl.cc
+++ b/src/inspector/v8-runtime-agent-impl.cc
@@ -272,6 +272,8 @@ void V8RuntimeAgentImpl::evaluate(
     std::unique_ptr<EvaluateCallback> callback) {
   TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("devtools.timeline"),
                "EvaluateScript");
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::evaluate");
   int contextId = 0;
   Response response = ensureContext(m_inspector, m_session->contextGroupId(),
                                     std::move(executionContextId),
@@ -357,6 +359,9 @@ void V8RuntimeAgentImpl::awaitPromise(
     const String16& promiseObjectId, Maybe<bool> returnByValue,
     Maybe<bool> generatePreview,
     std::unique_ptr<AwaitPromiseCallback> callback) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::awaitPromise");
   InjectedScript::ObjectScope scope(m_session, promiseObjectId);
   Response response = scope.initialize();
   if (!response.IsSuccess()) {
@@ -385,6 +390,9 @@ void V8RuntimeAgentImpl::callFunctionOn(
     Maybe<int> executionContextId, Maybe<String16> objectGroup,
     Maybe<bool> throwOnSideEffect, Maybe<bool> generateWebDriverValue,
     std::unique_ptr<CallFunctionOnCallback> callback) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::callFunctionOn");
   if (objectId.isJust() && executionContextId.isJust()) {
     callback->sendFailure(Response::ServerError(
         "ObjectId must not be specified together with executionContextId"));
@@ -451,6 +459,9 @@ Response V8RuntimeAgentImpl::getProperties(
     Maybe<protocol::Array<protocol::Runtime::PrivatePropertyDescriptor>>*
         privateProperties,
     Maybe<protocol::Runtime::ExceptionDetails>* exceptionDetails) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::getProperties");
   using protocol::Runtime::InternalPropertyDescriptor;
   using protocol::Runtime::PrivatePropertyDescriptor;
 
@@ -494,6 +505,9 @@ Response V8RuntimeAgentImpl::getProperties(
 }
 
 Response V8RuntimeAgentImpl::releaseObject(const String16& objectId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::releaseObject");
   InjectedScript::ObjectScope scope(m_session, objectId);
   Response response = scope.initialize();
   if (!response.IsSuccess()) return response;
@@ -502,16 +516,25 @@ Response V8RuntimeAgentImpl::releaseObject(const String16& objectId) {
 }
 
 Response V8RuntimeAgentImpl::releaseObjectGroup(const String16& objectGroup) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::releaseObjectGroup");
   m_session->releaseObjectGroup(objectGroup);
   return Response::Success();
 }
 
 Response V8RuntimeAgentImpl::runIfWaitingForDebugger() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::runIfWaitingForDebugger");
   m_inspector->client()->runIfWaitingForDebugger(m_session->contextGroupId());
   return Response::Success();
 }
 
 Response V8RuntimeAgentImpl::setCustomObjectFormatterEnabled(bool enabled) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::setCustomObjectFormatterEnabled");
   m_state->setBoolean(V8RuntimeAgentImplState::customObjectFormatterEnabled,
                       enabled);
   if (!m_enabled) return Response::ServerError("Runtime agent is not enabled");
@@ -520,6 +543,9 @@ Response V8RuntimeAgentImpl::setCustomObjectFormatterEnabled(bool enabled) {
 }
 
 Response V8RuntimeAgentImpl::setMaxCallStackSizeToCapture(int size) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::setMaxCallStackSizeToCapture");
   if (size < 0) {
     return Response::ServerError(
         "maxCallStackSizeToCapture should be non-negative");
@@ -535,6 +561,9 @@ Response V8RuntimeAgentImpl::setMaxCallStackSizeToCapture(int size) {
 }
 
 Response V8RuntimeAgentImpl::discardConsoleEntries() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::discardConsoleEntries");
   V8ConsoleMessageStorage* storage =
       m_inspector->ensureConsoleMessageStorage(m_session->contextGroupId());
   storage->clear();
@@ -545,6 +574,9 @@ Response V8RuntimeAgentImpl::compileScript(
     const String16& expression, const String16& sourceURL, bool persistScript,
     Maybe<int> executionContextId, Maybe<String16>* scriptId,
     Maybe<protocol::Runtime::ExceptionDetails>* exceptionDetails) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::compileScript");
   if (!m_enabled) return Response::ServerError("Runtime agent is not enabled");
 
   int contextId = 0;
@@ -589,6 +621,8 @@ void V8RuntimeAgentImpl::runScript(
     Maybe<bool> includeCommandLineAPI, Maybe<bool> returnByValue,
     Maybe<bool> generatePreview, Maybe<bool> awaitPromise,
     std::unique_ptr<RunScriptCallback> callback) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::runScript");
   if (!m_enabled) {
     callback->sendFailure(
         Response::ServerError("Runtime agent is not enabled"));
@@ -662,6 +696,9 @@ void V8RuntimeAgentImpl::runScript(
 Response V8RuntimeAgentImpl::queryObjects(
     const String16& prototypeObjectId, Maybe<String16> objectGroup,
     std::unique_ptr<protocol::Runtime::RemoteObject>* objects) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::queryObjects");
   InjectedScript::ObjectScope scope(m_session, prototypeObjectId);
   Response response = scope.initialize();
   if (!response.IsSuccess()) return response;
@@ -678,6 +715,9 @@ Response V8RuntimeAgentImpl::queryObjects(
 Response V8RuntimeAgentImpl::globalLexicalScopeNames(
     Maybe<int> executionContextId,
     std::unique_ptr<protocol::Array<String16>>* outNames) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::globalLexicalScopeNames");
   int contextId = 0;
   Response response = ensureContext(m_inspector, m_session->contextGroupId(),
                                     std::move(executionContextId),
@@ -699,6 +739,9 @@ Response V8RuntimeAgentImpl::globalLexicalScopeNames(
 }
 
 Response V8RuntimeAgentImpl::getIsolateId(String16* outIsolateId) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::getIsolateId");
   char buf[40];
   std::snprintf(buf, sizeof(buf), "%" PRIx64, m_inspector->isolateId());
   *outIsolateId = buf;
@@ -707,6 +750,9 @@ Response V8RuntimeAgentImpl::getIsolateId(String16* outIsolateId) {
 
 Response V8RuntimeAgentImpl::getHeapUsage(double* out_usedSize,
                                           double* out_totalSize) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::getHeapUsage");
   v8::HeapStatistics stats;
   m_inspector->isolate()->GetHeapStatistics(&stats);
   *out_usedSize = stats.used_heap_size();
@@ -716,6 +762,9 @@ Response V8RuntimeAgentImpl::getHeapUsage(double* out_usedSize,
 
 void V8RuntimeAgentImpl::terminateExecution(
     std::unique_ptr<TerminateExecutionCallback> callback) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::terminateExecution");
   m_inspector->debugger()->terminateExecution(std::move(callback));
 }
 
@@ -732,6 +781,8 @@ protocol::DictionaryValue* getOrCreateDictionary(
 Response V8RuntimeAgentImpl::addBinding(const String16& name,
                                         Maybe<int> executionContextId,
                                         Maybe<String16> executionContextName) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::addBinding");
   if (executionContextId.isJust()) {
     if (executionContextName.isJust()) {
       return Response::InvalidParams(
@@ -826,6 +877,9 @@ void V8RuntimeAgentImpl::addBinding(InspectedContext* context,
 }
 
 Response V8RuntimeAgentImpl::removeBinding(const String16& name) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::removeBinding");
   protocol::DictionaryValue* bindings =
       m_state->getObject(V8RuntimeAgentImplState::bindings);
   if (bindings) bindings->remove(name);
@@ -836,6 +890,9 @@ Response V8RuntimeAgentImpl::removeBinding(const String16& name) {
 Response V8RuntimeAgentImpl::getExceptionDetails(
     const String16& errorObjectId,
     Maybe<protocol::Runtime::ExceptionDetails>* out_exceptionDetails) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::getExceptionDetails");
   InjectedScript::ObjectScope scope(m_session, errorObjectId);
   Response response = scope.initialize();
   if (!response.IsSuccess()) return response;
@@ -933,6 +990,8 @@ void V8RuntimeAgentImpl::restore() {
 
 Response V8RuntimeAgentImpl::enable() {
   using v8::recordreplay;
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::enable");
   if (m_enabled) return Response::Success();
   TRACE_EVENT_WITH_FLOW0(TRACE_DISABLED_BY_DEFAULT("v8.inspector"),
                          "V8RuntimeAgentImpl::enable", this,
@@ -955,6 +1014,8 @@ Response V8RuntimeAgentImpl::enable() {
 }
 
 Response V8RuntimeAgentImpl::disable() {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::disable");
   if (!m_enabled) return Response::Success();
   TRACE_EVENT_WITH_FLOW0(TRACE_DISABLED_BY_DEFAULT("v8.inspector"),
                          "V8RuntimeAgentImpl::disable", this,
@@ -1042,6 +1103,9 @@ void V8RuntimeAgentImpl::inspect(
 }
 
 void V8RuntimeAgentImpl::messageAdded(V8ConsoleMessage* message) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_inspector->isolate(),
+      "V8RuntimeAgentImpl::messageAdded");
   if (m_enabled) reportMessage(message, true);
 }
 

--- a/src/inspector/v8-runtime-agent-impl.cc
+++ b/src/inspector/v8-runtime-agent-impl.cc
@@ -272,8 +272,6 @@ void V8RuntimeAgentImpl::evaluate(
     std::unique_ptr<EvaluateCallback> callback) {
   TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("devtools.timeline"),
                "EvaluateScript");
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::evaluate");
   int contextId = 0;
   Response response = ensureContext(m_inspector, m_session->contextGroupId(),
                                     std::move(executionContextId),
@@ -359,9 +357,6 @@ void V8RuntimeAgentImpl::awaitPromise(
     const String16& promiseObjectId, Maybe<bool> returnByValue,
     Maybe<bool> generatePreview,
     std::unique_ptr<AwaitPromiseCallback> callback) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::awaitPromise");
   InjectedScript::ObjectScope scope(m_session, promiseObjectId);
   Response response = scope.initialize();
   if (!response.IsSuccess()) {
@@ -390,9 +385,6 @@ void V8RuntimeAgentImpl::callFunctionOn(
     Maybe<int> executionContextId, Maybe<String16> objectGroup,
     Maybe<bool> throwOnSideEffect, Maybe<bool> generateWebDriverValue,
     std::unique_ptr<CallFunctionOnCallback> callback) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::callFunctionOn");
   if (objectId.isJust() && executionContextId.isJust()) {
     callback->sendFailure(Response::ServerError(
         "ObjectId must not be specified together with executionContextId"));
@@ -459,9 +451,6 @@ Response V8RuntimeAgentImpl::getProperties(
     Maybe<protocol::Array<protocol::Runtime::PrivatePropertyDescriptor>>*
         privateProperties,
     Maybe<protocol::Runtime::ExceptionDetails>* exceptionDetails) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::getProperties");
   using protocol::Runtime::InternalPropertyDescriptor;
   using protocol::Runtime::PrivatePropertyDescriptor;
 
@@ -505,9 +494,6 @@ Response V8RuntimeAgentImpl::getProperties(
 }
 
 Response V8RuntimeAgentImpl::releaseObject(const String16& objectId) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::releaseObject");
   InjectedScript::ObjectScope scope(m_session, objectId);
   Response response = scope.initialize();
   if (!response.IsSuccess()) return response;
@@ -516,25 +502,16 @@ Response V8RuntimeAgentImpl::releaseObject(const String16& objectId) {
 }
 
 Response V8RuntimeAgentImpl::releaseObjectGroup(const String16& objectGroup) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::releaseObjectGroup");
   m_session->releaseObjectGroup(objectGroup);
   return Response::Success();
 }
 
 Response V8RuntimeAgentImpl::runIfWaitingForDebugger() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::runIfWaitingForDebugger");
   m_inspector->client()->runIfWaitingForDebugger(m_session->contextGroupId());
   return Response::Success();
 }
 
 Response V8RuntimeAgentImpl::setCustomObjectFormatterEnabled(bool enabled) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::setCustomObjectFormatterEnabled");
   m_state->setBoolean(V8RuntimeAgentImplState::customObjectFormatterEnabled,
                       enabled);
   if (!m_enabled) return Response::ServerError("Runtime agent is not enabled");
@@ -543,9 +520,6 @@ Response V8RuntimeAgentImpl::setCustomObjectFormatterEnabled(bool enabled) {
 }
 
 Response V8RuntimeAgentImpl::setMaxCallStackSizeToCapture(int size) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::setMaxCallStackSizeToCapture");
   if (size < 0) {
     return Response::ServerError(
         "maxCallStackSizeToCapture should be non-negative");
@@ -561,9 +535,6 @@ Response V8RuntimeAgentImpl::setMaxCallStackSizeToCapture(int size) {
 }
 
 Response V8RuntimeAgentImpl::discardConsoleEntries() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::discardConsoleEntries");
   V8ConsoleMessageStorage* storage =
       m_inspector->ensureConsoleMessageStorage(m_session->contextGroupId());
   storage->clear();
@@ -574,9 +545,6 @@ Response V8RuntimeAgentImpl::compileScript(
     const String16& expression, const String16& sourceURL, bool persistScript,
     Maybe<int> executionContextId, Maybe<String16>* scriptId,
     Maybe<protocol::Runtime::ExceptionDetails>* exceptionDetails) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::compileScript");
   if (!m_enabled) return Response::ServerError("Runtime agent is not enabled");
 
   int contextId = 0;
@@ -621,8 +589,6 @@ void V8RuntimeAgentImpl::runScript(
     Maybe<bool> includeCommandLineAPI, Maybe<bool> returnByValue,
     Maybe<bool> generatePreview, Maybe<bool> awaitPromise,
     std::unique_ptr<RunScriptCallback> callback) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::runScript");
   if (!m_enabled) {
     callback->sendFailure(
         Response::ServerError("Runtime agent is not enabled"));
@@ -696,9 +662,6 @@ void V8RuntimeAgentImpl::runScript(
 Response V8RuntimeAgentImpl::queryObjects(
     const String16& prototypeObjectId, Maybe<String16> objectGroup,
     std::unique_ptr<protocol::Runtime::RemoteObject>* objects) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::queryObjects");
   InjectedScript::ObjectScope scope(m_session, prototypeObjectId);
   Response response = scope.initialize();
   if (!response.IsSuccess()) return response;
@@ -715,9 +678,6 @@ Response V8RuntimeAgentImpl::queryObjects(
 Response V8RuntimeAgentImpl::globalLexicalScopeNames(
     Maybe<int> executionContextId,
     std::unique_ptr<protocol::Array<String16>>* outNames) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::globalLexicalScopeNames");
   int contextId = 0;
   Response response = ensureContext(m_inspector, m_session->contextGroupId(),
                                     std::move(executionContextId),
@@ -739,9 +699,6 @@ Response V8RuntimeAgentImpl::globalLexicalScopeNames(
 }
 
 Response V8RuntimeAgentImpl::getIsolateId(String16* outIsolateId) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::getIsolateId");
   char buf[40];
   std::snprintf(buf, sizeof(buf), "%" PRIx64, m_inspector->isolateId());
   *outIsolateId = buf;
@@ -750,9 +707,6 @@ Response V8RuntimeAgentImpl::getIsolateId(String16* outIsolateId) {
 
 Response V8RuntimeAgentImpl::getHeapUsage(double* out_usedSize,
                                           double* out_totalSize) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::getHeapUsage");
   v8::HeapStatistics stats;
   m_inspector->isolate()->GetHeapStatistics(&stats);
   *out_usedSize = stats.used_heap_size();
@@ -762,9 +716,6 @@ Response V8RuntimeAgentImpl::getHeapUsage(double* out_usedSize,
 
 void V8RuntimeAgentImpl::terminateExecution(
     std::unique_ptr<TerminateExecutionCallback> callback) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::terminateExecution");
   m_inspector->debugger()->terminateExecution(std::move(callback));
 }
 
@@ -781,8 +732,6 @@ protocol::DictionaryValue* getOrCreateDictionary(
 Response V8RuntimeAgentImpl::addBinding(const String16& name,
                                         Maybe<int> executionContextId,
                                         Maybe<String16> executionContextName) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::addBinding");
   if (executionContextId.isJust()) {
     if (executionContextName.isJust()) {
       return Response::InvalidParams(
@@ -877,9 +826,6 @@ void V8RuntimeAgentImpl::addBinding(InspectedContext* context,
 }
 
 Response V8RuntimeAgentImpl::removeBinding(const String16& name) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::removeBinding");
   protocol::DictionaryValue* bindings =
       m_state->getObject(V8RuntimeAgentImplState::bindings);
   if (bindings) bindings->remove(name);
@@ -890,9 +836,6 @@ Response V8RuntimeAgentImpl::removeBinding(const String16& name) {
 Response V8RuntimeAgentImpl::getExceptionDetails(
     const String16& errorObjectId,
     Maybe<protocol::Runtime::ExceptionDetails>* out_exceptionDetails) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::getExceptionDetails");
   InjectedScript::ObjectScope scope(m_session, errorObjectId);
   Response response = scope.initialize();
   if (!response.IsSuccess()) return response;
@@ -928,10 +871,6 @@ Response V8RuntimeAgentImpl::getExceptionDetails(
 void V8RuntimeAgentImpl::bindingCalled(const String16& name,
                                        const String16& payload,
                                        int executionContextId) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::bindingCalled");
 
   if (!m_activeBindings.count(name)) return;
   m_frontend.bindingCalled(name, payload, executionContextId);
@@ -939,9 +878,6 @@ void V8RuntimeAgentImpl::bindingCalled(const String16& name,
 }
 
 void V8RuntimeAgentImpl::addBindings(InspectedContext* context) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::addBindings");
   const String16 contextName = context->humanReadableName();
   if (!m_enabled) return;
   protocol::DictionaryValue* bindings =
@@ -990,8 +926,6 @@ void V8RuntimeAgentImpl::restore() {
 
 Response V8RuntimeAgentImpl::enable() {
   using v8::recordreplay;
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::enable");
   if (m_enabled) return Response::Success();
   TRACE_EVENT_WITH_FLOW0(TRACE_DISABLED_BY_DEFAULT("v8.inspector"),
                          "V8RuntimeAgentImpl::enable", this,
@@ -1014,8 +948,6 @@ Response V8RuntimeAgentImpl::enable() {
 }
 
 Response V8RuntimeAgentImpl::disable() {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::disable");
   if (!m_enabled) return Response::Success();
   TRACE_EVENT_WITH_FLOW0(TRACE_DISABLED_BY_DEFAULT("v8.inspector"),
                          "V8RuntimeAgentImpl::disable", this,
@@ -1035,9 +967,6 @@ Response V8RuntimeAgentImpl::disable() {
 }
 
 void V8RuntimeAgentImpl::reset() {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::reset");
 
   m_compiledScripts.clear();
   if (m_enabled) {
@@ -1052,10 +981,6 @@ void V8RuntimeAgentImpl::reset() {
 
 void V8RuntimeAgentImpl::reportExecutionContextCreated(
     InspectedContext* context) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::reportExecutionContextCreated");
 
   if (!m_enabled) return;
   context->setReported(m_session->sessionId(), true);
@@ -1079,10 +1004,6 @@ void V8RuntimeAgentImpl::reportExecutionContextCreated(
 
 void V8RuntimeAgentImpl::reportExecutionContextDestroyed(
     InspectedContext* context) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::reportExecutionContextDestroyed");
 
   if (m_enabled && context->isReported(m_session->sessionId())) {
     context->setReported(m_session->sessionId(), false);
@@ -1093,9 +1014,6 @@ void V8RuntimeAgentImpl::reportExecutionContextDestroyed(
 void V8RuntimeAgentImpl::inspect(
     std::unique_ptr<protocol::Runtime::RemoteObject> objectToInspect,
     std::unique_ptr<protocol::DictionaryValue> hints, int executionContextId) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::inspect");
 
   if (m_enabled)
     m_frontend.inspectRequested(std::move(objectToInspect), std::move(hints),
@@ -1103,18 +1021,11 @@ void V8RuntimeAgentImpl::inspect(
 }
 
 void V8RuntimeAgentImpl::messageAdded(V8ConsoleMessage* message) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::messageAdded");
   if (m_enabled) reportMessage(message, true);
 }
 
 bool V8RuntimeAgentImpl::reportMessage(V8ConsoleMessage* message,
                                        bool generatePreview) {
-  v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
-  v8::replayio::AutoMaybeDisallowEvents disallow(
-      m_replay_owned, m_inspector->isolate(),
-      "V8RuntimeAgentImpl::reportMessage");
 
   message->reportToFrontend(&m_frontend, m_session, generatePreview);
   m_frontend.flush();

--- a/src/inspector/v8-runtime-agent-impl.h
+++ b/src/inspector/v8-runtime-agent-impl.h
@@ -144,6 +144,7 @@ class V8RuntimeAgentImpl : public protocol::Runtime::Backend {
                int executionContextId);
   void messageAdded(V8ConsoleMessage*);
   bool enabled() const { return m_enabled; }
+  bool replayOwned() const { return m_replay_owned; }
 
  private:
   bool reportMessage(V8ConsoleMessage*, bool generatePreview);
@@ -158,13 +159,11 @@ class V8RuntimeAgentImpl : public protocol::Runtime::Backend {
   protocol::Runtime::Frontend m_frontend;
   V8InspectorImpl* m_inspector;
   bool m_enabled;
+  bool m_replay_owned;
   std::unordered_map<String16, std::unique_ptr<v8::Global<v8::Script>>>
       m_compiledScripts;
   // Binding name -> executionContextIds mapping.
   std::unordered_map<String16, std::unordered_set<int>> m_activeBindings;
-
-  // Whether this agent is replaying specific, and should not interact with the recording.
-  bool m_replay_owned;
 };
 
 }  // namespace v8_inspector

--- a/src/inspector/v8-schema-agent-impl.cc
+++ b/src/inspector/v8-schema-agent-impl.cc
@@ -12,7 +12,9 @@ namespace v8_inspector {
 V8SchemaAgentImpl::V8SchemaAgentImpl(V8InspectorSessionImpl* session,
                                      protocol::FrontendChannel* frontendChannel,
                                      protocol::DictionaryValue* state)
-    : m_session(session), m_frontend(frontendChannel) {}
+    : m_session(session),
+      m_frontend(frontendChannel),
+      m_replay_owned(session->replayOwned()) {}
 
 V8SchemaAgentImpl::~V8SchemaAgentImpl() = default;
 

--- a/src/inspector/v8-schema-agent-impl.cc
+++ b/src/inspector/v8-schema-agent-impl.cc
@@ -6,6 +6,7 @@
 
 #include "src/base/replayio.h"
 #include "src/inspector/protocol/Protocol.h"
+#include "src/inspector/v8-inspector-impl.h"
 #include "src/inspector/v8-inspector-session-impl.h"
 
 namespace v8_inspector {

--- a/src/inspector/v8-schema-agent-impl.cc
+++ b/src/inspector/v8-schema-agent-impl.cc
@@ -4,7 +4,6 @@
 
 #include "src/inspector/v8-schema-agent-impl.h"
 
-#include "src/base/replayio.h"
 #include "src/inspector/protocol/Protocol.h"
 #include "src/inspector/v8-inspector-impl.h"
 #include "src/inspector/v8-inspector-session-impl.h"
@@ -14,17 +13,12 @@ namespace v8_inspector {
 V8SchemaAgentImpl::V8SchemaAgentImpl(V8InspectorSessionImpl* session,
                                      protocol::FrontendChannel* frontendChannel,
                                      protocol::DictionaryValue* state)
-    : m_session(session),
-      m_frontend(frontendChannel),
-      m_replay_owned(session->replayOwned()) {}
+    : m_session(session), m_frontend(frontendChannel) {}
 
 V8SchemaAgentImpl::~V8SchemaAgentImpl() = default;
 
 Response V8SchemaAgentImpl::getDomains(
     std::unique_ptr<protocol::Array<protocol::Schema::Domain>>* result) {
-  v8::replayio::AutoMaybeReplayOwned replay_owned(
-      m_replay_owned, m_session->inspector()->isolate(),
-      "V8SchemaAgentImpl::getDomains");
   *result =
       std::make_unique<std::vector<std::unique_ptr<protocol::Schema::Domain>>>(
           m_session->supportedDomainsImpl());

--- a/src/inspector/v8-schema-agent-impl.cc
+++ b/src/inspector/v8-schema-agent-impl.cc
@@ -4,6 +4,7 @@
 
 #include "src/inspector/v8-schema-agent-impl.h"
 
+#include "src/base/replayio.h"
 #include "src/inspector/protocol/Protocol.h"
 #include "src/inspector/v8-inspector-session-impl.h"
 
@@ -20,6 +21,9 @@ V8SchemaAgentImpl::~V8SchemaAgentImpl() = default;
 
 Response V8SchemaAgentImpl::getDomains(
     std::unique_ptr<protocol::Array<protocol::Schema::Domain>>* result) {
+  v8::replayio::AutoMaybeReplayOwned replay_owned(
+      m_replay_owned, m_session->inspector()->isolate(),
+      "V8SchemaAgentImpl::getDomains");
   *result =
       std::make_unique<std::vector<std::unique_ptr<protocol::Schema::Domain>>>(
           m_session->supportedDomainsImpl());

--- a/src/inspector/v8-schema-agent-impl.h
+++ b/src/inspector/v8-schema-agent-impl.h
@@ -24,7 +24,6 @@ class V8SchemaAgentImpl : public protocol::Schema::Backend {
   ~V8SchemaAgentImpl() override;
   V8SchemaAgentImpl(const V8SchemaAgentImpl&) = delete;
   V8SchemaAgentImpl& operator=(const V8SchemaAgentImpl&) = delete;
-  bool replayOwned() const { return m_replay_owned; }
 
   Response getDomains(
       std::unique_ptr<protocol::Array<protocol::Schema::Domain>>*) override;
@@ -32,7 +31,6 @@ class V8SchemaAgentImpl : public protocol::Schema::Backend {
  private:
   V8InspectorSessionImpl* m_session;
   protocol::Schema::Frontend m_frontend;
-  bool m_replay_owned;
 };
 
 }  // namespace v8_inspector

--- a/src/inspector/v8-schema-agent-impl.h
+++ b/src/inspector/v8-schema-agent-impl.h
@@ -24,6 +24,7 @@ class V8SchemaAgentImpl : public protocol::Schema::Backend {
   ~V8SchemaAgentImpl() override;
   V8SchemaAgentImpl(const V8SchemaAgentImpl&) = delete;
   V8SchemaAgentImpl& operator=(const V8SchemaAgentImpl&) = delete;
+  bool replayOwned() const { return m_replay_owned; }
 
   Response getDomains(
       std::unique_ptr<protocol::Array<protocol::Schema::Domain>>*) override;
@@ -31,6 +32,7 @@ class V8SchemaAgentImpl : public protocol::Schema::Backend {
  private:
   V8InspectorSessionImpl* m_session;
   protocol::Schema::Frontend m_frontend;
+  bool m_replay_owned;
 };
 
 }  // namespace v8_inspector


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1403
# Summary

* crash-0039: `ReplayMismatch` / `StackCommonFrame`, follow-up to crash-0038 (same mismatch shape).
* Replay-owned inspector session `2` recorded a `forEachSession` `MAYBE_EVENTS_DISALLOWED` assert into the event stream with events *allowed*, diverging vs a later recorded `RegisterPointer`.
* Root cause: replay ownership is a property of the create unit (**ReplaySession** = one `V8InspectorSessionImpl`), not of the blink caller stack. crash-0038's stack `CheckReplayOwned()` gate on `contextCreated` saw a blink caller and no-oped, so `forEachSession` visited the owned session with events allowed and the assert fired.
* Fix:
  * Seed `m_replay_owned` on the session at connect from `AreEventsDisallowed()`.
  * Propagate that flag by copy onto every session member (agents + `InjectedScript`).
  * Wrap each owned-object work site with the combined `AutoMaybeReplayOwned` (Mark + Disallow) RAII keyed off the flag — including each `forEachSession` visit and every session-member agent work method — so the `MAYBE` assert auto-skips under Disallow for **ReplaySession** while side effects are correctly marked replay-owned.
  * Remove the `resetContextGroup consoleStorage` assert (allowed-to-be-divergent value).

# Problem

* MismatchKind: `StackCommonFrame`.
* Replayed leaf is a `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED` on **ReplaySession**; events were allowed, so the assert entered the stream and mismatched the later recorded `RegisterPointer`.

## Mismatch Leaves

* recorded: `RegisterPointer("PageVisibilityObserver", …)`
* replayed: `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED("V8InspectorImpl::forEachSession %d %d", …)`
  * `sessionId=2`
  * `hasGroup=1`

## Frame Candidates

* recorded: `blink::PageVisibilityObserver::PageVisibilityObserver(blink::Page*)+45`
  * `third_party/blink/renderer/core/page/page_visibility_observer.cc:13`
  * `recordreplay::RegisterPointer("PageVisibilityObserver", this)`; `+45` is the return address after that call
* replayed: `v8_inspector::V8InspectorImpl::forEachSession(…)+1095`
  * `v8/src/inspector/v8-inspector-impl.cc:453`
  * pre-fix site: `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED("V8InspectorImpl::forEachSession %d %d", sessionId, hasGroup)`
  * events were allowed at that call

## Common Frame

* `LocalWindowProxy::Initialize` in `local_window_proxy.cc`
* Call order inside `Initialize()`:
  1. Replay init block at lines 244–296
  2. `MainThreadDebugger::ContextCreated` at line 302 → `V8InspectorImpl::contextCreated` → `forEachSession`
  3. `DispatchDidClearWindowObjectInMainWorld` at line 316 → `PageVisibilityObserver` `RegisterPointer`
* Stack offsets: replayed `+2517` = step 2; recorded `+2680` = step 3

## ReplaySession

* Divergent create path: `getInspectorSession` → `connect` under `AutoMarkReplayCode` + `AutoDisallowEvents`; builds one `V8InspectorSessionImpl` and its V8 agents.
* **ReplaySession** = that session. Session `2` in this mismatch is **ReplaySession**.
* Other sessions in the same `contextGroupId` come from DevTools `ConnectToV8` without disallow.

## Assert Semantics

* `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED` skips only when events are already disallowed.
* crash-0038 gated `V8InspectorImpl::contextCreated` with stack `CheckReplayOwned()`.
  * Blink `MainThreadDebugger::ContextCreated` sees stack false → that gate no-ops.
* `forEachSession` still visited session `2` with events allowed → assert fired.

## Ownership History

* `770bf9c0ee` #122: `m_replayOnly` on `V8RuntimeAgentImpl` only, seeded `IsReplaying() && AreEventsDisallowed()`. RAII surface on one child, not ownership of the create unit.
* `10fb49ae8e` RUN-3380: renamed to `m_replay_owned`.
* `1165ee6034` #301: moved the flag onto `V8InspectorSessionImpl`, seeded from stack `CheckReplayOwned()` at connect. Correct identity target, wrong consequence: wrapped nearly all session traffic as divergent.
* Ownership identity is not Mark+Disallow on every path through **ReplaySession** (`SendCDPMessage` already disallows protocol dispatch into it).

## Rejected

* Wrap only the Replay init block in `AutoMarkReplayCode` + `AutoDisallowEvents` — those RAIIs end before `ContextCreated` at line 302, so they do not cover the divergent `forEachSession` assert.
* Assert-skip on `forEachSession` when `session->replayOwned()` *without* Mark+Disallow — silences the assert but does not mark side effects from **ReplaySession** work as replay-owned.
* Inferring ownership from stack `CheckReplayOwned()` alone for session object identity — blink `ContextCreated` stack is not Mark'd; misses per-session visits inside `forEachSession`.

# Solution

## Model

* The divergent create unit is **ReplaySession** — one `V8InspectorSessionImpl`, the only owned object.
* A context group has many sessions (DevTools `ConnectToV8` + one **ReplaySession**); `forEachSession` visits all of them.
* Agent classes are per-session helpers, not ownership units — only the instance hanging off **ReplaySession** is owned.
* **SessionMembers** of **ReplaySession**:
  * Ctor: `V8RuntimeAgentImpl`, `V8DebuggerAgentImpl`, `V8ConsoleAgentImpl`, `V8ProfilerAgentImpl`
  * Ctor when `kFullyTrusted`: `V8HeapProfilerAgentImpl`, `V8SchemaAgentImpl`
  * Lazy: `InjectedScript` on `InspectedContext`, keyed by `sessionId`
* **NotOwned** (shared across sessions, no session ownership label): `V8ConsoleMessageStorage`, blink `InspectorData` agents, `V8InspectorImpl` / `InspectedContext` / context-group maps.
* Rule: any Replay-created V8 object that does non-deterministic work must Mark+Disallow that work, keyed off object ownership (`m_replay_owned`), not caller stack. DevTools sessions stay `m_replay_owned=false` → wraps no-op.

## Implementation

* Seed `m_replay_owned` on `V8InspectorSessionImpl` at connect from `AreEventsDisallowed()`.
* Propagate the flag by copy at member construction from `session->replayOwned()` onto every **SessionMember** (`V8RuntimeAgentImpl`, `V8DebuggerAgentImpl`, `V8ConsoleAgentImpl`, `V8ProfilerAgentImpl`, `V8HeapProfilerAgentImpl`, `V8SchemaAgentImpl`, `InjectedScript`).
* Add `v8::replayio::AutoMaybeReplayOwned` — a single RAII combining `AutoMaybeMarkReplayCode` + `AutoMaybeDisallowEvents`, gated on the ownership flag.
* Key it off the flag at owned-object work sites:
  * `forEachSession`: wrap each visit + callback (assert then auto-skips under Disallow for **ReplaySession**; never key off `runtimeAgent()`).
  * `V8InspectorSessionImpl`: dtor / `reset` / `discardInjectedScripts` / `releaseObjectGroup` / `setCustomObjectFormatterEnabled` / `reportAllContexts` / `dispatchProtocolMessage`.
  * Every session-member agent work method keys off its copied flag: `V8RuntimeAgentImpl`, `V8DebuggerAgentImpl`, `V8ConsoleAgentImpl`, `V8ProfilerAgentImpl`, `V8HeapProfilerAgentImpl`, `V8SchemaAgentImpl`.
  * `InjectedScript` work sites + promise callbacks (then / catch / sendPromiseCollected); handlers store/copy the flag.
  * `V8Console` session dispatch helpers (`setFunctionBreakpoint`, `inspectImpl`, `inspectedObject`).
* Assert re-eval ([InvalidAssertValues]): never Assert on allowed-to-be-divergent values; never Assert inside DisallowEvents without a good reason; if inside, use `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED`.
  * Keep `forEachSession`, `forEachContext`, `resetContextGroup hasContexts`, session-ctor / RuntimeAgent `restore` / `enable`, `DidClearContextsForFrame` as `MAYBE`.
  * Remove `resetContextGroup consoleStorage` assert — `hasConsoleMessageStorage` is allowed-to-be-divergent when **ReplaySession** enabled Runtime.
* Do not put ownership on **NotOwned**.
* Re-run interactive replay suite.

# G2: execution.cc — crash on divergent record-time C++→JS

* `Invoke` blocks a C++→JS entry via the `DUMP_ON_FAILURE` path when `AutoDisallowEvents` is active.
* Prior behavior: log and return `undefined` for both recording and replaying.
* A blocked entry **while recording** means the recording itself already diverged, so a bad recording would ship silently.
* Change:
  * On the recording side, hard `Crash("EncounteredDivergentJSWhenRecording")` instead of returning `undefined`.
  * Replaying side unchanged.
  * Log the offending script name via new `GetFunctionScriptName` helper.

# Raw Data

* buildId: `linux-chromium-20260724-fd1d6db24a1a-0814b5e98095`
* linkerVersion: `linker-linux-16040-0814b5e98095`
* recordingId: `ece9aeae-a1b7-4901-9682-493243283219`
