### PR TITLE
[crash-0042] Disable replay-owned console preview; rewind divergent Progress

### DIFF
--- a/src/builtins/builtins-api.cc
+++ b/src/builtins/builtins-api.cc
@@ -17,8 +17,6 @@
 namespace v8 {
 namespace internal {
 
-extern bool RecordReplayIsDivergentWithoutPause();
-
 namespace {
 
 // Returns the holder JSObject if the function can legally be called with this
@@ -178,10 +176,6 @@ MaybeHandle<Object> Builtins::InvokeApiFunction(
     Handle<Object> receiver, int argc, Handle<Object> args[],
     Handle<HeapObject> new_target) {
   RCS_SCOPE(isolate, RuntimeCallCounterId::kInvokeApiFunction);
-
-  if (RecordReplayIsDivergentWithoutPause()) {
-    return isolate->factory()->undefined_value();
-  }
 
   // Do proper receiver conversion for non-strict mode api functions.
   if (!is_construct && !receiver->IsJSReceiver()) {

--- a/src/builtins/builtins-api.cc
+++ b/src/builtins/builtins-api.cc
@@ -7,6 +7,7 @@
 #include "src/base/small-vector.h"
 #include "src/builtins/builtins-utils-inl.h"
 #include "src/builtins/builtins.h"
+#include "src/execution/frames.h"
 #include "src/logging/log.h"
 #include "src/logging/runtime-call-stats-scope.h"
 #include "src/objects/objects-inl.h"
@@ -16,6 +17,9 @@
 
 namespace v8 {
 namespace internal {
+
+extern bool RecordReplayWarnAndSuppressDivergentUserJS(
+    Isolate* isolate, Handle<JSFunction> function);
 
 namespace {
 
@@ -176,6 +180,13 @@ MaybeHandle<Object> Builtins::InvokeApiFunction(
     Handle<Object> receiver, int argc, Handle<Object> args[],
     Handle<HeapObject> new_target) {
   RCS_SCOPE(isolate, RuntimeCallCounterId::kInvokeApiFunction);
+
+  for (JavaScriptFrameIterator it(isolate); !it.done(); it.Advance()) {
+    Handle<JSFunction> function(it.frame()->function(), isolate);
+    if (RecordReplayWarnAndSuppressDivergentUserJS(isolate, function)) {
+      return isolate->factory()->undefined_value();
+    }
+  }
 
   // Do proper receiver conversion for non-strict mode api functions.
   if (!is_construct && !receiver->IsJSReceiver()) {

--- a/src/builtins/builtins-api.cc
+++ b/src/builtins/builtins-api.cc
@@ -7,7 +7,6 @@
 #include "src/base/small-vector.h"
 #include "src/builtins/builtins-utils-inl.h"
 #include "src/builtins/builtins.h"
-#include "src/execution/frames.h"
 #include "src/logging/log.h"
 #include "src/logging/runtime-call-stats-scope.h"
 #include "src/objects/objects-inl.h"
@@ -17,9 +16,6 @@
 
 namespace v8 {
 namespace internal {
-
-extern bool RecordReplayWarnAndSuppressDivergentUserJS(
-    Isolate* isolate, Handle<JSFunction> function);
 
 namespace {
 
@@ -180,13 +176,6 @@ MaybeHandle<Object> Builtins::InvokeApiFunction(
     Handle<Object> receiver, int argc, Handle<Object> args[],
     Handle<HeapObject> new_target) {
   RCS_SCOPE(isolate, RuntimeCallCounterId::kInvokeApiFunction);
-
-  for (JavaScriptFrameIterator it(isolate); !it.done(); it.Advance()) {
-    Handle<JSFunction> function(it.frame()->function(), isolate);
-    if (RecordReplayWarnAndSuppressDivergentUserJS(isolate, function)) {
-      return isolate->factory()->undefined_value();
-    }
-  }
 
   // Do proper receiver conversion for non-strict mode api functions.
   if (!is_construct && !receiver->IsJSReceiver()) {

--- a/src/builtins/builtins-api.cc
+++ b/src/builtins/builtins-api.cc
@@ -17,6 +17,8 @@
 namespace v8 {
 namespace internal {
 
+extern bool RecordReplayIsDivergentWithoutPause();
+
 namespace {
 
 // Returns the holder JSObject if the function can legally be called with this
@@ -177,11 +179,7 @@ MaybeHandle<Object> Builtins::InvokeApiFunction(
     Handle<HeapObject> new_target) {
   RCS_SCOPE(isolate, RuntimeCallCounterId::kInvokeApiFunction);
 
-  // Native API getters/setters skip Execution::Invoke's divergent-user-JS gate.
-  // Under EventsDisallowed, calling the stub can re-enter instrumented user JS
-  // (e.g. monkey-patched Window.crypto) and diverge.
-  if (recordreplay::AreEventsDisallowed("InvokeApiFunction") &&
-      !recordreplay::HasDivergedFromRecording()) {
+  if (RecordReplayIsDivergentWithoutPause()) {
     return isolate->factory()->undefined_value();
   }
 

--- a/src/builtins/builtins-api.cc
+++ b/src/builtins/builtins-api.cc
@@ -177,6 +177,14 @@ MaybeHandle<Object> Builtins::InvokeApiFunction(
     Handle<HeapObject> new_target) {
   RCS_SCOPE(isolate, RuntimeCallCounterId::kInvokeApiFunction);
 
+  // Native API getters/setters skip Execution::Invoke's divergent-user-JS gate.
+  // Under EventsDisallowed, calling the stub can re-enter instrumented user JS
+  // (e.g. monkey-patched Window.crypto) and diverge.
+  if (recordreplay::AreEventsDisallowed("InvokeApiFunction") &&
+      !recordreplay::HasDivergedFromRecording()) {
+    return isolate->factory()->undefined_value();
+  }
+
   // Do proper receiver conversion for non-strict mode api functions.
   if (!is_construct && !receiver->IsJSReceiver()) {
     ASSIGN_RETURN_ON_EXCEPTION(

--- a/src/builtins/builtins-api.cc
+++ b/src/builtins/builtins-api.cc
@@ -7,6 +7,7 @@
 #include "src/base/small-vector.h"
 #include "src/builtins/builtins-utils-inl.h"
 #include "src/builtins/builtins.h"
+#include "src/debug/debug.h"
 #include "src/logging/log.h"
 #include "src/logging/runtime-call-stats-scope.h"
 #include "src/objects/objects-inl.h"
@@ -56,6 +57,8 @@ V8_WARN_UNUSED_RESULT MaybeHandle<Object> HandleApiCallHelper(
     Isolate* isolate, Handle<HeapObject> new_target,
     Handle<FunctionTemplateInfo> fun_data, Handle<Object> receiver,
     Address* argv, int argc) {
+  // Cover HandleApiCall / CallApiCallback as well as InvokeApiFunction.
+  RecordReplayScrubDivergentProgressScope scrub_divergent_progress;
   Handle<JSReceiver> js_receiver;
   JSReceiver raw_holder;
   if (is_construct) {
@@ -176,6 +179,7 @@ MaybeHandle<Object> Builtins::InvokeApiFunction(
     Handle<Object> receiver, int argc, Handle<Object> args[],
     Handle<HeapObject> new_target) {
   RCS_SCOPE(isolate, RuntimeCallCounterId::kInvokeApiFunction);
+  RecordReplayScrubDivergentProgressScope scrub_divergent_progress;
 
   // Do proper receiver conversion for non-strict mode api functions.
   if (!is_construct && !receiver->IsJSReceiver()) {
@@ -207,6 +211,7 @@ MaybeHandle<Object> Builtins::InvokeApiFunction(
 // a function (without new).
 V8_WARN_UNUSED_RESULT static Object HandleApiCallAsFunctionOrConstructor(
     Isolate* isolate, bool is_construct_call, BuiltinArguments args) {
+  RecordReplayScrubDivergentProgressScope scrub_divergent_progress;
   Handle<Object> receiver = args.receiver();
 
   // Get the object called.

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3947,7 +3947,6 @@ struct AutoAllowCodeGenerationFromStrings {
 char* CommandCallback(const char* command, const char* params) {
   CHECK(IsMainThread());
   AutoMarkReplayCode amrc;
-  uint64_t startProgressCounter = *gProgressCounter;
 
   Isolate* isolate = Isolate::Current();
   replayio::AutoDisallowEvents disallow("CommandCallback", (v8::Isolate*)isolate);
@@ -4018,15 +4017,6 @@ char* CommandCallback(const char* command, const char* params) {
   Handle<Object> result = rv.ToHandleChecked();
   Handle<Object> rvStr = JsonStringify(isolate, result, undefined, undefined).ToHandleChecked();
   std::unique_ptr<char[]> rvCStr = String::cast(*rvStr).ToCString();
-
-  if (startProgressCounter < *gProgressCounter && !recordreplay::HasDivergedFromRecording()) {
-    // [RUN-1988] Our command handler incremented the PC by accidentally calling
-    // into instrumented user code.
-    // Note that a warning has already been generated due to
-    // gRecordReplayCheckProgress being set.
-    // → Let's reset the PC.
-    *gProgressCounter = startProgressCounter;
-  }
 
   return strdup(rvCStr.get());
 }

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3726,11 +3726,15 @@ bool RecordReplayHasRegisteredScript(Script script) {
     gRegisteredScripts->find(script.id()) != gRegisteredScripts->end();
 }
 
+bool RecordReplayIsDivergentWithoutPause() {
+  return recordreplay::AreEventsDisallowed() &&
+         !recordreplay::HasDivergedFromRecording();
+}
+
 // Whether we are divergently calling into user JS without having paused first.
 bool RecordReplayIsDivergentUserJSWithoutPause(
     const SharedFunctionInfo& shared) {
-  return recordreplay::AreEventsDisallowed() &&
-         !recordreplay::HasDivergedFromRecording() &&
+  return RecordReplayIsDivergentWithoutPause() &&
          shared.script().IsScript() &&
          RecordReplayHasRegisteredScript(
              Script::cast(shared.script()));

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3726,15 +3726,11 @@ bool RecordReplayHasRegisteredScript(Script script) {
     gRegisteredScripts->find(script.id()) != gRegisteredScripts->end();
 }
 
-bool RecordReplayIsDivergentWithoutPause() {
-  return recordreplay::AreEventsDisallowed() &&
-         !recordreplay::HasDivergedFromRecording();
-}
-
 // Whether we are divergently calling into user JS without having paused first.
 bool RecordReplayIsDivergentUserJSWithoutPause(
     const SharedFunctionInfo& shared) {
-  return RecordReplayIsDivergentWithoutPause() &&
+  return recordreplay::AreEventsDisallowed() &&
+         !recordreplay::HasDivergedFromRecording() &&
          shared.script().IsScript() &&
          RecordReplayHasRegisteredScript(
              Script::cast(shared.script()));

--- a/src/debug/debug.h
+++ b/src/debug/debug.h
@@ -720,6 +720,23 @@ class SuppressDebug {
   bool old_state_;
 };
 
+// [RUN-1988] On EventsDisallowed paths, rewind Progress if instrumented user JS
+// advanced it. Used at C++→JS / API callback entries.
+class RecordReplayScrubDivergentProgressScope {
+ public:
+  RecordReplayScrubDivergentProgressScope();
+  ~RecordReplayScrubDivergentProgressScope();
+  RecordReplayScrubDivergentProgressScope(
+      const RecordReplayScrubDivergentProgressScope&) = delete;
+  RecordReplayScrubDivergentProgressScope& operator=(
+      const RecordReplayScrubDivergentProgressScope&) = delete;
+
+ private:
+  bool active_;
+  uint64_t start_progress_;
+  size_t start_data_size_;
+};
+
 }  // namespace internal
 }  // namespace v8
 

--- a/src/execution/execution.cc
+++ b/src/execution/execution.cc
@@ -311,6 +311,7 @@ static std::string GetFunctionLocationInfo(Isolate* isolate, Handle<JSFunction> 
 V8_WARN_UNUSED_RESULT MaybeHandle<Object> Invoke(Isolate* isolate,
                                                  const InvokeParams& params) {
   RCS_SCOPE(isolate, RuntimeCallCounterId::kInvoke);
+  RecordReplayScrubDivergentProgressScope scrub_divergent_progress;
   DCHECK(!params.receiver->IsJSGlobalObject());
   DCHECK_LE(params.argc, FixedArray::kMaxLength);
 

--- a/src/execution/execution.cc
+++ b/src/execution/execution.cc
@@ -308,6 +308,21 @@ static std::string GetFunctionLocationInfo(Isolate* isolate, Handle<JSFunction> 
   return os.str();
 }
 
+// Warning + suppress when calling into registered user JS on a divergent path.
+bool RecordReplayWarnAndSuppressDivergentUserJS(Isolate* isolate,
+                                                Handle<JSFunction> function) {
+  if (!RecordReplayIsDivergentUserJSWithoutPause(function->shared())) {
+    return false;
+  }
+  std::string location = GetFunctionLocationInfo(isolate, function);
+  std::stringstream stack;
+  isolate->PrintCurrentStackTrace(stack);
+  recordreplay::Warning(
+      "JS Invoke: Non-deterministic user JS PC=%zu %s stack=%s",
+      *gProgressCounter, location.c_str(), stack.str().c_str());
+  return true;
+}
+
 V8_WARN_UNUSED_RESULT MaybeHandle<Object> Invoke(Isolate* isolate,
                                                  const InvokeParams& params) {
   RCS_SCOPE(isolate, RuntimeCallCounterId::kInvoke);
@@ -446,13 +461,7 @@ V8_WARN_UNUSED_RESULT MaybeHandle<Object> Invoke(Isolate* isolate,
   // User JS must not run on divergent paths unless paused.
   if (params.target->IsJSFunction()) {
     Handle<JSFunction> function = Handle<JSFunction>::cast(params.target);
-    if (RecordReplayIsDivergentUserJSWithoutPause(function->shared())) {
-      std::string location = GetFunctionLocationInfo(isolate, function);
-      std::stringstream stack;
-      isolate->PrintCurrentStackTrace(stack);
-      recordreplay::Warning(
-          "JS Invoke: Non-deterministic user JS PC=%zu %s stack=%s",
-          *gProgressCounter, location.c_str(), stack.str().c_str());
+    if (RecordReplayWarnAndSuppressDivergentUserJS(isolate, function)) {
       return isolate->factory()->undefined_value();
     }
   }

--- a/src/execution/execution.cc
+++ b/src/execution/execution.cc
@@ -308,21 +308,6 @@ static std::string GetFunctionLocationInfo(Isolate* isolate, Handle<JSFunction> 
   return os.str();
 }
 
-// Warning + suppress when calling into registered user JS on a divergent path.
-bool RecordReplayWarnAndSuppressDivergentUserJS(Isolate* isolate,
-                                                Handle<JSFunction> function) {
-  if (!RecordReplayIsDivergentUserJSWithoutPause(function->shared())) {
-    return false;
-  }
-  std::string location = GetFunctionLocationInfo(isolate, function);
-  std::stringstream stack;
-  isolate->PrintCurrentStackTrace(stack);
-  recordreplay::Warning(
-      "JS Invoke: Non-deterministic user JS PC=%zu %s stack=%s",
-      *gProgressCounter, location.c_str(), stack.str().c_str());
-  return true;
-}
-
 V8_WARN_UNUSED_RESULT MaybeHandle<Object> Invoke(Isolate* isolate,
                                                  const InvokeParams& params) {
   RCS_SCOPE(isolate, RuntimeCallCounterId::kInvoke);
@@ -461,7 +446,13 @@ V8_WARN_UNUSED_RESULT MaybeHandle<Object> Invoke(Isolate* isolate,
   // User JS must not run on divergent paths unless paused.
   if (params.target->IsJSFunction()) {
     Handle<JSFunction> function = Handle<JSFunction>::cast(params.target);
-    if (RecordReplayWarnAndSuppressDivergentUserJS(isolate, function)) {
+    if (RecordReplayIsDivergentUserJSWithoutPause(function->shared())) {
+      std::string location = GetFunctionLocationInfo(isolate, function);
+      std::stringstream stack;
+      isolate->PrintCurrentStackTrace(stack);
+      recordreplay::Warning(
+          "JS Invoke: Non-deterministic user JS PC=%zu %s stack=%s",
+          *gProgressCounter, location.c_str(), stack.str().c_str());
       return isolate->factory()->undefined_value();
     }
   }

--- a/src/inspector/v8-runtime-agent-impl.cc
+++ b/src/inspector/v8-runtime-agent-impl.cc
@@ -1021,7 +1021,7 @@ void V8RuntimeAgentImpl::inspect(
 }
 
 void V8RuntimeAgentImpl::messageAdded(V8ConsoleMessage* message) {
-  if (m_enabled) reportMessage(message, true);
+  if (m_enabled) reportMessage(message, /*generatePreview=*/!m_replay_owned);
 }
 
 bool V8RuntimeAgentImpl::reportMessage(V8ConsoleMessage* message,

--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -980,6 +980,29 @@ static inline bool RecordReplayBytecodeAllowed() {
 // within that script of the function which executed.
 static std::vector<uint64_t>* gProgressData;
 
+RecordReplayScrubDivergentProgressScope::
+    RecordReplayScrubDivergentProgressScope()
+    : active_(false), start_progress_(0), start_data_size_(0) {
+  if (!recordreplay::IsRecordingOrReplaying() || !IsMainThread()) return;
+  if (!recordreplay::AreEventsDisallowed()) return;
+  if (recordreplay::HasDivergedFromRecording()) return;
+  active_ = true;
+  start_progress_ = *gProgressCounter;
+  start_data_size_ = gProgressData ? gProgressData->size() : 0;
+}
+
+RecordReplayScrubDivergentProgressScope::
+    ~RecordReplayScrubDivergentProgressScope() {
+  if (!active_) return;
+  if (recordreplay::HasDivergedFromRecording()) return;
+  if (start_progress_ >= *gProgressCounter) return;
+  // [RUN-1988] Divergent path advanced PC via instrumented user code.
+  *gProgressCounter = start_progress_;
+  if (gProgressData && gProgressData->size() > start_data_size_) {
+    gProgressData->resize(start_data_size_);
+  }
+}
+
 // Buffer holding data most recently reported to the recorder.
 static std::vector<uint64_t>* gReportedProgressData;
 


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1411

* Lead: `Window.crypto` **ApiGetterStub** under `EventsDisallowed` → monkey-patched Turnstile user JS → `[RUN-1919]` / Progress mismatch.
* Path: replay-owned console `generatePreview=true` → `InvokeApiFunction` (**GateSkip**).
* Fixes:
  * G1: `generatePreview=false` when `m_replay_owned` in `messageAdded`.
  * G2: **ProgressRewind** — after divergent `Invoke` / API entry under `EventsDisallowed`, restore Progress counter + `gProgressData` if user JS advanced them.