### PR TITLE
Remove ReplayOnlyInspectorSession diagnostic Asserts

### DIFF
--- a/src/inspector/v8-inspector-impl.cc
+++ b/src/inspector/v8-inspector-impl.cc
@@ -422,12 +422,7 @@ V8Console* V8InspectorImpl::console() {
 void V8InspectorImpl::forEachContext(
     int contextGroupId,
     const std::function<void(InspectedContext*)>& callback) {
-  using v8::recordreplay;
   auto it = m_contexts.find(contextGroupId);
-  int hasGroup = it != m_contexts.end();
-  size_t n = hasGroup ? it->second->size() : 0;
-  REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
-      "V8InspectorImpl::forEachContext %d %zu", hasGroup, n);
   if (it == m_contexts.end()) return;
   std::vector<int> ids;
   ids.reserve(it->second->size());
@@ -436,12 +431,7 @@ void V8InspectorImpl::forEachContext(
   // Retrieve by ids each time since |callback| may destroy some contexts.
   for (auto& contextId : ids) {
     it = m_contexts.find(contextGroupId);
-    int hasGroupNow = it != m_contexts.end();
-    int found =
-        hasGroupNow && it->second->find(contextId) != it->second->end();
-    REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED(
-        "V8InspectorImpl::forEachContext item %d %d", hasGroupNow, found);
-    if (!hasGroupNow) continue;
+    if (it == m_contexts.end()) continue;
     auto contextIt = it->second->find(contextId);
     if (contextIt != it->second->end()) callback(contextIt->second.get());
   }

--- a/src/inspector/v8-inspector-session-impl.cc
+++ b/src/inspector/v8-inspector-session-impl.cc
@@ -157,9 +157,6 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(
     if (m_heapProfilerAgent) m_heapProfilerAgent->restore();
     m_profilerAgent->restore();
     m_consoleAgent->restore();
-  } else {
-    using v8::recordreplay;
-    REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED("V8RuntimeAgentImpl::restore %d", 0);
   }
 }
 

--- a/src/inspector/v8-runtime-agent-impl.cc
+++ b/src/inspector/v8-runtime-agent-impl.cc
@@ -904,15 +904,12 @@ void V8RuntimeAgentImpl::addBindings(InspectedContext* context) {
 }
 
 void V8RuntimeAgentImpl::restore() {
-  using v8::recordreplay;
   v8::replayio::AutoMaybeMarkReplayCode mark(m_replay_owned);
   v8::replayio::AutoMaybeDisallowEvents disallow(
       m_replay_owned, m_inspector->isolate(), "V8RuntimeAgentImpl::restore");
 
   int runtimeEnabled = m_state->booleanProperty(
       V8RuntimeAgentImplState::runtimeEnabled, false);
-  REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED("V8RuntimeAgentImpl::restore %d",
-                                        runtimeEnabled);
   if (!runtimeEnabled) return;
   m_frontend.executionContextsCleared();
   enable();
@@ -931,7 +928,6 @@ void V8RuntimeAgentImpl::restore() {
 }
 
 Response V8RuntimeAgentImpl::enable() {
-  using v8::recordreplay;
   if (m_enabled) return Response::Success();
   TRACE_EVENT_WITH_FLOW0(TRACE_DISABLED_BY_DEFAULT("v8.inspector"),
                          "V8RuntimeAgentImpl::enable", this,
@@ -944,8 +940,6 @@ Response V8RuntimeAgentImpl::enable() {
       this, V8StackTraceImpl::kDefaultMaxCallStackSizeToCapture);
   V8ConsoleMessageStorage* storage =
       m_inspector->ensureConsoleMessageStorage(m_session->contextGroupId());
-  REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED("V8RuntimeAgentImpl::enable %zu",
-                                        storage->messages().size());
   m_session->reportAllContexts(this);
   for (const auto& message : storage->messages()) {
     if (!reportMessage(message.get(), false)) break;


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1428

# [forEachContext] Summary

* ControlFlowMismatch: recorded `resetContextGroup` vs replayed `forEachContext`.
* ReplayOnlyInspectorSession walks `m_contexts` during consoleStorage erase.
* Remove diagnostic `forEachContext` Asserts.
* Keep `resetContextGroup` Assert.

# [Runtime.enable] Summary

* crash-0034 diagnostic Asserts observe `runtimeEnabled` and console-message count.
* Both are replay-divergent under ReplayOnlyInspectorSession.
* Remove `V8RuntimeAgentImpl::restore` / `enable` Asserts and the empty-session restore stub.

<hr>

# [forEachContext] Problem

* ControlFlowMismatch on navigation commit.
  * recorded: `V8InspectorImpl::resetContextGroup 1`
  * replayed: `V8InspectorImpl::forEachContext 1 2`
* Shared ancestor: `V8InspectorImpl::resetContextGroup` ← `LocalDOMWindow::FrameDestroyed` / `Reset`.

## Path Split

* Both sides enter `resetContextGroup`.
* `resetContextGroup` erases `m_consoleStorageMap` before its own Assert.
* Erase → `~V8ConsoleMessageStorage` → `clear` → `forEachSession` → `releaseObjectGroup` → `forEachContext`.
* Record leaf: no prior `forEachContext` Assert at this hitOrder → hits `resetContextGroup`.
* Replay leaf: ReplayOnlyInspectorSession present → `forEachContext` Assert fires first.

## Why Assert Is Wrong

* `forEachContext` Asserts observe `m_contexts` group presence / size / item lookup.
* That set is allowed-to-be-divergent under ReplayOnlyInspectorSession.
* Same InvalidAssertValues class as the removed `forEachSession` Assert (v8 `#314` / crash-0055).

## Assert Provenance

* Added in v8 `#298` as crash-0034 diagnostics.
* Also surfaced crash-0036 / crash-0055 ControlFlowMismatch noise against `resetContextGroup`.
* crash-0055 removed `forEachSession` only.
* Left `forEachContext` and `resetContextGroup` in place.

# Solution

* Remove both `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED` sites in `V8InspectorImpl::forEachContext`.
* Drop locals that existed only for those Asserts.
* Do not touch `resetContextGroup` Assert.
  * After this remove, both sides should land on `hasContexts=1`.

# Raw Data

* buildId: `linux-chromium-20260802-b841856e4633-bdda21cf9aa2`
* linkerVersion: `linker-linux-16069-bdda21cf9aa2`
* recordingId: `c4e4cad2-c67d-4a0a-aa59-976949d891e5`
* reportId: `13e30a7e-4af4-45c2-9cd7-e1360d95f6d9`

<hr>

# [Runtime.enable] Problem

* crash-0034 added diagnostic Asserts on `Runtime.enable` / `restore` control-flow leaves.
  * `V8RuntimeAgentImpl::restore %d` — `runtimeEnabled`
  * `V8RuntimeAgentImpl::enable %zu` — `storage->messages().size()`
  * Session ctor stub: `V8RuntimeAgentImpl::restore %d` with literal `0` when `savedState` is empty
* Console-message count and replay-only session restore state are allowed-to-be-divergent under ReplayOnlyInspectorSession.
* Same InvalidAssertValues class as `forEachContext` / `forEachSession`.

## Assert Provenance

* Added in v8 `#298` / crash-0034 diagnostics.
* Purpose was to turn opaque `Runtime.enable` ControlFlowMismatch into a data mismatch.
* That diagnostic Assert itself observes ReplayOnlyInspectorSession-divergent values.

# Solution

* Remove `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED` from `V8RuntimeAgentImpl::restore`.
* Remove `REPLAY_ASSERT_MAYBE_EVENTS_DISALLOWED` from `V8RuntimeAgentImpl::enable`.
* Remove the empty-`savedState` restore stub Assert in `V8InspectorSessionImpl` ctor.
* Keep Mark+Disallow ownership wraps.
* Do not touch `resetContextGroup` Assert.

# Raw Data

* buildId: `linux-chromium-20260721-b8d9a62296f4-0814b5e98095`
* linkerVersion: `linker-linux-16040-0814b5e98095`
* recordingId: `7c437665-51d4-4e42-a8ad-9a2821b55671`
