### PR TITLE
[crash-0049] Restore null gProgressData after divergent Progress scrub

### DIFF
--- a/src/runtime/runtime-debug.cc
+++ b/src/runtime/runtime-debug.cc
@@ -998,7 +998,12 @@ RecordReplayScrubDivergentProgressScope::
   if (start_progress_ >= *gProgressCounter) return;
   // [RUN-1988] Divergent path advanced PC via instrumented user code.
   *gProgressCounter = start_progress_;
-  if (gProgressData && gProgressData->size() > start_data_size_) {
+  if (start_data_size_ == 0) {
+    if (gProgressData) {
+      delete gProgressData;
+      gProgressData = nullptr;
+    }
+  } else if (gProgressData && gProgressData->size() > start_data_size_) {
     gProgressData->resize(start_data_size_);
   }
 }
@@ -1114,7 +1119,7 @@ static char* GetProgressMismatchMessage(const uint64_t* recorded, size_t recorde
 }
 
 void RecordReplayCallbackAssertGetData(void** pbuf, size_t* psize) {
-  if (!IsMainThread() || !gProgressData) {
+  if (!IsMainThread() || !gProgressData || gProgressData->empty()) {
     *psize = 0;
     return;
   }


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1415

# crash-0049 Summary

* RecorderCrash: `RecordReplayCallbackAssertGetData` aborts on libc++ `vector[]` of empty non-null `gProgressData`.
* Cause: `RecordReplayScrubDivergentProgressScope` dtor `resize(0)` when pre-entry was null.
  * Leaves resident empty vector.
  * Later SequenceManager `[RUN-1916]` Assert → `gGetData` → `[0]`.
* Fix
  * Scrub dtor
    * `delete` + `gProgressData = nullptr` when `start_data_size_ == 0`.
    * Else `resize(start_data_size_)`.
  * `gGetData`: treat `empty()` like null.

# crash-0048 Summary

* Piggy-backed on chromium PR only.
  * Mojo `PlatformFile` `RecordReplayValue` lives in chromium/src.
  * See paired chromium write-up.