### PR TITLE
[crash-0062][crash-0063] Mutex emit + narrow ObjectProtoToString gate

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -4852,16 +4852,17 @@ MaybeLocal<Array> v8::Object::GetOwnPropertyNames(
 MaybeLocal<String> v8::Object::ObjectProtoToString(Local<Context> context) {
   PREPARE_FOR_EXECUTION(context, Object, ObjectProtoToString, String);
   auto self = Utils::OpenHandle(this);
+  // ObjectToString can run a user @@toStringTag getter via CallBuiltin.
+  if (recordreplay::AreEventsDisallowed() &&
+      !recordreplay::HasDivergedFromRecording()) {
+    RETURN_ESCAPED(Utils::ToLocal(i_isolate->factory()->object_to_string()));
+  }
   Local<Value> result;
   has_pending_exception = !ToLocal<Value>(
       i::Execution::CallBuiltin(i_isolate, i_isolate->object_to_string(), self,
                                 0, nullptr),
       &result);
   RETURN_ON_FAILED_EXECUTION(String);
-  // CallBuiltin returns undefined when it blocks divergent builtin entry.
-  if (!result->IsString()) {
-    RETURN_ESCAPED(Utils::ToLocal(i_isolate->factory()->object_to_string()));
-  }
   RETURN_ESCAPED(Local<String>::Cast(result));
 }
 

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -4852,6 +4852,11 @@ MaybeLocal<Array> v8::Object::GetOwnPropertyNames(
 MaybeLocal<String> v8::Object::ObjectProtoToString(Local<Context> context) {
   PREPARE_FOR_EXECUTION(context, Object, ObjectProtoToString, String);
   auto self = Utils::OpenHandle(this);
+  // ObjectToString can run a user @@toStringTag getter via CallBuiltin.
+  if (recordreplay::AreEventsDisallowed() &&
+      !recordreplay::HasDivergedFromRecording()) {
+    RETURN_ESCAPED(Utils::ToLocal(i_isolate->factory()->object_to_string()));
+  }
   Local<Value> result;
   has_pending_exception = !ToLocal<Value>(
       i::Execution::CallBuiltin(i_isolate, i_isolate->object_to_string(), self,

--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -4852,17 +4852,16 @@ MaybeLocal<Array> v8::Object::GetOwnPropertyNames(
 MaybeLocal<String> v8::Object::ObjectProtoToString(Local<Context> context) {
   PREPARE_FOR_EXECUTION(context, Object, ObjectProtoToString, String);
   auto self = Utils::OpenHandle(this);
-  // ObjectToString can run a user @@toStringTag getter via CallBuiltin.
-  if (recordreplay::AreEventsDisallowed() &&
-      !recordreplay::HasDivergedFromRecording()) {
-    RETURN_ESCAPED(Utils::ToLocal(i_isolate->factory()->object_to_string()));
-  }
   Local<Value> result;
   has_pending_exception = !ToLocal<Value>(
       i::Execution::CallBuiltin(i_isolate, i_isolate->object_to_string(), self,
                                 0, nullptr),
       &result);
   RETURN_ON_FAILED_EXECUTION(String);
+  // CallBuiltin returns undefined when it blocks divergent builtin entry.
+  if (!result->IsString()) {
+    RETURN_ESCAPED(Utils::ToLocal(i_isolate->factory()->object_to_string()));
+  }
   RETURN_ESCAPED(Local<String>::Cast(result));
 }
 

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3701,7 +3701,6 @@ static ScriptIdSet* gRegisteredScripts;
 
 typedef std::unordered_map<int, bool> ScriptIdBoolMap;
 static ScriptIdBoolMap* gOpcodeEmitByScript = nullptr;
-static base::Mutex* gOpcodeEmitByScriptMutex = new base::Mutex;
 
 // Compiles diverge (GC bytecode flush, cache ageing, etc.); freeze first emit
 // decision per script_id (both lit and dark).
@@ -3710,7 +3709,6 @@ bool RecordReplayShouldEmitOpcodes(int script_id, bool record_replay_ignore) {
       recordreplay::IsRecordingOrReplaying("emit-opcodes") &&
       RecordReplayHasDefaultContext() && !record_replay_ignore;
   if (script_id == v8::UnboundScript::kNoScriptId) return base_emit_opcodes;
-  base::MutexGuard guard(gOpcodeEmitByScriptMutex);
   if (!gOpcodeEmitByScript) {
     gOpcodeEmitByScript = new ScriptIdBoolMap;
   }

--- a/src/debug/debug.cc
+++ b/src/debug/debug.cc
@@ -3701,6 +3701,7 @@ static ScriptIdSet* gRegisteredScripts;
 
 typedef std::unordered_map<int, bool> ScriptIdBoolMap;
 static ScriptIdBoolMap* gOpcodeEmitByScript = nullptr;
+static base::Mutex* gOpcodeEmitByScriptMutex = new base::Mutex;
 
 // Compiles diverge (GC bytecode flush, cache ageing, etc.); freeze first emit
 // decision per script_id (both lit and dark).
@@ -3709,6 +3710,7 @@ bool RecordReplayShouldEmitOpcodes(int script_id, bool record_replay_ignore) {
       recordreplay::IsRecordingOrReplaying("emit-opcodes") &&
       RecordReplayHasDefaultContext() && !record_replay_ignore;
   if (script_id == v8::UnboundScript::kNoScriptId) return base_emit_opcodes;
+  base::MutexGuard guard(gOpcodeEmitByScriptMutex);
   if (!gOpcodeEmitByScript) {
     gOpcodeEmitByScript = new ScriptIdBoolMap;
   }

--- a/src/execution/execution.cc
+++ b/src/execution/execution.cc
@@ -308,6 +308,17 @@ static std::string GetFunctionLocationInfo(Isolate* isolate, Handle<JSFunction> 
   return os.str();
 }
 
+// Block C++→JS entry that can run registered user JS while events are disallowed.
+static MaybeHandle<Object> RecordReplayBlockNonDeterministicUserJs(
+    Isolate* isolate, const char* kind, const std::string& detail) {
+  std::stringstream stack;
+  isolate->PrintCurrentStackTrace(stack);
+  recordreplay::Warning(
+      "%s:BLOCKED:NonDeterministicUserJS PC=%zu %s stack=%s", kind,
+      *gProgressCounter, detail.c_str(), stack.str().c_str());
+  return isolate->factory()->undefined_value();
+}
+
 V8_WARN_UNUSED_RESULT MaybeHandle<Object> Invoke(Isolate* isolate,
                                                  const InvokeParams& params) {
   RCS_SCOPE(isolate, RuntimeCallCounterId::kInvoke);
@@ -448,13 +459,8 @@ V8_WARN_UNUSED_RESULT MaybeHandle<Object> Invoke(Isolate* isolate,
   if (params.target->IsJSFunction()) {
     Handle<JSFunction> function = Handle<JSFunction>::cast(params.target);
     if (RecordReplayIsDivergentUserJSWithoutPause(function->shared())) {
-      std::string location = GetFunctionLocationInfo(isolate, function);
-      std::stringstream stack;
-      isolate->PrintCurrentStackTrace(stack);
-      recordreplay::Warning(
-          "JSInvoke:BLOCKED:NonDeterministicUserJS PC=%zu %s stack=%s",
-          *gProgressCounter, location.c_str(), stack.str().c_str());
-      return isolate->factory()->undefined_value();
+      return RecordReplayBlockNonDeterministicUserJs(
+          isolate, "JSInvoke", GetFunctionLocationInfo(isolate, function));
     }
   }
 
@@ -634,6 +640,13 @@ MaybeHandle<Object> Execution::CallBuiltin(Isolate* isolate,
                                            Handle<Object> argv[]) {
   DCHECK(builtin->code().is_builtin());
   DisableBreak no_break(isolate->debug());
+  // Builtins can enter user JS via NotInvoke paths (e.g. @@toStringTag getters).
+  // Invoke's divergent-user check only sees the builtin target, so it misses that.
+  if (recordreplay::AreEventsDisallowed() &&
+      !recordreplay::HasDivergedFromRecording()) {
+    return RecordReplayBlockNonDeterministicUserJs(
+        isolate, "JSCallBuiltin", GetFunctionLocationInfo(isolate, builtin));
+  }
   return Invoke(isolate, InvokeParams::SetUpForCall(isolate, builtin, receiver,
                                                     argc, argv));
 }

--- a/src/execution/execution.cc
+++ b/src/execution/execution.cc
@@ -640,13 +640,6 @@ MaybeHandle<Object> Execution::CallBuiltin(Isolate* isolate,
                                            Handle<Object> argv[]) {
   DCHECK(builtin->code().is_builtin());
   DisableBreak no_break(isolate->debug());
-  // Builtins can enter user JS via NotInvoke paths (e.g. @@toStringTag getters).
-  // Invoke's divergent-user check only sees the builtin target, so it misses that.
-  if (recordreplay::AreEventsDisallowed() &&
-      !recordreplay::HasDivergedFromRecording()) {
-    return RecordReplayBlockNonDeterministicUserJs(
-        isolate, "JSCallBuiltin", GetFunctionLocationInfo(isolate, builtin));
-  }
   return Invoke(isolate, InvokeParams::SetUpForCall(isolate, builtin, receiver,
                                                     argc, argv));
 }

--- a/src/interpreter/bytecode-array-builder.cc
+++ b/src/interpreter/bytecode-array-builder.cc
@@ -26,6 +26,8 @@ extern bool RecordReplayShouldEmitOpcodes(int script_id,
                                           bool record_replay_ignore);
 extern bool gRecordReplayAssertTrackedObjects;
 
+extern size_t NumRunningBackgroundCompileTasks();
+
 namespace interpreter {
 
 class RegisterTransferWriter final
@@ -73,12 +75,16 @@ BytecodeArrayBuilder::BytecodeArrayBuilder(
         zone->New<RegisterTransferWriter>(this));
   }
 
-  // Record/replay opcodes can only be emitted for scripts that run on the
-  // main thread. Background compile must not consult/mutate the emit map.
-  if (IsMainThread() &&
-      RecordReplayShouldEmitOpcodes(script_id, record_replay_ignore)) {
+  if (RecordReplayShouldEmitOpcodes(script_id, record_replay_ignore)) {
     emit_record_replay_opcodes_ = true;
     emit_record_replay_assert_values_ = record_replay_assert_values;
+
+    // Record/replay opcodes can only be emitted for scripts that run on the
+    // main thread. If we aren't on the main thread, this must have been
+    // triggered by a background compile task.
+    if (!IsMainThread()) {
+      CHECK(NumRunningBackgroundCompileTasks() != 0);
+    }
   }
 }
 

--- a/src/interpreter/bytecode-array-builder.cc
+++ b/src/interpreter/bytecode-array-builder.cc
@@ -26,8 +26,6 @@ extern bool RecordReplayShouldEmitOpcodes(int script_id,
                                           bool record_replay_ignore);
 extern bool gRecordReplayAssertTrackedObjects;
 
-extern size_t NumRunningBackgroundCompileTasks();
-
 namespace interpreter {
 
 class RegisterTransferWriter final
@@ -75,16 +73,12 @@ BytecodeArrayBuilder::BytecodeArrayBuilder(
         zone->New<RegisterTransferWriter>(this));
   }
 
-  if (RecordReplayShouldEmitOpcodes(script_id, record_replay_ignore)) {
+  // Record/replay opcodes can only be emitted for scripts that run on the
+  // main thread. Background compile must not consult/mutate the emit map.
+  if (IsMainThread() &&
+      RecordReplayShouldEmitOpcodes(script_id, record_replay_ignore)) {
     emit_record_replay_opcodes_ = true;
     emit_record_replay_assert_values_ = record_replay_assert_values;
-
-    // Record/replay opcodes can only be emitted for scripts that run on the
-    // main thread. If we aren't on the main thread, this must have been
-    // triggered by a background compile task.
-    if (!IsMainThread()) {
-      CHECK(NumRunningBackgroundCompileTasks() != 0);
-    }
   }
 }
 


### PR DESCRIPTION
* paired w/ https://github.com/replayio/chromium/pull/1429

# [crash-0062] Summary

* Root cause
  * Background compile threads called `RecordReplayShouldEmitOpcodes`, mutated unsynchronized `gOpcodeEmitByScript`, and raced into `__do_rehash` SIGSEGV.
* Fix
  * Dedicated unordered `base::Mutex` around `gOpcodeEmitByScript` only.
  * Keep allowing background compile to emit.
  * Keep the existing off-main `CHECK(NumRunningBackgroundCompileTasks() != 0)`.

# [crash-0063] Summary

* Root cause
  * `console.debug` stringification called `ObjectProtoToString` → `CallBuiltin(ObjectToString)`.
  * `ObjectToString` ran a user `@@toStringTag` getter via NotInvoke under `forEachSession` EventsDisallowed.
  * `Invoke`'s divergent-user gate only sees the builtin target, so it missed the user leaf.
* Fix
  * In `ObjectProtoToString` only: if events are disallowed and we have not diverged, return `"[object Object]"` and do not call the builtin.

<hr>

# [crash-0062] Problem

* Problem type: RecorderCrash.
* signal 11 in `__do_rehash` via `RecordReplayShouldEmitOpcodes` on `BackgroundCompileTask` (`threadId: 9`).
* recordingId: e3bb9197-2c4e-45da-b534-862e1934c585

# [crash-0062] Solution

* Guard `gOpcodeEmitByScript` with dedicated `base::Mutex`.
* Keep background emit allowed.

<hr>

# [crash-0063] Problem

* Problem type: ReplayMismatch / Js.
* `[RUN-1919]` under `EventsDisallowed:V8InspectorImpl::forEachSession` via `console.debug` → `ObjectProtoToString` → user `@@toStringTag`.
* recordingId: 5ce958a0-3b0e-4006-ab91-a94aa53e445e

# [crash-0063] Solution

* `ObjectProtoToString`: return `"[object Object]"` when events are disallowed and not diverged.
* Do not blanket-block `CallBuiltin`.
